### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Write package.json
         uses: DamianReeves/write-file-action@master
         with:
-          path: ./package.json
+          path: package.json
           write-mode: overwrite
           contents: |
             {
@@ -37,17 +37,10 @@ jobs:
                 "@semantic-release/changelog": "^6.0.3"
               }
             }
-      - name: Upload artifact package.json
-        uses: actions/upload-artifact@v4
-        with:
-          name: package.json
-          path: ./package.json
-          retention-days: 1
-          if-no-files-found: error
       - name: Write .releaserc.json
         uses: DamianReeves/write-file-action@master
         with:
-          path: ./.releaserc.json
+          path: .releaserc.json
           write-mode: overwrite
           contents: |
             {
@@ -85,11 +78,14 @@ jobs:
                 ]
               ]
             }
-      - name: Upload artifact .releaserc.json
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: .releaserc.json
-          path: ./.releaserc.json
+          name: semantic-release-artifacts
+          path: |
+            package.json
+            .releaserc.json
+          include-hidden-files: true
           retention-days: 1
           if-no-files-found: error
       - name: setup semantic-release
@@ -131,14 +127,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
-      - name: Download artifact package.json
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: package.json
-      - name: Download artifact .releaserc.json
-        uses: actions/download-artifact@v4
-        with:
-          name: .releaserc.json
+          name: semantic-release-artifacts
       - name: setup semantic-release
         run: npm i
       - name: Release


### PR DESCRIPTION
- upload all generated files needed for semantic-release into one artifact
- include hidden files (i.e. `.releaserc.json`)
- tested locally with `nektos/act`