### PR TITLE
chore: upgrade semantic release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
           retention-days: 1
           if-no-files-found: error
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -136,7 +136,7 @@ jobs:
         with:
           name: semantic-release-artifacts
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}


### PR DESCRIPTION
This pull request updates the release workflow configuration to improve compatibility with dependencies and ensure successful installations. The most important changes are grouped below:

Dependency management:

* Updated the `semantic-release` dependency version to `25.0.0-beta.6` in the workflow configuration to ensure the latest features and fixes are used.

Workflow installation commands:

* Changed the npm install command from `npm i` to `npm install --legacy-peer-deps` in both the `setup semantic-release` steps to address potential peer dependency conflicts during installation. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL95-R96) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL138-R139)