### PR TITLE
docs: update diode target

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ See all [examples](./examples/main.go) for reference.
 #### Linting
 
 ```shell
-make list
+make lint
 ```
 
 #### Testing

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go get github.com/netboxlabs/diode-sdk-go
 
 ### Example
 
-* `target` should be the address of the Diode service, e.g. `grpc://localhost:8081` for insecure connection
+* `target` should be the address of the Diode service, e.g. `grpc://localhost:8080/diode` for insecure connection
   or `grpcs://example.com` for secure connection.
 
 ```go


### PR DESCRIPTION
Update diode target references into default diode's ingress provided via docker compose