### PR TITLE
feat: add diode-replay-dryrun helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,16 +174,16 @@ multiple times to ingest several dry-run files in a single request:
 
 ```bash
 diode-replay-dryrun \
-  -file /tmp/example-app_1750106879725947344.json \
-  -file /tmp/other.json \
-  -target grpc://localhost:8080/diode \
-  -app example-app \
-  -version 0.1.0 \
+  --file /tmp/example-app_1750106879725947344.json \
+  --file /tmp/other.json \
+  --target grpc://localhost:8080/diode \
+  --app-name example-app \
+  --app-version 0.1.0 \
   -client-id YOUR_CLIENT_ID \
   -client-secret YOUR_CLIENT_SECRET
 ```
 
-The flags `-file`, `-target`, `-app`, and `-version` are required. You may
+The flags `-file`, `-target`, `-app-name`, and `-app-version` are required. You may
 repeat `-file` to specify multiple files. OAuth2
 credentials can be supplied using `-client-id` and `-client-secret` or the
 `DIODE_CLIENT_ID` and `DIODE_CLIENT_SECRET` environment variables.

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ multiple times to ingest several dry-run files in a single request:
 
 ```bash
 diode-replay-dryrun \
-  --file /tmp/example-app_1750106879725947344.json \
-  --file /tmp/other.json \
-  --target grpc://localhost:8080/diode \
-  --app-name example-app \
-  --app-version 0.1.0 \
+  -file /tmp/example-app_1750106879725947344.json \
+  -file /tmp/other.json \
+  -target grpc://localhost:8080/diode \
+  -app-name example-app \
+  -app-version 0.1.0 \
   -client-id YOUR_CLIENT_ID \
   -client-secret YOUR_CLIENT_SECRET
 ```

--- a/README.md
+++ b/README.md
@@ -155,6 +155,39 @@ if err != nil {
 }
 ```
 
+### CLI to replay dry-run files
+
+A small helper binary is included to ingest JSON files created by the
+`DryRunClient` and send them to a running Diode service.
+
+Install the helper using `go install`:
+
+```bash
+go install github.com/netboxlabs/diode-sdk-go/cmd/diode-replay-dryrun@latest
+```
+
+This installs the command separately from the SDK library obtained with
+`go get`.
+
+Run it by providing one or more JSON files and connection details. Use `-file`
+multiple times to ingest several dry-run files in a single request:
+
+```bash
+diode-replay-dryrun \
+  -file /tmp/example-app_1750106879725947344.json \
+  -file /tmp/other.json \
+  -target grpc://localhost:8080/diode \
+  -app example-app \
+  -version 0.1.0 \
+  -client-id YOUR_CLIENT_ID \
+  -client-secret YOUR_CLIENT_SECRET
+```
+
+The flags `-file`, `-target`, `-app`, and `-version` are required. You may
+repeat `-file` to specify multiple files. OAuth2
+credentials can be supplied using `-client-id` and `-client-secret` or the
+`DIODE_CLIENT_ID` and `DIODE_CLIENT_SECRET` environment variables.
+
 ## Supported entities (object types)
 
 * ASN

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ pipelines.
 More information about Diode can be found
 at [https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in-netbox/](https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in-netbox/).
 
+## Prerequisites
+- Go 1.24 or later installed
+
 ## Installation
 
 ```bash

--- a/cmd/diode-replay-dryrun/main.go
+++ b/cmd/diode-replay-dryrun/main.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
 
 type fileList []string
@@ -43,15 +42,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	var allEntities []*diodepb.Entity
-	for _, f := range files {
-		ents, err := diode.LoadDryRunEntities(f)
-		if err != nil {
-			log.Fatal(err)
-		}
-		allEntities = append(allEntities, ents...)
-	}
-
 	client, err := diode.NewClient(
 		*target,
 		*app,
@@ -64,19 +54,29 @@ func main() {
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			log.Printf("failed to close client: %v", err)
+			log.Printf("Failed to close client: %v", err)
 		}
 	}()
 
-	response, err := client.IngestProto(context.Background(), allEntities)
-	if err != nil {
-		log.Fatal(err)
+	ctx := context.Background()
+	for _, f := range files {
+		entities, err := diode.LoadDryRunEntities(f)
+		if err != nil {
+			log.Printf("Failed to load %s: %v", f, err)
+			continue
+		}
+
+		resp, err := client.IngestProto(ctx, entities)
+		if err != nil {
+			log.Printf("Failed to ingest %s: %v", f, err)
+			continue
+		}
+
+		if resp.GetErrors() != nil {
+			log.Printf("Errors while ingesting %s: %v", f, resp.GetErrors())
+			continue
+		}
+
+		log.Printf("Ingested %d entities from %s successfully", len(entities), f)
 	}
-
-	if response.GetErrors() != nil {
-		log.Fatalf("Ingestion errors: %v", response.GetErrors())
-	}
-
-	log.Printf("Ingested %d entities successfully", len(allEntities))
-
 }

--- a/cmd/diode-replay-dryrun/main.go
+++ b/cmd/diode-replay-dryrun/main.go
@@ -21,12 +21,12 @@ func (f *fileList) Set(s string) error {
 
 func main() {
 	var files fileList
-	flag.Var(&files, "file", "Path to dry run JSON file (may be repeated)")
-	target := flag.String("target", "", "Diode gRPC target")
-	app := flag.String("app-name", "", "Producer application name")
-	version := flag.String("app-version", "", "Producer application version")
-	clientID := flag.String("client-id", "", "OAuth2 client ID")
-	clientSecret := flag.String("client-secret", "", "OAuth2 client secret")
+	flag.Var(&files, "file", "Dry-run JSON file to ingest (may be repeated)")
+	target := flag.String("target", "", "gRPC target of the Diode server, e.g. grpc://localhost:8080/diodet")
+	app := flag.String("app-name", "", "Application name used when ingesting the dry-run messages")
+	version := flag.String("app-version", "", "Application version used when ingesting the dry-run messages")
+	clientID := flag.String("client-id", "", "OAuth2 client ID. Defaults to the DIODE_CLIENT_ID environment variable if not provided")
+	clientSecret := flag.String("client-secret", "", "OAuth2 client secret. Defaults to the DIODE_CLIENT_SECRET environment variable if not provided")
 	flag.Parse()
 
 	// Fall back to environment variables if flags are not provided

--- a/cmd/diode-replay-dryrun/main.go
+++ b/cmd/diode-replay-dryrun/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+)
+
+type fileList []string
+
+func (f *fileList) String() string { return strings.Join(*f, ",") }
+
+func (f *fileList) Set(s string) error {
+	*f = append(*f, s)
+	return nil
+}
+
+func main() {
+	var files fileList
+	flag.Var(&files, "file", "Path to dry run JSON file (may be repeated)")
+	target := flag.String("target", "", "Diode gRPC target")
+	app := flag.String("app-name", "", "Producer application name")
+	version := flag.String("app-version", "", "Producer application version")
+	clientID := flag.String("client-id", "", "OAuth2 client ID")
+	clientSecret := flag.String("client-secret", "", "OAuth2 client secret")
+	flag.Parse()
+
+	// Fall back to environment variables if flags are not provided
+	if *clientID == "" {
+		*clientID = os.Getenv("DIODE_CLIENT_ID")
+	}
+	if *clientSecret == "" {
+		*clientSecret = os.Getenv("DIODE_CLIENT_SECRET")
+	}
+
+	if len(files) == 0 || *target == "" || *app == "" || *version == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	var allEntities []*diodepb.Entity
+	for _, f := range files {
+		ents, err := diode.LoadDryRunEntities(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		allEntities = append(allEntities, ents...)
+	}
+
+	client, err := diode.NewClient(
+		*target,
+		*app,
+		*version,
+		diode.WithClientID(*clientID),
+		diode.WithClientSecret(*clientSecret),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := client.Close(); err != nil {
+			log.Printf("failed to close client: %v", err)
+		}
+	}()
+
+	response, err := client.IngestProto(context.Background(), allEntities)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if response.GetErrors() != nil {
+		log.Fatalf("Ingestion errors: %v", response.GetErrors())
+	}
+
+	log.Printf("Ingested %d entities successfully", len(allEntities))
+
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/net v0.38.0
 	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.33.0
 )
@@ -13,7 +14,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect


### PR DESCRIPTION
This pull request introduces a new CLI tool, `diode-replay-dryrun`, to replay dry-run files generated by the `DryRunClient` and send them to a Diode service. It also updates the project dependencies in `go.mod`. Below are the most important changes:

### Addition of the `diode-replay-dryrun` CLI Tool

* **Documentation Update**: Added a new section in `README.md` explaining the purpose of the `diode-replay-dryrun` tool, installation instructions, and usage examples. The tool supports ingesting multiple JSON files and provides flexibility in specifying OAuth2 credentials via flags or environment variables.
* **Implementation**: Created a new `main.go` file for the CLI tool, which includes:
  - Parsing command-line flags for input files, target, app details, and OAuth2 credentials.
  - Loading and ingesting dry-run entities from JSON files using the `diode` SDK.
  - Handling errors and logging the results of ingestion.

### Dependency Updates

* **`go.mod` Changes**: Updated the `golang.org/x/net` dependency to be a direct requirement instead of indirect. This ensures compatibility with the new CLI tool.