### PR TITLE
fix: cli error message and logging

### DIFF
--- a/cmd/diode-replay-dryrun/main.go
+++ b/cmd/diode-replay-dryrun/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	"fmt"
 	"os"
 	"strings"
 
@@ -22,7 +22,7 @@ func (f *fileList) Set(s string) error {
 func main() {
 	var files fileList
 	flag.Var(&files, "file", "Dry-run JSON file to ingest (may be repeated)")
-	target := flag.String("target", "", "gRPC target of the Diode server, e.g. grpc://localhost:8080/diodet")
+	target := flag.String("target", "", "gRPC target of the Diode server, e.g. grpc://localhost:8080/diode")
 	app := flag.String("app-name", "", "Application name used when ingesting the dry-run messages")
 	version := flag.String("app-version", "", "Application version used when ingesting the dry-run messages")
 	clientID := flag.String("client-id", "", "OAuth2 client ID. Defaults to the DIODE_CLIENT_ID environment variable if not provided")
@@ -39,6 +39,7 @@ func main() {
 
 	if len(files) == 0 || *target == "" || *app == "" || *version == "" {
 		flag.Usage()
+		fmt.Fprintf(os.Stderr, "Error: the following arguments are required: -target, -app-name, -app-version, -file\n")
 		os.Exit(1)
 	}
 
@@ -50,11 +51,13 @@ func main() {
 		diode.WithClientSecret(*clientSecret),
 	)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintf(os.Stderr, "Failed to create Diode client: %v\n", err)
+		os.Exit(1)
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			log.Printf("Failed to close client: %v", err)
+			fmt.Fprintf(os.Stderr, "Failed to close Diode client: %v\n", err)
+			os.Exit(1)
 		}
 	}()
 
@@ -62,21 +65,21 @@ func main() {
 	for _, f := range files {
 		entities, err := diode.LoadDryRunEntities(f)
 		if err != nil {
-			log.Printf("Failed to load %s: %v", f, err)
+			fmt.Fprintf(os.Stderr, "Failed to load entities from %s: %v\n", f, err)
 			continue
 		}
 
 		resp, err := client.IngestProto(ctx, entities)
 		if err != nil {
-			log.Printf("Failed to ingest %s: %v", f, err)
+			fmt.Fprintf(os.Stderr, "Failed to ingest %s: %v\n", f, err)
 			continue
 		}
 
 		if resp.GetErrors() != nil {
-			log.Printf("Errors while ingesting %s: %v", f, resp.GetErrors())
+			fmt.Fprintf(os.Stderr, "Errors while ingesting %s: %v\n", f, resp.GetErrors())
 			continue
 		}
 
-		log.Printf("Ingested %d entities from %s successfully", len(entities), f)
+		fmt.Fprintf(os.Stdout, "Successfully ingested %d entities from %s\n", len(entities), f)
 	}
 }

--- a/cmd/diode-replay-dryrun/main.go
+++ b/cmd/diode-replay-dryrun/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -37,9 +37,11 @@ func main() {
 		*clientSecret = os.Getenv("DIODE_CLIENT_SECRET")
 	}
 
+	log.SetFlags(0)
+
 	if len(files) == 0 || *target == "" || *app == "" || *version == "" {
 		flag.Usage()
-		fmt.Fprintf(os.Stderr, "Error: the following arguments are required: -target, -app-name, -app-version, -file\n")
+		log.Println("Error: the following arguments are required: -target, -app-name, -app-version, -file")
 		os.Exit(1)
 	}
 
@@ -51,13 +53,11 @@ func main() {
 		diode.WithClientSecret(*clientSecret),
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Diode client: %v\n", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to close Diode client: %v\n", err)
-			os.Exit(1)
+			log.Printf("Failed to close client: %v", err)
 		}
 	}()
 
@@ -65,21 +65,21 @@ func main() {
 	for _, f := range files {
 		entities, err := diode.LoadDryRunEntities(f)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to load entities from %s: %v\n", f, err)
+			log.Printf("Failed to load %s: %v", f, err)
 			continue
 		}
 
 		resp, err := client.IngestProto(ctx, entities)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to ingest %s: %v\n", f, err)
+			log.Printf("Failed to ingest %s: %v", f, err)
 			continue
 		}
 
 		if resp.GetErrors() != nil {
-			fmt.Fprintf(os.Stderr, "Errors while ingesting %s: %v\n", f, resp.GetErrors())
+			log.Printf("Errors while ingesting %s: %v", f, resp.GetErrors())
 			continue
 		}
 
-		fmt.Fprintf(os.Stdout, "Successfully ingested %d entities from %s\n", len(entities), f)
+		log.Printf("Ingested %d entities from %s successfully", len(entities), f)
 	}
 }


### PR DESCRIPTION
This pull request refactors error handling and logging in the `cmd/diode-replay-dryrun/main.go` file to improve clarity and consistency. It replaces `log` with `fmt` for better control over output streams and updates error messages for improved user feedback.

### Error handling improvements:
* Replaced `log.Fatal` with `fmt.Fprintf` to print errors to `os.Stderr` and explicitly exit the program with `os.Exit(1)` for better control over error handling.
* Updated error messages to provide more detailed and user-friendly feedback, such as specifying required arguments and clarifying error contexts. [[1]](diffhunk://#diff-62c5074f502afd222847bea3dadf6a74a0d2793295a0f16d7565f58ce4a315ccR42) [[2]](diffhunk://#diff-62c5074f502afd222847bea3dadf6a74a0d2793295a0f16d7565f58ce4a315ccL53-R83)

### Logging improvements:
* Replaced `log.Printf` with `fmt.Fprintf` to direct output to the appropriate streams (`os.Stderr` for errors, `os.Stdout` for success messages).

### Minor updates:
* Updated the `-target` flag description to fix a typo in the example URL.
* Removed the unused `log` import and replaced it with `fmt`.