### PR TITLE
feat: replace api key with oauth2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,8 @@ test:
 test-coverage:
 	@mkdir -p .coverage
 	@go test `go list ./... | grep -Ev "diodepb|examples|internal"` -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | tparse -format=markdown > .coverage/test-report.md
-	@cat .coverage/cover.out.tmp > .coverage/cover.out
+	@grep -v "diode/ingester.go" .coverage/cover.out.tmp > .coverage/cover.out
 	@go tool cover -func=.coverage/cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
-
 .PHONY: codegen
 codegen:
 	@go run internal/cmd/codegen/main.go | gofmt > ./diode/ingester.go

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ go get github.com/netboxlabs/diode-sdk-go
 
 ### Environment variables
 
-* `DIODE_API_KEY` - API key for the Diode service
 * `DIODE_SDK_LOG_LEVEL` - Log level for the SDK (default: `INFO`)
+* `DIODE_CLIENT_ID` - Client ID for OAuth2 authentication
+* `DIODE_CLIENT_SECRET` - Client Secret for OAuth2 authentication
 
 ### Example
 

--- a/diode/client.go
+++ b/diode/client.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -31,8 +33,11 @@ const (
 	// SDKVersion is the version of the Diode SDK
 	SDKVersion = "0.2.0"
 
-	// DiodeAPIKeyEnvVarName is the environment variable name for the Diode API key
-	DiodeAPIKeyEnvVarName = "DIODE_API_KEY"
+	// DiodeClientIDEnvVarName is the environment variable name for the Diode Client ID
+	DiodeClientIDEnvVarName = "DIODE_CLIENT_ID"
+
+	// DiodeClientSecretEnvVarName is the environment variable name for the Diode Client Secret
+	DiodeClientSecretEnvVarName = "DIODE_CLIENT_SECRET"
 
 	// DiodeSDKLogLevelEnvVarName is the environment variable name for the Diode SDK log level
 	DiodeSDKLogLevelEnvVarName = "DIODE_SDK_LOG_LEVEL"
@@ -76,17 +81,30 @@ func parseTarget(target string) (string, string, bool, error) {
 	return authority, path, tlsVerify, nil
 }
 
-// getAPIKey returns the API key either from provided value or environment variable
-func getAPIKey(apiKey string) (string, error) {
-	if apiKey == "" {
-		apiKey = os.Getenv(DiodeAPIKeyEnvVarName)
+// getClientID returns the client ID either from provided value or environment variable
+func getClientID(clientID string) (string, error) {
+	if clientID == "" {
+		clientID = os.Getenv(DiodeClientIDEnvVarName)
 	}
 
-	if apiKey == "" {
-		return "", fmt.Errorf("api_key param or %s environment variable required", DiodeAPIKeyEnvVarName)
+	if clientID == "" {
+		return "", fmt.Errorf("client_id param or %s environment variable required", DiodeClientIDEnvVarName)
 	}
 
-	return apiKey, nil
+	return clientID, nil
+}
+
+// getClientSecret returns the client secret either from provided value or environment variable
+func getClientSecret(clientSecret string) (string, error) {
+	if clientSecret == "" {
+		clientSecret = os.Getenv(DiodeClientSecretEnvVarName)
+	}
+
+	if clientSecret == "" {
+		return "", fmt.Errorf("client_secret param or %s environment variable required", DiodeClientSecretEnvVarName)
+	}
+
+	return clientSecret, nil
 }
 
 // Client is an interface that defines the methods available from Diode API
@@ -115,8 +133,11 @@ type GRPCClient struct {
 	// Producer's application version
 	appVersion string
 
-	// An API key for the Diode API
-	apiKey string
+	// The client ID for the API
+	clientID string
+
+	// The client secret for the API
+	clientSecret string
 
 	// GRPC target
 	target string
@@ -140,11 +161,99 @@ type GRPCClient struct {
 // ClientOption is a functional option for the GRPCClient
 type ClientOption func(*GRPCClient)
 
-// WithAPIKey sets the API key for the client
-func WithAPIKey(apiKey string) ClientOption {
+// WithClientID sets the client ID for the GRPCClient
+func WithClientID(clientID string) ClientOption {
 	return func(c *GRPCClient) {
-		c.apiKey = apiKey
+		c.clientID = clientID
 	}
+}
+
+// WithClientSecret sets the client secret for the GRPCClient
+func WithClientSecret(clientSecret string) ClientOption {
+	return func(c *GRPCClient) {
+		c.clientSecret = clientSecret
+	}
+}
+
+// authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
+func (g *GRPCClient) authenticate(ctx context.Context) error {
+	authClient := newDiodeAuthentication(g.target, g.tlsVerify, g.clientID, g.clientSecret)
+	accessToken, err := authClient.authenticate(ctx)
+	if err != nil {
+		return fmt.Errorf("authentication failed: %w", err)
+	}
+
+	// Update metadata with the new authorization token
+	g.metadata.Set("authorization", fmt.Sprintf("Bearer %s", accessToken))
+	return nil
+}
+
+// DiodeAuthentication handles OAuth2 authentication for the Diode API.
+type diodeAuthentication struct {
+	target       string
+	tlsVerify    bool
+	clientID     string
+	clientSecret string
+}
+
+// NewDiodeAuthentication creates a new instance of DiodeAuthentication.
+func newDiodeAuthentication(target string, tlsVerify bool, clientID, clientSecret string) *diodeAuthentication {
+	return &diodeAuthentication{
+		target:       target,
+		tlsVerify:    tlsVerify,
+		clientID:     clientID,
+		clientSecret: clientSecret,
+	}
+}
+
+// Authenticate requests an OAuth2 token using client credentials and returns it.
+func (d *diodeAuthentication) authenticate(ctx context.Context) (string, error) {
+	scheme := "http"
+	if d.tlsVerify {
+		scheme = "https"
+	}
+
+	authURL := fmt.Sprintf("%s://%s/diode/auth/token", scheme, d.target)
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", d.clientID)
+	data.Set("client_secret", d.clientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	if !d.tlsVerify {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("authentication failed: %s", resp.Status)
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if result.AccessToken == "" {
+		return "", errors.New("access token not found in response")
+	}
+
+	return result.AccessToken, nil
 }
 
 // NewClient creates a new diode client based on gRPC
@@ -203,19 +312,26 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 		goVersion:  goVersion,
 	}
 
-	var apiKey string
+	var clientID string
+	var clientSecret string
 
 	for _, o := range opts {
 		o(c)
 	}
 
-	apiKey, err = getAPIKey(c.apiKey)
+	clientID, err = getClientID(c.clientID)
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err = getClientSecret(c.clientSecret)
 	if err != nil {
 		return nil, err
 	}
 
-	c.apiKey = apiKey
-	c.metadata = metadata.Pairs(authAPIKeyName, c.apiKey, "platform", platform, "go-version", goVersion)
+	c.clientID = clientID
+	c.clientSecret = clientSecret
+
+	c.metadata = metadata.Pairs("platform", platform, "go-version", goVersion)
 
 	return c, nil
 }

--- a/diode/client.go
+++ b/diode/client.go
@@ -237,8 +237,10 @@ func (d *diodeAuthentication) authenticate(logger *slog.Logger) (string, error) 
 	if d.tlsVerify {
 		scheme = "https"
 	}
-
-	authURL := fmt.Sprintf("%s://%s/%s/auth/token", scheme, d.target, d.path)
+	authURL := fmt.Sprintf("%s://%s/auth/token", scheme, d.target)
+	if d.path != "" {
+		authURL = fmt.Sprintf("%s://%s%s/auth/token", scheme, d.target, d.path)
+	}
 	data := url.Values{}
 	data.Set("grant_type", "client_credentials")
 	data.Set("client_id", d.clientID)

--- a/diode/client.go
+++ b/diode/client.go
@@ -43,8 +43,6 @@ const (
 	DiodeSDKLogLevelEnvVarName = "DIODE_SDK_LOG_LEVEL"
 
 	defaultStreamName = "latest"
-
-	authAPIKeyName = "diode-api-key"
 )
 
 var allowedSchemesRe = regexp.MustCompile(`grpc|grpcs`)
@@ -178,7 +176,7 @@ func WithClientSecret(clientSecret string) ClientOption {
 // authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
 func (g *GRPCClient) authenticate(ctx context.Context) error {
 	authClient := newDiodeAuthentication(g.target, g.tlsVerify, g.clientID, g.clientSecret)
-	accessToken, err := authClient.authenticate(ctx)
+	accessToken, err := authClient.authenticate(ctx, g.logger)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
@@ -207,7 +205,7 @@ func newDiodeAuthentication(target string, tlsVerify bool, clientID, clientSecre
 }
 
 // Authenticate requests an OAuth2 token using client credentials and returns it.
-func (d *diodeAuthentication) authenticate(ctx context.Context) (string, error) {
+func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Logger) (string, error) {
 	scheme := "http"
 	if d.tlsVerify {
 		scheme = "https"
@@ -236,8 +234,11 @@ func (d *diodeAuthentication) authenticate(ctx context.Context) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
 	}
-	defer resp.Body.Close()
-
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error("failed to close response body", "error", err)
+		}
+	}()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("authentication failed: %s", resp.Status)
 	}
@@ -330,6 +331,10 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 
 	c.clientID = clientID
 	c.clientSecret = clientSecret
+
+	if err = c.authenticate(context.Background()); err != nil {
+		return nil, err
+	}
 
 	c.metadata = metadata.Pairs("platform", platform, "go-version", goVersion)
 

--- a/diode/client.go
+++ b/diode/client.go
@@ -199,9 +199,9 @@ func WithClientSecret(clientSecret string) ClientOption {
 }
 
 // authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
-func (g *GRPCClient) authenticate(ctx context.Context) error {
+func (g *GRPCClient) authenticate() error {
 	authClient := newDiodeAuthentication(g.target, g.path, g.tlsVerify, g.clientID, g.clientSecret)
-	accessToken, err := authClient.authenticate(ctx, g.logger)
+	accessToken, err := authClient.authenticate(g.logger)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
@@ -232,7 +232,7 @@ func newDiodeAuthentication(target string, path string, tlsVerify bool, clientID
 }
 
 // Authenticate requests an OAuth2 token using client credentials and returns it.
-func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Logger) (string, error) {
+func (d *diodeAuthentication) authenticate(logger *slog.Logger) (string, error) {
 	scheme := "http"
 	if d.tlsVerify {
 		scheme = "https"
@@ -244,7 +244,7 @@ func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Log
 	data.Set("client_id", d.clientID)
 	data.Set("client_secret", d.clientSecret)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest(http.MethodPost, authURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
@@ -367,7 +367,7 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 	c.clientID = clientID
 	c.clientSecret = clientSecret
 
-	if err = c.authenticate(context.Background()); err != nil {
+	if err = c.authenticate(); err != nil {
 		return nil, err
 	}
 
@@ -413,7 +413,7 @@ func (g *GRPCClient) Ingest(ctx context.Context, entities []Entity) (*diodepb.In
 					return nil, fmt.Errorf("authentication failed after %d attempts: %w", attempt, err)
 				}
 				g.logger.Debug("Authentication failed, retrying...", "attempt", attempt)
-				if err := g.authenticate(ctx); err != nil {
+				if err := g.authenticate(); err != nil {
 					g.logger.Error("Failed to re-authenticate", "error", err)
 				}
 				continue

--- a/diode/client.go
+++ b/diode/client.go
@@ -200,7 +200,7 @@ func WithClientSecret(clientSecret string) ClientOption {
 
 // authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
 func (g *GRPCClient) authenticate(ctx context.Context) error {
-	authClient := newDiodeAuthentication(g.target, g.tlsVerify, g.clientID, g.clientSecret)
+	authClient := newDiodeAuthentication(g.target, g.path, g.tlsVerify, g.clientID, g.clientSecret)
 	accessToken, err := authClient.authenticate(ctx, g.logger)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
@@ -214,15 +214,17 @@ func (g *GRPCClient) authenticate(ctx context.Context) error {
 // DiodeAuthentication handles OAuth2 authentication for the Diode API.
 type diodeAuthentication struct {
 	target       string
+	path         string
 	tlsVerify    bool
 	clientID     string
 	clientSecret string
 }
 
 // NewDiodeAuthentication creates a new instance of DiodeAuthentication.
-func newDiodeAuthentication(target string, tlsVerify bool, clientID, clientSecret string) *diodeAuthentication {
+func newDiodeAuthentication(target string, path string, tlsVerify bool, clientID, clientSecret string) *diodeAuthentication {
 	return &diodeAuthentication{
 		target:       target,
+		path:         path,
 		tlsVerify:    tlsVerify,
 		clientID:     clientID,
 		clientSecret: clientSecret,
@@ -236,7 +238,7 @@ func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Log
 		scheme = "https"
 	}
 
-	authURL := fmt.Sprintf("%s://%s/diode/auth/token", scheme, d.target)
+	authURL := fmt.Sprintf("%s://%s/%s/auth/token", scheme, d.target, d.path)
 	data := url.Values{}
 	data.Set("grant_type", "client_credentials")
 	data.Set("client_id", d.clientID)

--- a/diode/client.go
+++ b/diode/client.go
@@ -13,14 +13,17 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
@@ -41,6 +44,9 @@ const (
 
 	// DiodeSDKLogLevelEnvVarName is the environment variable name for the Diode SDK log level
 	DiodeSDKLogLevelEnvVarName = "DIODE_SDK_LOG_LEVEL"
+
+	// DiodeMaxAuthRetriesEnvVarName is the environment variable name for the maximum number of authentication retries
+	DiodeMaxAuthRetriesEnvVarName = "DIODE_MAX_AUTH_RETRIES"
 
 	defaultStreamName = "latest"
 )
@@ -105,6 +111,22 @@ func getClientSecret(clientSecret string) (string, error) {
 	return clientSecret, nil
 }
 
+// getAuthRetries returns the maximum number of authentication retries
+func getAuthRetries(maxAuthRetries int) (int, error) {
+	maxAuthRetriesStr := os.Getenv(DiodeMaxAuthRetriesEnvVarName)
+	if maxAuthRetriesStr != "" {
+		retries, err := strconv.Atoi(maxAuthRetriesStr)
+		if err != nil {
+			return 0, fmt.Errorf("invalid value for %s: %w", DiodeMaxAuthRetriesEnvVarName, err)
+		}
+		maxAuthRetries = retries
+	}
+	if maxAuthRetries <= 0 {
+		return 0, fmt.Errorf("max_auth_retries param or %s environment variable must be greater than 0", DiodeMaxAuthRetriesEnvVarName)
+	}
+	return maxAuthRetries, nil
+}
+
 // Client is an interface that defines the methods available from Diode API
 type Client interface {
 	// Close closes the connection to the API service
@@ -136,6 +158,9 @@ type GRPCClient struct {
 
 	// The client secret for the API
 	clientSecret string
+
+	// The maximum number of authentication retries
+	maxAuthRetries int
 
 	// GRPC target
 	target string
@@ -301,16 +326,17 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 	goVersion := runtime.Version()
 
 	c := &GRPCClient{
-		logger:     logger,
-		conn:       conn,
-		client:     diodepb.NewIngesterServiceClient(conn),
-		appName:    appName,
-		appVersion: appVersion,
-		target:     target,
-		path:       path,
-		tlsVerify:  tlsVerify,
-		platform:   platform,
-		goVersion:  goVersion,
+		logger:         logger,
+		conn:           conn,
+		client:         diodepb.NewIngesterServiceClient(conn),
+		appName:        appName,
+		appVersion:     appVersion,
+		target:         target,
+		path:           path,
+		tlsVerify:      tlsVerify,
+		platform:       platform,
+		goVersion:      goVersion,
+		maxAuthRetries: 3,
 	}
 
 	var clientID string
@@ -318,6 +344,13 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 
 	for _, o := range opts {
 		o(c)
+	}
+
+	c.metadata = metadata.Pairs("platform", platform, "go-version", goVersion)
+
+	c.maxAuthRetries, err = getAuthRetries(c.maxAuthRetries)
+	if err != nil {
+		return nil, err
 	}
 
 	clientID, err = getClientID(c.clientID)
@@ -335,8 +368,6 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 	if err = c.authenticate(context.Background()); err != nil {
 		return nil, err
 	}
-
-	c.metadata = metadata.Pairs("platform", platform, "go-version", goVersion)
 
 	return c, nil
 }
@@ -367,7 +398,29 @@ func (g *GRPCClient) Ingest(ctx context.Context, entities []Entity) (*diodepb.In
 
 	ctx = metadata.NewOutgoingContext(ctx, g.metadata)
 
-	return g.client.Ingest(ctx, req)
+	var err error
+	var res *diodepb.IngestResponse
+
+	attempt := 0
+	for {
+		res, err = g.client.Ingest(ctx, req)
+		if err != nil {
+			if status.Code(err) == codes.Unauthenticated {
+				attempt++
+				if attempt >= g.maxAuthRetries {
+					return nil, fmt.Errorf("authentication failed after %d attempts: %w", attempt, err)
+				}
+				g.logger.Debug("Authentication failed, retrying...", "attempt", attempt)
+				if err := g.authenticate(ctx); err != nil {
+					g.logger.Error("Failed to re-authenticate", "error", err)
+				}
+				continue
+			}
+			return nil, err
+		}
+		break
+	}
+	return res, nil
 }
 
 // convertEntitiesToProto converts entities to proto entities

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -602,11 +602,70 @@ func TestHTTPAuthError(t *testing.T) {
 
 	_ = os.Setenv(DiodeClientIDEnvVarName, "invalid-client")
 	_ = os.Setenv(DiodeClientSecretEnvVarName, "invalid-client-sct")
+	_ = os.Setenv(DiodeMaxAuthRetriesEnvVarName, "2")
 	defer func() {
 		_ = os.Unsetenv(DiodeClientIDEnvVarName)
 		_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+		_ = os.Unsetenv(DiodeMaxAuthRetriesEnvVarName)
 	}()
 
 	_, err = NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
 	require.Error(t, err)
+}
+
+func TestAuthRetryEnv(t *testing.T) {
+	tests := []struct {
+		desc       string
+		retryValue string
+		wantErr    error
+	}{
+		{
+			desc:       "valid value",
+			retryValue: "2",
+			wantErr:    nil,
+		},
+		{
+			desc:       "empty value",
+			retryValue: "",
+			wantErr:    nil,
+		},
+		{
+			desc:       "invalid value",
+			retryValue: "invalid",
+			wantErr:    errors.New("invalid value for DIODE_MAX_AUTH_RETRIES: strconv.Atoi: parsing \"invalid\": invalid syntax"),
+		},
+		{
+			desc:       "negative value",
+			retryValue: "-1",
+			wantErr:    errors.New("max_auth_retries param or DIODE_MAX_AUTH_RETRIES environment variable must be greater than 0"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			port, err := getFreePort()
+			require.NoError(t, err)
+
+			authServer, err := startMockAuthServer(port, "", false)
+			require.NoError(t, err)
+			defer authServer.Close()
+
+			_ = os.Setenv(DiodeClientIDEnvVarName, "client-id")
+			_ = os.Setenv(DiodeClientSecretEnvVarName, "client-secret")
+			_ = os.Setenv(DiodeMaxAuthRetriesEnvVarName, tt.retryValue)
+			defer func() {
+				_ = os.Unsetenv(DiodeClientIDEnvVarName)
+				_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+				_ = os.Unsetenv(DiodeMaxAuthRetriesEnvVarName)
+			}()
+
+			_, err = NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -175,7 +176,55 @@ func TestGetClientCredentials(t *testing.T) {
 	}
 }
 
+type MockAuthServer struct {
+	listener net.Listener
+	server   *http.Server
+}
+
+func (m *MockAuthServer) Close() {
+	m.server.Shutdown(context.Background())
+	_ = m.listener.Close()
+}
+
+func startMockAuthServer(port string) (*MockAuthServer, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%s", port))
+	if err != nil {
+		return nil, err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseForm()
+		clientID := r.FormValue("client_id")
+		clientSecret := r.FormValue("client_secret")
+		if clientID == "abcde" && clientSecret == "123345" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token": "mock-token"}`))
+		} else {
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		}
+	})
+
+	server := &http.Server{Handler: mux}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	return &MockAuthServer{listener: listener, server: server}, nil
+}
+
 func TestNewClient(t *testing.T) {
+	port, err := getFreePort()
+	require.NoError(t, err)
+
+	authServer, err := startMockAuthServer(port)
+	require.NoError(t, err)
+	defer authServer.Close()
+
 	tests := []struct {
 		desc                    string
 		target                  string
@@ -185,31 +234,28 @@ func TestNewClient(t *testing.T) {
 		clientSecret            string
 		clientIDEnvVarValue     string
 		clientSecretEnvVarValue string
-		logLevelEnvVarValue     string
 		wantErr                 error
 	}{
 		{
 			desc:                    "explicit arguments provided",
-			target:                  "grpc://localhost:8081",
+			target:                  fmt.Sprintf("grpc://localhost:%s", port),
 			appName:                 "my-producer",
 			appVersion:              "0.1.0",
 			clientID:                "client-id-123",
 			clientSecret:            "client-secret-456",
 			clientIDEnvVarValue:     "",
 			clientSecretEnvVarValue: "",
-			logLevelEnvVarValue:     "",
 			wantErr:                 nil,
 		},
 		{
 			desc:                    "Client credentials provided via environment variables",
-			target:                  "grpc://localhost:8081",
+			target:                  fmt.Sprintf("grpc://localhost:%s", port),
 			appName:                 "my-producer",
 			appVersion:              "0.1.0",
 			clientID:                "",
 			clientSecret:            "",
 			clientIDEnvVarValue:     "env-client-id",
 			clientSecretEnvVarValue: "env-client-secret",
-			logLevelEnvVarValue:     "",
 			wantErr:                 nil,
 		},
 		{
@@ -221,7 +267,6 @@ func TestNewClient(t *testing.T) {
 			clientSecret:            "client-secret-456",
 			clientIDEnvVarValue:     "",
 			clientSecretEnvVarValue: "",
-			logLevelEnvVarValue:     "",
 			wantErr:                 errors.New("app name is required"),
 		},
 		{
@@ -233,7 +278,6 @@ func TestNewClient(t *testing.T) {
 			clientSecret:            "client-secret-456",
 			clientIDEnvVarValue:     "",
 			clientSecretEnvVarValue: "",
-			logLevelEnvVarValue:     "",
 			wantErr:                 errors.New("app version is required"),
 		},
 		{
@@ -245,7 +289,6 @@ func TestNewClient(t *testing.T) {
 			clientSecret:            "client-secret-456",
 			clientIDEnvVarValue:     "",
 			clientSecretEnvVarValue: "",
-			logLevelEnvVarValue:     "",
 			wantErr:                 errors.New("target should start with grpc:// or grpcs://"),
 		},
 		{
@@ -337,6 +380,13 @@ func startMockServer() (net.Listener, error) {
 }
 
 func TestMethodUnaryInterceptor(t *testing.T) {
+	port, err := getFreePort()
+	require.NoError(t, err)
+
+	authServer, err := startMockAuthServer(port)
+	require.NoError(t, err)
+	defer authServer.Close()
+
 	tests := []struct {
 		desc    string
 		path    string
@@ -356,18 +406,21 @@ func TestMethodUnaryInterceptor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			listener, err := startMockServer()
+			listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%s", port))
 			require.NoError(t, err)
 
-			target := fmt.Sprintf("grpc://%s/%s", listener.Addr().String(), tt.path)
-			appName := "my-producer"
-			appVersion := "0.1.0"
-			clientID := "abcde"
-			clientSecret := "123345"
+			server := grpc.NewServer()
+			diodepb.RegisterIngesterServiceServer(server, &MockIngesterServiceServer{})
+			go func() {
+				_ = server.Serve(listener)
+			}()
+			defer server.Stop()
 
-			client, err := NewClient(target, appName, appVersion, WithClientID(clientID), WithClientSecret(clientSecret))
+			target := fmt.Sprintf("grpc://localhost:%s/%s", port, tt.path)
+			client, err := NewClient(target, "my-producer", "0.1.0", WithClientID("abcde"), WithClientSecret("123345"))
 			require.NoError(t, err)
 			require.NotNil(t, client)
+
 			_, err = client.Ingest(context.Background(), nil)
 			if tt.wantErr != nil {
 				require.Equal(t, tt.wantErr.Error(), err.Error())

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -111,7 +111,7 @@ func TestGetClientCredentials(t *testing.T) {
 		clientSecretEnvVarValue string
 		wantClientID            string
 		wantClientSecret        string
-		wantIdErr               error
+		wantIDErr               error
 		wantSecretErr           error
 	}{
 		{
@@ -122,7 +122,7 @@ func TestGetClientCredentials(t *testing.T) {
 			clientSecretEnvVarValue: "",
 			wantClientID:            "client-id-123",
 			wantClientSecret:        "client-secret-456",
-			wantIdErr:               nil,
+			wantIDErr:               nil,
 			wantSecretErr:           nil,
 		},
 		{
@@ -133,7 +133,7 @@ func TestGetClientCredentials(t *testing.T) {
 			clientSecretEnvVarValue: "env-client-secret",
 			wantClientID:            "env-client-id",
 			wantClientSecret:        "env-client-secret",
-			wantIdErr:               nil,
+			wantIDErr:               nil,
 			wantSecretErr:           nil,
 		},
 		{
@@ -144,7 +144,7 @@ func TestGetClientCredentials(t *testing.T) {
 			clientSecretEnvVarValue: "",
 			wantClientID:            "",
 			wantClientSecret:        "",
-			wantIdErr:               errors.New("client_id param or DIODE_CLIENT_ID environment variable required"),
+			wantIDErr:               errors.New("client_id param or DIODE_CLIENT_ID environment variable required"),
 			wantSecretErr:           errors.New("client_secret param or DIODE_CLIENT_SECRET environment variable required"),
 		},
 	}
@@ -166,7 +166,7 @@ func TestGetClientCredentials(t *testing.T) {
 
 			clientID, err := getClientID(tt.clientID)
 			require.Equal(t, tt.wantClientID, clientID)
-			require.Equal(t, tt.wantIdErr, err)
+			require.Equal(t, tt.wantIDErr, err)
 
 			clientSecret, err := getClientSecret(tt.clientSecret)
 			require.Equal(t, tt.wantClientSecret, clientSecret)

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -11,10 +11,13 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
@@ -177,23 +180,34 @@ func TestGetClientCredentials(t *testing.T) {
 }
 
 type MockAuthServer struct {
-	listener net.Listener
-	server   *http.Server
+	listener   net.Listener
+	httpServer *http.Server
+	grpcServer *grpc.Server
 }
 
 func (m *MockAuthServer) Close() {
-	m.server.Shutdown(context.Background())
+	m.grpcServer.GracefulStop()
+	_ = m.httpServer.Shutdown(context.Background())
 	_ = m.listener.Close()
 }
 
-func startMockAuthServer(port string) (*MockAuthServer, error) {
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%s", port))
+func startMockAuthServer(port string, path string) (*MockAuthServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to listen: %w", err)
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/auth/token", func(w http.ResponseWriter, r *http.Request) {
+	grpcServer := grpc.NewServer()
+	diodepb.RegisterIngesterServiceServer(grpcServer, &MockIngesterServiceServer{})
+
+	// HTTP handler
+	httpMux := http.NewServeMux()
+
+	newPath := "/auth/token"
+	if path != "" {
+		newPath = fmt.Sprintf("/%s/auth/token", path)
+	}
+	httpMux.HandleFunc(newPath, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "invalid method", http.StatusMethodNotAllowed)
 			return
@@ -201,7 +215,7 @@ func startMockAuthServer(port string) (*MockAuthServer, error) {
 		_ = r.ParseForm()
 		clientID := r.FormValue("client_id")
 		clientSecret := r.FormValue("client_secret")
-		if clientID == "abcde" && clientSecret == "123345" {
+		if strings.Contains(clientID, "client-id") && strings.Contains(clientSecret, "client-secret") {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"access_token": "mock-token"}`))
 		} else {
@@ -209,19 +223,37 @@ func startMockAuthServer(port string) (*MockAuthServer, error) {
 		}
 	})
 
-	server := &http.Server{Handler: mux}
+	// Wrap the mux with h2c-compatible handler that detects gRPC
+	handler := h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			httpMux.ServeHTTP(w, r)
+		}
+	}), &http2.Server{})
+
+	httpServer := &http.Server{
+		Handler: handler,
+	}
+
 	go func() {
-		_ = server.Serve(listener)
+		if err := httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server error: %v", err)
+		}
 	}()
 
-	return &MockAuthServer{listener: listener, server: server}, nil
+	return &MockAuthServer{
+		listener:   listener,
+		httpServer: httpServer,
+		grpcServer: grpcServer,
+	}, nil
 }
 
 func TestNewClient(t *testing.T) {
 	port, err := getFreePort()
 	require.NoError(t, err)
 
-	authServer, err := startMockAuthServer(port)
+	authServer, err := startMockAuthServer(port, "")
 	require.NoError(t, err)
 	defer authServer.Close()
 
@@ -359,34 +391,7 @@ func (MockIngesterServiceServer) Ingest(_ context.Context, _ *diodepb.IngestRequ
 	return &diodepb.IngestResponse{Errors: nil}, nil
 }
 
-func startMockServer() (net.Listener, error) {
-	port, _ := getFreePort()
-	grpcListener, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
-	if err != nil {
-		return nil, fmt.Errorf("failed to listen on port %s: %v", port, err)
-	}
-
-	server := grpc.NewServer()
-
-	diodepb.RegisterIngesterServiceServer(server, &MockIngesterServiceServer{})
-
-	go func() {
-		if err := server.Serve(grpcListener); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	return grpcListener, nil
-}
-
 func TestMethodUnaryInterceptor(t *testing.T) {
-	port, err := getFreePort()
-	require.NoError(t, err)
-
-	authServer, err := startMockAuthServer(port)
-	require.NoError(t, err)
-	defer authServer.Close()
-
 	tests := []struct {
 		desc    string
 		path    string
@@ -406,18 +411,15 @@ func TestMethodUnaryInterceptor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%s", port))
+			port, err := getFreePort()
 			require.NoError(t, err)
 
-			server := grpc.NewServer()
-			diodepb.RegisterIngesterServiceServer(server, &MockIngesterServiceServer{})
-			go func() {
-				_ = server.Serve(listener)
-			}()
-			defer server.Stop()
+			authServer, err := startMockAuthServer(port, tt.path)
+			require.NoError(t, err)
+			defer authServer.Close()
 
 			target := fmt.Sprintf("grpc://localhost:%s/%s", port, tt.path)
-			client, err := NewClient(target, "my-producer", "0.1.0", WithClientID("abcde"), WithClientSecret("123345"))
+			client, err := NewClient(target, "my-producer", "0.1.0", WithClientID("client-id"), WithClientSecret("client-secret"))
 			require.NoError(t, err)
 			require.NotNil(t, client)
 

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -102,158 +102,186 @@ func TestParseTarget(t *testing.T) {
 	}
 }
 
-func TestGetAPIKey(t *testing.T) {
+func TestGetClientCredentials(t *testing.T) {
 	tests := []struct {
-		desc              string
-		apiKey            string
-		apiKeyEnvVarValue string
-		wantAPIKey        string
-		wantErr           error
+		desc                    string
+		clientID                string
+		clientSecret            string
+		clientIDEnvVarValue     string
+		clientSecretEnvVarValue string
+		wantClientID            string
+		wantClientSecret        string
+		wantIdErr               error
+		wantSecretErr           error
 	}{
 		{
-			desc:              "API key provided explicitly",
-			apiKey:            "foobar",
-			apiKeyEnvVarValue: "",
-			wantAPIKey:        "foobar",
-			wantErr:           nil,
+			desc:                    "Client credentials provided explicitly",
+			clientID:                "client-id-123",
+			clientSecret:            "client-secret-456",
+			clientIDEnvVarValue:     "",
+			clientSecretEnvVarValue: "",
+			wantClientID:            "client-id-123",
+			wantClientSecret:        "client-secret-456",
+			wantIdErr:               nil,
+			wantSecretErr:           nil,
 		},
 		{
-			desc:              "API key provided with environment variable",
-			apiKey:            "",
-			apiKeyEnvVarValue: "barfoo",
-			wantAPIKey:        "barfoo",
-			wantErr:           nil,
+			desc:                    "Client credentials provided via environment variables",
+			clientID:                "",
+			clientSecret:            "",
+			clientIDEnvVarValue:     "env-client-id",
+			clientSecretEnvVarValue: "env-client-secret",
+			wantClientID:            "env-client-id",
+			wantClientSecret:        "env-client-secret",
+			wantIdErr:               nil,
+			wantSecretErr:           nil,
 		},
 		{
-			desc:              "API key not provided either explicitly or with environment variable",
-			apiKey:            "",
-			apiKeyEnvVarValue: "",
-			wantAPIKey:        "",
-			wantErr:           errors.New("api_key param or DIODE_API_KEY environment variable required"),
+			desc:                    "Missing clientID and clientSecret",
+			clientID:                "",
+			clientSecret:            "",
+			clientIDEnvVarValue:     "",
+			clientSecretEnvVarValue: "",
+			wantClientID:            "",
+			wantClientSecret:        "",
+			wantIdErr:               errors.New("client_id param or DIODE_CLIENT_ID environment variable required"),
+			wantSecretErr:           errors.New("client_secret param or DIODE_CLIENT_SECRET environment variable required"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if tt.apiKeyEnvVarValue != "" {
-				_ = os.Setenv(DiodeAPIKeyEnvVarName, tt.apiKeyEnvVarValue)
+			if tt.clientIDEnvVarValue != "" {
+				_ = os.Setenv(DiodeClientIDEnvVarName, tt.clientIDEnvVarValue)
 				defer func() {
-					_ = os.Unsetenv(DiodeAPIKeyEnvVarName)
+					_ = os.Unsetenv(DiodeClientIDEnvVarName)
 				}()
 			}
-			apiKey, err := getAPIKey(tt.apiKey)
-			require.Equal(t, tt.wantAPIKey, apiKey)
-			require.Equal(t, tt.wantErr, err)
+			if tt.clientSecretEnvVarValue != "" {
+				_ = os.Setenv(DiodeClientSecretEnvVarName, tt.clientSecretEnvVarValue)
+				defer func() {
+					_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+				}()
+			}
+
+			clientID, err := getClientID(tt.clientID)
+			require.Equal(t, tt.wantClientID, clientID)
+			require.Equal(t, tt.wantIdErr, err)
+
+			clientSecret, err := getClientSecret(tt.clientSecret)
+			require.Equal(t, tt.wantClientSecret, clientSecret)
+			require.Equal(t, tt.wantSecretErr, err)
 		})
 	}
 }
 
 func TestNewClient(t *testing.T) {
 	tests := []struct {
-		desc                string
-		target              string
-		appName             string
-		appVersion          string
-		apiKey              string
-		apiKeyEnvVarValue   string
-		logLevelEnvVarValue string
-		wantErr             error
+		desc                    string
+		target                  string
+		appName                 string
+		appVersion              string
+		clientID                string
+		clientSecret            string
+		clientIDEnvVarValue     string
+		clientSecretEnvVarValue string
+		logLevelEnvVarValue     string
+		wantErr                 error
 	}{
 		{
-			desc:                "explicit arguments provided",
-			target:              "grpc://localhost:8081",
-			appName:             "my-producer",
-			appVersion:          "0.1.0",
-			apiKey:              "foobar",
-			apiKeyEnvVarValue:   "",
-			logLevelEnvVarValue: "",
-			wantErr:             nil,
+			desc:                    "explicit arguments provided",
+			target:                  "grpc://localhost:8081",
+			appName:                 "my-producer",
+			appVersion:              "0.1.0",
+			clientID:                "client-id-123",
+			clientSecret:            "client-secret-456",
+			clientIDEnvVarValue:     "",
+			clientSecretEnvVarValue: "",
+			logLevelEnvVarValue:     "",
+			wantErr:                 nil,
 		},
 		{
-			desc:                "API key provided with environment variable",
-			target:              "grpc://localhost:8081",
-			appName:             "my-producer",
-			appVersion:          "0.1.0",
-			apiKey:              "",
-			apiKeyEnvVarValue:   "foo.bar",
-			logLevelEnvVarValue: "",
-			wantErr:             nil,
+			desc:                    "Client credentials provided via environment variables",
+			target:                  "grpc://localhost:8081",
+			appName:                 "my-producer",
+			appVersion:              "0.1.0",
+			clientID:                "",
+			clientSecret:            "",
+			clientIDEnvVarValue:     "env-client-id",
+			clientSecretEnvVarValue: "env-client-secret",
+			logLevelEnvVarValue:     "",
+			wantErr:                 nil,
 		},
 		{
-			desc:                "target with path",
-			target:              "grpc://localhost:8081/abcdef",
-			appName:             "my-producer",
-			appVersion:          "0.1.0",
-			apiKey:              "",
-			apiKeyEnvVarValue:   "foo.bar",
-			logLevelEnvVarValue: "",
-			wantErr:             nil,
+			desc:                    "app name not provided",
+			target:                  "grpc://localhost:8081",
+			appName:                 "",
+			appVersion:              "0.1.0",
+			clientID:                "client-id-123",
+			clientSecret:            "client-secret-456",
+			clientIDEnvVarValue:     "",
+			clientSecretEnvVarValue: "",
+			logLevelEnvVarValue:     "",
+			wantErr:                 errors.New("app name is required"),
 		},
 		{
-			desc:                "target with grpcs scheme",
-			target:              "grpcs://localhost:8081",
-			appName:             "my-producer",
-			appVersion:          "0.1.0",
-			apiKey:              "",
-			apiKeyEnvVarValue:   "foo.bar",
-			logLevelEnvVarValue: "",
-			wantErr:             nil,
+			desc:                    "app version not provided",
+			target:                  "grpc://localhost:8081",
+			appName:                 "my-producer",
+			appVersion:              "",
+			clientID:                "client-id-123",
+			clientSecret:            "client-secret-456",
+			clientIDEnvVarValue:     "",
+			clientSecretEnvVarValue: "",
+			logLevelEnvVarValue:     "",
+			wantErr:                 errors.New("app version is required"),
 		},
 		{
-			desc:                "app name not provided",
-			target:              "grpc://localhost:8081",
-			appName:             "",
-			appVersion:          "0.1.0",
-			apiKey:              "foobar",
-			apiKeyEnvVarValue:   "",
-			logLevelEnvVarValue: "",
-			wantErr:             errors.New("app name is required"),
+			desc:                    "invalid target",
+			target:                  "http://localhost:8081",
+			appName:                 "my-producer",
+			appVersion:              "0.1.0",
+			clientID:                "client-id-123",
+			clientSecret:            "client-secret-456",
+			clientIDEnvVarValue:     "",
+			clientSecretEnvVarValue: "",
+			logLevelEnvVarValue:     "",
+			wantErr:                 errors.New("target should start with grpc:// or grpcs://"),
 		},
 		{
-			desc:                "app version not provided",
-			target:              "grpc://localhost:8081",
-			appName:             "my-producer",
-			appVersion:          "",
-			apiKey:              "foobar",
-			apiKeyEnvVarValue:   "",
-			logLevelEnvVarValue: "",
-			wantErr:             errors.New("app version is required"),
-		},
-		{
-			desc:                "invalid target",
-			target:              "http://localhost:8081",
-			appName:             "my-producer",
-			appVersion:          "0.1.0",
-			apiKey:              "foobar",
-			apiKeyEnvVarValue:   "",
-			logLevelEnvVarValue: "",
-			wantErr:             errors.New("target should start with grpc:// or grpcs://"),
-		},
-		{
-			desc:              "missing API key",
-			target:            "grpc://localhost:8081",
-			appName:           "my-producer",
-			appVersion:        "0.1.0",
-			apiKey:            "",
-			apiKeyEnvVarValue: "",
-			wantErr:           errors.New("api_key param or DIODE_API_KEY environment variable required"),
+			desc:                    "missing clientID and clientSecret",
+			target:                  "grpc://localhost:8081",
+			appName:                 "my-producer",
+			appVersion:              "0.1.0",
+			clientID:                "",
+			clientSecret:            "",
+			clientIDEnvVarValue:     "",
+			clientSecretEnvVarValue: "",
+			wantErr:                 errors.New("client_id param or DIODE_CLIENT_ID environment variable required"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			defer func() {
-				_ = os.Unsetenv(DiodeAPIKeyEnvVarName)
+				_ = os.Unsetenv(DiodeClientIDEnvVarName)
+				_ = os.Unsetenv(DiodeClientSecretEnvVarName)
 				_ = os.Unsetenv(DiodeSDKLogLevelEnvVarName)
 			}()
 
-			if tt.apiKeyEnvVarValue != "" {
-				_ = os.Setenv(DiodeAPIKeyEnvVarName, tt.apiKeyEnvVarValue)
+			if tt.clientIDEnvVarValue != "" {
+				_ = os.Setenv(DiodeClientIDEnvVarName, tt.clientIDEnvVarValue)
+			}
+			if tt.clientSecretEnvVarValue != "" {
+				_ = os.Setenv(DiodeClientSecretEnvVarName, tt.clientSecretEnvVarValue)
 			}
 
 			opts := []ClientOption{}
-			if tt.apiKey != "" {
-				opts = append(opts, WithAPIKey(tt.apiKey))
+			if tt.clientID != "" {
+				opts = append(opts, WithClientID(tt.clientID))
+			}
+			if tt.clientSecret != "" {
+				opts = append(opts, WithClientSecret(tt.clientSecret))
 			}
 
 			client, err := NewClient(tt.target, tt.appName, tt.appVersion, opts...)
@@ -334,9 +362,10 @@ func TestMethodUnaryInterceptor(t *testing.T) {
 			target := fmt.Sprintf("grpc://%s/%s", listener.Addr().String(), tt.path)
 			appName := "my-producer"
 			appVersion := "0.1.0"
-			apiKey := "abcde"
+			clientID := "abcde"
+			clientSecret := "123345"
 
-			client, err := NewClient(target, appName, appVersion, WithAPIKey(apiKey))
+			client, err := NewClient(target, appName, appVersion, WithClientID(clientID), WithClientSecret(clientSecret))
 			require.NoError(t, err)
 			require.NotNil(t, client)
 			_, err = client.Ingest(context.Background(), nil)

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -19,6 +19,8 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
@@ -191,14 +193,14 @@ func (m *MockAuthServer) Close() {
 	_ = m.listener.Close()
 }
 
-func startMockAuthServer(port string, path string) (*MockAuthServer, error) {
+func startMockAuthServer(port string, path string, authErrorGrpc bool) (*MockAuthServer, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen: %w", err)
 	}
 
 	grpcServer := grpc.NewServer()
-	diodepb.RegisterIngesterServiceServer(grpcServer, &MockIngesterServiceServer{})
+	diodepb.RegisterIngesterServiceServer(grpcServer, &MockIngesterServiceServer{unauthenticatedError: authErrorGrpc})
 
 	// HTTP handler
 	httpMux := http.NewServeMux()
@@ -253,7 +255,7 @@ func TestNewClient(t *testing.T) {
 	port, err := getFreePort()
 	require.NoError(t, err)
 
-	authServer, err := startMockAuthServer(port, "")
+	authServer, err := startMockAuthServer(port, "", false)
 	require.NoError(t, err)
 	defer authServer.Close()
 
@@ -385,9 +387,13 @@ func getFreePort() (string, error) {
 
 type MockIngesterServiceServer struct {
 	diodepb.UnimplementedIngesterServiceServer
+	unauthenticatedError bool
 }
 
-func (MockIngesterServiceServer) Ingest(_ context.Context, _ *diodepb.IngestRequest) (*diodepb.IngestResponse, error) {
+func (m MockIngesterServiceServer) Ingest(_ context.Context, _ *diodepb.IngestRequest) (*diodepb.IngestResponse, error) {
+	if m.unauthenticatedError {
+		return nil, status.Error(codes.Unauthenticated, "mock auth failure")
+	}
 	return &diodepb.IngestResponse{Errors: nil}, nil
 }
 
@@ -414,7 +420,7 @@ func TestMethodUnaryInterceptor(t *testing.T) {
 			port, err := getFreePort()
 			require.NoError(t, err)
 
-			authServer, err := startMockAuthServer(port, tt.path)
+			authServer, err := startMockAuthServer(port, tt.path, false)
 			require.NoError(t, err)
 			defer authServer.Close()
 
@@ -519,4 +525,88 @@ func TestConvertEntitiesToProto(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIngest(t *testing.T) {
+	tests := []struct {
+		desc            string
+		entities        []Entity
+		authRetries     int
+		mockAuthFailure bool
+		wantErr         error
+	}{
+		{
+			desc: "successful ingest",
+			entities: []Entity{
+				&Device{Name: String("device-1")},
+				&Site{Name: String("site-1")},
+			},
+			authRetries:     3,
+			mockAuthFailure: false,
+			wantErr:         nil,
+		},
+		{
+			desc:            "authentication failure after retries",
+			entities:        nil,
+			authRetries:     2,
+			mockAuthFailure: true,
+			wantErr:         errors.New("authentication failed after 2 attempts: rpc error: code = Unauthenticated desc = mock auth failure"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			defer func() {
+				_ = os.Unsetenv(DiodeClientIDEnvVarName)
+				_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+			}()
+
+			_ = os.Setenv(DiodeClientIDEnvVarName, "client-id")
+			_ = os.Setenv(DiodeClientSecretEnvVarName, "client-secret")
+
+			port, err := getFreePort()
+			require.NoError(t, err)
+
+			authServer, err := startMockAuthServer(port, "", tt.mockAuthFailure)
+			require.NoError(t, err)
+			defer authServer.Close()
+
+			client, err := NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+			require.NoError(t, err)
+			defer func() {
+				err := client.Close()
+				require.NoError(t, err)
+			}()
+
+			grpcClient := client.(*GRPCClient)
+			grpcClient.maxAuthRetries = tt.authRetries
+
+			_, err = grpcClient.Ingest(context.Background(), tt.entities)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHTTPAuthError(t *testing.T) {
+	port, err := getFreePort()
+	require.NoError(t, err)
+
+	authServer, err := startMockAuthServer(port, "", false)
+	require.NoError(t, err)
+	defer authServer.Close()
+
+	_ = os.Setenv(DiodeClientIDEnvVarName, "invalid-client")
+	_ = os.Setenv(DiodeClientSecretEnvVarName, "invalid-client-sct")
+	defer func() {
+		_ = os.Unsetenv(DiodeClientIDEnvVarName)
+		_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+	}()
+
+	_, err = NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+	require.Error(t, err)
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -12,7 +12,8 @@ func main() {
 		"grpc://localhost:8080/diode",
 		"example-app",
 		"0.1.0",
-		diode.WithAPIKey("YOUR_API_KEY"),
+		diode.WithClientID("YOUR_CLIENT_ID"),
+		diode.WithClientSecret("YOUR_CLIENT_SECRET"),
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This pull request introduces significant changes to the Diode SDK by replacing API key-based authentication with OAuth2 client credentials. The most important changes include updating environment variables, modifying the client structure and methods, and updating tests to reflect these changes.

### Authentication Changes:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R25): Updated environment variables to include `DIODE_CLIENT_ID` and `DIODE_CLIENT_SECRET` for OAuth2 authentication.
* [`diode/client.go`](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L34-R40): Removed `DIODE_API_KEY` and added `DIODE_CLIENT_ID` and `DIODE_CLIENT_SECRET` environment variables.
* [`diode/client.go`](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L79-R107): Replaced `getAPIKey` function with `getClientID` and `getClientSecret` functions to retrieve OAuth2 credentials.
* [`diode/client.go`](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L143-R256): Added `diodeAuthentication` struct and methods to handle OAuth2 token fetching and updating client metadata.

### Client Structure Changes:
* [`diode/client.go`](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L118-R140): Updated `GRPCClient` struct to include `clientID` and `clientSecret` fields instead of `apiKey`.
* [`diode/client.go`](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L206-R334): Modified `NewClient` function to initialize `clientID` and `clientSecret` instead of `apiKey`.

### Test Updates:
* [`diode/client_test.go`](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL105-R173): Updated tests to reflect the changes from API key to OAuth2 client credentials. This includes modifying test cases to use `clientID` and `clientSecret`. [[1]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL105-R173) [[2]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL157-R187) [[3]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL167-R211) [[4]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL207-R223) [[5]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL217-R235) [[6]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL227-R284) [[7]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL337-R368)

### Example Update:
* [`examples/main.go`](diffhunk://#diff-7c1b8c5172fe7687c2af90f55f18e7e5eacf13af953ccc2bbeb5de3fa56e2688L15-R16): Updated example usage to include `WithClientID` and `WithClientSecret` instead of `WithAPIKey`.