### PR TITLE
feat: Support HTTP schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ More information about Diode can be found
 at [https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in-netbox/](https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in-netbox/).
 
 ## Prerequisites
+
 - Go 1.24 or later installed
 
 ## Installation
@@ -30,8 +31,9 @@ go get github.com/netboxlabs/diode-sdk-go
 
 ### Example
 
-* `target` should be the address of the Diode service, e.g. `grpc://localhost:8080/diode` for insecure connection
-  or `grpcs://example.com` for secure connection.
+* `target` should be the address of the Diode service.
+  * Insecure connections: `grpc://localhost:8080/diode` or `http://localhost:8080/diode`
+  * Secure connections: `grpcs://example.com` or `https://example.com`
 
 ```go
 package main
@@ -119,16 +121,17 @@ See all [examples](./examples/main.go) for reference.
 
 ### Dry run client
 
-Use a `DryRunClient` to inspect what would be sent to Diode without actually sending any data. When a directory is provided a new JSON file is created for each ingest call.
+Use a `DryRunClient` to inspect what would be sent to Diode without actually sending any data. When a directory is
+provided a new JSON file is created for each ingest call.
 
 ```go
 // Write ingest payload to a timestamped file in /tmp
 client, err := diode.NewDryRunClient("example-app", "/tmp")
 if err != nil {
-        log.Fatal(err)
+log.Fatal(err)
 }
 _, _ = client.Ingest(context.Background(), []diode.Entity{
-        &diode.Device{Name: diode.String("Device A")},
+&diode.Device{Name: diode.String("Device A")},
 })
 _ = client.Close()
 ```
@@ -138,23 +141,23 @@ Loaded entities can later be ingested using a real client:
 ```go
 protoEntities, err := diode.LoadDryRunEntities("/tmp/example-app_1750106879725947344.json")
 if err != nil {
-        log.Fatal(err)
+log.Fatal(err)
 }
 
 realClient, err := diode.NewClient(
-        "grpc://localhost:8080/diode",
-        "example-app",
-        "0.1.0",
-        diode.WithClientID("YOUR_CLIENT_ID"),
-        diode.WithClientSecret("YOUR_CLIENT_SECRET"),
+"grpc://localhost:8080/diode",
+"example-app",
+"0.1.0",
+diode.WithClientID("YOUR_CLIENT_ID"),
+diode.WithClientSecret("YOUR_CLIENT_SECRET"),
 )
 if err != nil {
-        log.Fatal(err)
+log.Fatal(err)
 }
 
 _, err = realClient.IngestProto(context.Background(), protoEntities)
 if err != nil {
-        log.Fatal(err)
+log.Fatal(err)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ More information about Diode can be found
 at [https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in-netbox/](https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in-netbox/).
 
 ## Prerequisites
-
 - Go 1.24 or later installed
 
 ## Installation
@@ -121,17 +120,16 @@ See all [examples](./examples/main.go) for reference.
 
 ### Dry run client
 
-Use a `DryRunClient` to inspect what would be sent to Diode without actually sending any data. When a directory is
-provided a new JSON file is created for each ingest call.
+Use a `DryRunClient` to inspect what would be sent to Diode without actually sending any data. When a directory is provided a new JSON file is created for each ingest call.
 
 ```go
 // Write ingest payload to a timestamped file in /tmp
 client, err := diode.NewDryRunClient("example-app", "/tmp")
 if err != nil {
-log.Fatal(err)
+        log.Fatal(err)
 }
 _, _ = client.Ingest(context.Background(), []diode.Entity{
-&diode.Device{Name: diode.String("Device A")},
+        &diode.Device{Name: diode.String("Device A")},
 })
 _ = client.Close()
 ```
@@ -141,23 +139,23 @@ Loaded entities can later be ingested using a real client:
 ```go
 protoEntities, err := diode.LoadDryRunEntities("/tmp/example-app_1750106879725947344.json")
 if err != nil {
-log.Fatal(err)
+        log.Fatal(err)
 }
 
 realClient, err := diode.NewClient(
-"grpc://localhost:8080/diode",
-"example-app",
-"0.1.0",
-diode.WithClientID("YOUR_CLIENT_ID"),
-diode.WithClientSecret("YOUR_CLIENT_SECRET"),
+        "grpc://localhost:8080/diode",
+        "example-app",
+        "0.1.0",
+        diode.WithClientID("YOUR_CLIENT_ID"),
+        diode.WithClientSecret("YOUR_CLIENT_SECRET"),
 )
 if err != nil {
-log.Fatal(err)
+        log.Fatal(err)
 }
 
 _, err = realClient.IngestProto(context.Background(), protoEntities)
 if err != nil {
-log.Fatal(err)
+        log.Fatal(err)
 }
 ```
 

--- a/diode/client.go
+++ b/diode/client.go
@@ -54,7 +54,7 @@ const (
 	defaultStreamName = "latest"
 )
 
-var allowedSchemesRe = regexp.MustCompile(`grpc|grpcs`)
+var allowedSchemesRe = regexp.MustCompile(`grpc|grpcs|http|https`)
 
 // loadCerts loads the system x509 cert pool
 func loadCerts() *x509.CertPool {
@@ -74,6 +74,14 @@ func parseTarget(target string) (string, string, bool, error) {
 	}
 
 	authority := u.Host
+	if u.Port() == "" {
+		switch u.Scheme {
+		case "grpc", "http":
+			authority += ":80"
+		case "grpcs", "https":
+			authority += ":443"
+		}
+	}
 
 	path := u.Path
 	if path == "/" {

--- a/diode/client.go
+++ b/diode/client.go
@@ -74,9 +74,6 @@ func parseTarget(target string) (string, string, bool, error) {
 	}
 
 	authority := u.Host
-	if u.Port() == "" {
-		authority += ":443"
-	}
 
 	path := u.Path
 	if path == "/" {

--- a/diode/client.go
+++ b/diode/client.go
@@ -70,7 +70,7 @@ func parseTarget(target string) (string, string, bool, error) {
 	}
 
 	if !allowedSchemesRe.MatchString(u.Scheme) {
-		return "", "", false, errors.New("target should start with grpc:// or grpcs://")
+		return "", "", false, errors.New("target should start with grpc:// or grpcs:// or http:// or https://")
 	}
 
 	authority := u.Host
@@ -80,6 +80,8 @@ func parseTarget(target string) (string, string, bool, error) {
 			authority += ":80"
 		case "grpcs", "https":
 			authority += ":443"
+		default:
+			return "", "", false, fmt.Errorf("missing port with unsupported scheme: %s", u.Scheme)
 		}
 	}
 

--- a/diode/client.go
+++ b/diode/client.go
@@ -56,7 +56,7 @@ const (
 
 var (
 	// ErrInvalidTargetScheme is returned when the target URL does not start with a valid scheme.
-	ErrInvalidTargetScheme = errors.New("target should start with grpc:// or grpcs:// or http:// or https://")
+	ErrInvalidTargetScheme = errors.New("target should start with grpc://, grpcs://, http:// or https://")
 
 	allowedSchemesRe = regexp.MustCompile(`grpc|grpcs|http|https`)
 )

--- a/diode/client.go
+++ b/diode/client.go
@@ -54,7 +54,12 @@ const (
 	defaultStreamName = "latest"
 )
 
-var allowedSchemesRe = regexp.MustCompile(`grpc|grpcs|http|https`)
+var (
+	// ErrInvalidTargetScheme is returned when the target URL does not start with a valid scheme.
+	ErrInvalidTargetScheme = errors.New("target should start with grpc:// or grpcs:// or http:// or https://")
+
+	allowedSchemesRe = regexp.MustCompile(`grpc|grpcs|http|https`)
+)
 
 // loadCerts loads the system x509 cert pool
 func loadCerts() *x509.CertPool {
@@ -70,7 +75,7 @@ func parseTarget(target string) (string, string, bool, error) {
 	}
 
 	if !allowedSchemesRe.MatchString(u.Scheme) {
-		return "", "", false, errors.New("target should start with grpc:// or grpcs:// or http:// or https://")
+		return "", "", false, ErrInvalidTargetScheme
 	}
 
 	authority := u.Host
@@ -81,7 +86,7 @@ func parseTarget(target string) (string, string, bool, error) {
 		case "grpcs", "https":
 			authority += ":443"
 		default:
-			return "", "", false, fmt.Errorf("missing port with unsupported scheme: %s", u.Scheme)
+			return "", "", false, fmt.Errorf("missing port with unsupported scheme: %s: %w", u.Scheme, ErrInvalidTargetScheme)
 		}
 	}
 
@@ -90,7 +95,11 @@ func parseTarget(target string) (string, string, bool, error) {
 		path = ""
 	}
 
-	tlsVerify := u.Scheme == "grpcs"
+	tlsVerify := false
+	switch u.Scheme {
+	case "grpcs", "https":
+		tlsVerify = true
+	}
 
 	return authority, path, tlsVerify, nil
 }

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -64,6 +64,20 @@ func TestParseTarget(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
+			desc:      "valid HTTP target",
+			target:    "http://localhost:8081",
+			authority: "localhost:8081",
+			tlsVerify: false,
+			wantErr:   nil,
+		},
+		{
+			desc:      "valid HTTP target with tls",
+			target:    "https://localhost:8081",
+			authority: "localhost:8081",
+			tlsVerify: true,
+			wantErr:   nil,
+		},
+		{
 			desc:      "valid target empty path on grpc://localhost:8081/",
 			target:    "grpc://localhost:8081/",
 			authority: "localhost:8081",
@@ -81,11 +95,11 @@ func TestParseTarget(t *testing.T) {
 		},
 		{
 			desc:      "invalid scheme in target",
-			target:    "http://localhost:8081",
+			target:    "ftp://localhost:8081",
 			authority: "",
 			path:      "",
 			tlsVerify: false,
-			wantErr:   errors.New("target should start with grpc:// or grpcs://"),
+			wantErr:   ErrInvalidTargetScheme,
 		},
 		{
 			desc:      "invalid target",

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -331,14 +331,14 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			desc:                    "invalid target",
-			target:                  "http://localhost:8081",
+			target:                  "ftp://localhost:8081",
 			appName:                 "my-producer",
 			appVersion:              "0.1.0",
 			clientID:                "client-id-123",
 			clientSecret:            "client-secret-456",
 			clientIDEnvVarValue:     "",
 			clientSecretEnvVarValue: "",
-			wantErr:                 errors.New("target should start with grpc:// or grpcs://"),
+			wantErr:                 ErrInvalidTargetScheme,
 		},
 		{
 			desc:                    "missing clientID and clientSecret",


### PR DESCRIPTION
This pull request expands the supported URL schemes in the `parseTarget` function to include both HTTP and HTTPS, in addition to the existing gRPC schemes. It updates the scheme validation logic, adjusts default ports and TLS verification accordingly, and improves error handling. The test suite is also updated to cover the new supported schemes and error scenarios.

**Expanded protocol support and validation:**

* Added support for `http` and `https` schemes in `parseTarget`, updating the `allowedSchemesRe` regular expression and related logic to accept these schemes. [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L57-R62) [[2]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L73-R102)
* Introduced a new error variable `ErrInvalidTargetScheme` for consistent error handling when an unsupported scheme is encountered. [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L57-R62) [[2]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L73-R102)

**Connection handling improvements:**

* Adjusted default port assignment: `grpc` and `http` default to port 80, `grpcs` and `https` default to port 443 if the port is not specified.
* Updated TLS verification logic: enabled for `grpcs` and `https`, disabled for `grpc` and `http`.

**Test coverage enhancements:**

* Added new test cases for valid `http` and `https` targets, including correct port and TLS verification expectations.
* Updated the invalid scheme test case to use an unsupported scheme (`ftp`) and expect the new `ErrInvalidTargetScheme` error.