### PR TITLE
feat: add OAuth2 scope for data ingestion and update authentication flow

### DIFF
--- a/diode/client.go
+++ b/diode/client.go
@@ -48,6 +48,9 @@ const (
 	// DiodeMaxAuthRetriesEnvVarName is the environment variable name for the maximum number of authentication retries
 	DiodeMaxAuthRetriesEnvVarName = "DIODE_MAX_AUTH_RETRIES"
 
+	// DiodeOAuth2IngestScope is the OAuth2 scope for the data ingestion
+	DiodeOAuth2IngestScope = "diode:ingest"
+
 	defaultStreamName = "latest"
 )
 
@@ -201,7 +204,7 @@ func WithClientSecret(clientSecret string) ClientOption {
 // authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
 func (g *GRPCClient) authenticate() error {
 	authClient := newDiodeAuthentication(g.target, g.path, g.tlsVerify, g.clientID, g.clientSecret)
-	accessToken, err := authClient.authenticate(g.logger)
+	accessToken, err := authClient.authenticate(g.logger, []string{DiodeOAuth2IngestScope})
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
@@ -232,7 +235,7 @@ func newDiodeAuthentication(target string, path string, tlsVerify bool, clientID
 }
 
 // Authenticate requests an OAuth2 token using client credentials and returns it.
-func (d *diodeAuthentication) authenticate(logger *slog.Logger) (string, error) {
+func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string) (string, error) {
 	scheme := "http"
 	if d.tlsVerify {
 		scheme = "https"
@@ -245,7 +248,7 @@ func (d *diodeAuthentication) authenticate(logger *slog.Logger) (string, error) 
 	data.Set("grant_type", "client_credentials")
 	data.Set("client_id", d.clientID)
 	data.Set("client_secret", d.clientSecret)
-
+	data.Set("scope", strings.Join(scopes, " "))
 	req, err := http.NewRequest(http.MethodPost, authURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -217,7 +217,8 @@ func startMockAuthServer(port string, path string, authErrorGrpc bool) (*MockAut
 		_ = r.ParseForm()
 		clientID := r.FormValue("client_id")
 		clientSecret := r.FormValue("client_secret")
-		if strings.Contains(clientID, "client-id") && strings.Contains(clientSecret, "client-secret") {
+		scope := r.FormValue("scope")
+		if strings.Contains(clientID, "client-id") && strings.Contains(clientSecret, "client-secret") && strings.Contains(scope, DiodeOAuth2IngestScope) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"access_token": "mock-token"}`))
 		} else {


### PR DESCRIPTION
This pull request introduces support for specifying OAuth2 scopes during authentication in the `diode` client. The changes ensure that the `DiodeOAuth2IngestScope` is included in authentication requests and validated in tests.

### OAuth2 Scope Support:

* Added a new constant, `DiodeOAuth2IngestScope`, representing the OAuth2 scope for data ingestion. (`diode/client.go`, [diode/client.goR51-R53](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R51-R53))
* Updated the `authenticate` method in `diodeAuthentication` to accept a `scopes` parameter and include the specified scopes in the authentication request payload. (`diode/client.go`, [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L235-R238) [[2]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L248-R251)
* Modified the `GRPCClient`'s `authenticate` method to pass the `DiodeOAuth2IngestScope` when requesting an access token. (`diode/client.go`, [diode/client.goL204-R207](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L204-R207))

### Test Enhancements:

* Updated the mock authentication server in `diode/client_test.go` to validate the presence of the `DiodeOAuth2IngestScope` in the `scope` parameter during tests. (`diode/client_test.go`, [diode/client_test.goL220-R221](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bL220-R221))