### PR TITLE
feat: set entity timestamp (at source) if not provided

### DIFF
--- a/diode/client.go
+++ b/diode/client.go
@@ -12,12 +12,14 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
@@ -230,10 +232,7 @@ func (g *GRPCClient) Close() error {
 func (g *GRPCClient) Ingest(ctx context.Context, entities []Entity) (*diodepb.IngestResponse, error) {
 	stream := defaultStreamName
 
-	protoEntities := make([]*diodepb.Entity, 0)
-	for _, entity := range entities {
-		protoEntities = append(protoEntities, entity.ConvertToProtoEntity())
-	}
+	protoEntities := convertEntitiesToProto(entities)
 
 	req := &diodepb.IngestRequest{
 		Id:                 uuid.NewString(),
@@ -248,6 +247,17 @@ func (g *GRPCClient) Ingest(ctx context.Context, entities []Entity) (*diodepb.In
 	ctx = metadata.NewOutgoingContext(ctx, g.metadata)
 
 	return g.client.Ingest(ctx, req)
+}
+
+// convertEntitiesToProto converts entities to proto entities
+func convertEntitiesToProto(entities []Entity) []*diodepb.Entity {
+	protoEntities := make([]*diodepb.Entity, 0)
+	for _, entity := range entities {
+		entityPb := entity.ConvertToProtoEntity()
+		entityPb.Timestamp = timestamppb.New(time.Now().UTC())
+		protoEntities = append(protoEntities, entityPb)
+	}
+	return protoEntities
 }
 
 // methodUnaryInterceptor returns a gRPC dial option with a unary interceptor

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -404,3 +404,35 @@ func TestNewLogger(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertEntitiesToProto(t *testing.T) {
+	tests := []struct {
+		desc     string
+		entities []Entity
+	}{
+		{
+			desc:     "empty entities",
+			entities: nil,
+		},
+		{
+			desc: "non-empty entities",
+			entities: []Entity{
+				&Device{Name: String("device-1")},
+				&Site{Name: String("site-1")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			protoEntities := convertEntitiesToProto(tt.entities)
+			require.NotNil(t, protoEntities)
+			assert.Equal(t, len(tt.entities), len(protoEntities))
+			for _, entityPb := range protoEntities {
+				assert.NotNil(t, entityPb.Timestamp)
+				assert.NotZero(t, entityPb.Timestamp.Seconds)
+				assert.NotZero(t, entityPb.Timestamp.Nanos)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to the `diode/client.go` and `diode/client_test.go` files, focusing on refactoring and adding new functionality. The most important changes include the introduction of a new helper function for converting entities to proto entities, the addition of a timestamp to each proto entity, and the corresponding unit tests.

### Refactoring and new functionality:

* [`diode/client.go`](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L233-R235): Added a new helper function `convertEntitiesToProto` to convert entities to proto entities and include a timestamp for each entity. This refactoring simplifies the `Ingest` method. [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L233-R235) [[2]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R252-R262)
* [`diode/client.go`](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R15-R22): Imported additional packages `time` and `google.golang.org/protobuf/types/known/timestamppb` to support the new timestamp functionality.

### Unit tests:

* [`diode/client_test.go`](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bR407-R438): Added a new test function `TestConvertEntitiesToProto` to verify the correct conversion of entities to proto entities, including the presence of timestamps.