### PR TITLE
feat: dynamic SDK version retrieval

### DIFF
--- a/diode/client.go
+++ b/diode/client.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -32,9 +33,6 @@ import (
 const (
 	// SDKName is the name of the Diode SDK
 	SDKName = "diode-sdk-go"
-
-	// SDKVersion is the version of the Diode SDK
-	SDKVersion = "1.4.0"
 
 	// DiodeCertFileEnvVarName is the environment variable name for the custom certificate file path
 	DiodeCertFileEnvVarName = "DIODE_CERT_FILE"
@@ -181,6 +179,23 @@ func getCertFile(certFile string) string {
 	return certFile
 }
 
+// getSDKVersion returns the SDK version from build info or a fallback
+func getSDKVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+
+	// Check if this module is in the dependency list (when used as a dependency)
+	for _, mod := range info.Deps {
+		if strings.HasSuffix(mod.Path, "/diode-sdk-go") || mod.Path == "github.com/netboxlabs/diode-sdk-go" {
+			return mod.Version
+		}
+	}
+
+	return "dev"
+}
+
 // Client is an interface that defines the methods available from Diode API
 type Client interface {
 	// Close closes the connection to the API service
@@ -242,6 +257,12 @@ type GRPCClient struct {
 
 	// Go version
 	goVersion string
+
+	// SDK name
+	sdkName string
+
+	// SDK version
+	sdkVersion string
 
 	// Metadata
 	metadata metadata.MD
@@ -396,6 +417,7 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 
 	platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 	goVersion := runtime.Version()
+	sdkVersion := getSDKVersion()
 
 	c := &GRPCClient{
 		logger:         logger,
@@ -407,6 +429,8 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 		tlsVerify:      tlsVerify,
 		platform:       platform,
 		goVersion:      goVersion,
+		sdkName:        SDKName,
+		sdkVersion:     sdkVersion,
 		maxAuthRetries: 3,
 	}
 
@@ -428,7 +452,7 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 	c.rootCAs = rootCAs
 
 	dialOpts := []grpc.DialOption{
-		grpc.WithUserAgent(userAgent()),
+		grpc.WithUserAgent(fmt.Sprintf("%s/%s", c.sdkName, c.sdkVersion)),
 	}
 
 	if path != "" {
@@ -507,8 +531,8 @@ func (g *GRPCClient) IngestProto(ctx context.Context, entities []*diodepb.Entity
 		Stream:             stream,
 		ProducerAppName:    g.appName,
 		ProducerAppVersion: g.appVersion,
-		SdkName:            SDKName,
-		SdkVersion:         SDKVersion,
+		SdkName:            g.sdkName,
+		SdkVersion:         g.sdkVersion,
 	}
 
 	ctx = metadata.NewOutgoingContext(ctx, g.metadata)
@@ -561,11 +585,6 @@ func methodUnaryInterceptor(path string) grpc.DialOption {
 		method = fmt.Sprintf("%s%s", path, method)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	})
-}
-
-// userAgent returns the user agent string for the SDK
-func userAgent() string {
-	return fmt.Sprintf("%s/%s", SDKName, SDKVersion)
 }
 
 // newLogger creates a new logger for the SDK

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -641,6 +641,77 @@ func TestMethodUnaryInterceptor(t *testing.T) {
 	}
 }
 
+func TestGetSDKVersion(t *testing.T) {
+	tests := []struct {
+		desc        string
+		wantVersion string
+	}{
+		{
+			desc:        "SDK version detection",
+			wantVersion: "dev", // When running tests, build info won't have module dependencies
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			version := getSDKVersion()
+			// Since we're running in a test environment without proper module deps,
+			// we should at least get a non-empty version string
+			assert.NotEmpty(t, version)
+			// When running tests locally, it should return "dev"
+			if version != "dev" {
+				// If not "dev", it should be a valid version string (starts with v or is a commit hash)
+				assert.True(t, version[0] == 'v' || len(version) >= 7,
+					"version should be 'dev', start with 'v', or be a commit hash (7+ chars): %s", version)
+			}
+		})
+	}
+}
+
+func TestClientSDKVersionCaching(t *testing.T) {
+	port, err := getFreePort()
+	require.NoError(t, err)
+
+	authServer, err := startMockAuthServer(port, "", false)
+	require.NoError(t, err)
+	defer authServer.Close()
+
+	_ = os.Setenv(DiodeClientIDEnvVarName, "client-id")
+	_ = os.Setenv(DiodeClientSecretEnvVarName, "client-secret")
+	defer func() {
+		_ = os.Unsetenv(DiodeClientIDEnvVarName)
+		_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+	}()
+
+	client, err := NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+	require.NoError(t, err)
+	defer func() {
+		err := client.Close()
+		require.NoError(t, err)
+	}()
+
+	grpcClient := client.(*GRPCClient)
+
+	// Verify that SDK name and version are cached
+	assert.Equal(t, SDKName, grpcClient.sdkName)
+	assert.NotEmpty(t, grpcClient.sdkVersion)
+
+	// The cached version should be consistent
+	cachedVersion := grpcClient.sdkVersion
+
+	// Create another client and verify it gets the same version
+	client2, err := NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+	require.NoError(t, err)
+	defer func() {
+		err := client2.Close()
+		require.NoError(t, err)
+	}()
+
+	grpcClient2 := client2.(*GRPCClient)
+	assert.Equal(t, cachedVersion, grpcClient2.sdkVersion)
+	assert.Equal(t, SDKName, grpcClient2.sdkName)
+}
+
 func TestNewLogger(t *testing.T) {
 	tests := []struct {
 		desc                string

--- a/diode/dryrun.go
+++ b/diode/dryrun.go
@@ -22,8 +22,10 @@ const (
 
 // DryRunClient implements Client and writes ingest payloads to stdout or a file.
 type DryRunClient struct {
-	appName   string
-	dryRunDir string
+	appName    string
+	dryRunDir  string
+	sdkName    string
+	sdkVersion string
 }
 
 // NewDryRunClient creates a new DryRunClient.
@@ -39,7 +41,12 @@ func NewDryRunClient(appName string, dryRunDir string) (Client, error) {
 			return nil, err
 		}
 	}
-	return &DryRunClient{appName: appName, dryRunDir: dryRunDir}, nil
+	return &DryRunClient{
+		appName:    appName,
+		dryRunDir:  dryRunDir,
+		sdkName:    SDKName,
+		sdkVersion: getSDKVersion(),
+	}, nil
 }
 
 // Close closes the DryRunClient writer if necessary.
@@ -60,8 +67,8 @@ func (d *DryRunClient) IngestProto(_ context.Context, entities []*diodepb.Entity
 	wrapper := &diodepb.IngestRequest{
 		Id:         uuid.New().String(),
 		Entities:   entities,
-		SdkName:    SDKName,
-		SdkVersion: SDKVersion,
+		SdkName:    d.sdkName,
+		SdkVersion: d.sdkVersion,
 	}
 
 	data, err := protojson.MarshalOptions{UseProtoNames: true, Indent: "  "}.Marshal(wrapper)

--- a/diode/dryrun_test.go
+++ b/diode/dryrun_test.go
@@ -134,3 +134,31 @@ func TestLoadDryRunEntitiesError(t *testing.T) {
 	_, err := LoadDryRunEntities("not-exist.json")
 	require.Error(t, err)
 }
+
+func TestDryRunClientSDKVersionCaching(t *testing.T) {
+	client, err := NewDryRunClient("test-app", "")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	dryRunClient := client.(*DryRunClient)
+
+	// Verify that SDK name and version are cached during initialization
+	require.Equal(t, SDKName, dryRunClient.sdkName)
+	require.NotEmpty(t, dryRunClient.sdkVersion)
+
+	// The cached version should be consistent
+	cachedVersion := dryRunClient.sdkVersion
+	cachedName := dryRunClient.sdkName
+
+	// Create another client and verify it gets the same version
+	client2, err := NewDryRunClient("test-app-2", "")
+	require.NoError(t, err)
+	defer func() {
+		err := client2.Close()
+		require.NoError(t, err)
+	}()
+
+	dryRunClient2 := client2.(*DryRunClient)
+	require.Equal(t, cachedVersion, dryRunClient2.sdkVersion)
+	require.Equal(t, cachedName, dryRunClient2.sdkName)
+}


### PR DESCRIPTION
This pull request refactors how the SDK version is determined and propagated throughout the codebase, replacing the previous hardcoded `SDKVersion` constant with a dynamic value retrieved at runtime. The SDK name and version are now cached in both gRPC and DryRun clients, ensuring consistency and easier maintainability. Additional tests were added to verify correct SDK version detection and caching behavior.

**SDK Version Detection and Propagation:**

* Introduced `getSDKVersion()` to dynamically determine the SDK version using Go build info, with a fallback to `"dev"` if unavailable. The function checks module dependencies for the SDK version. (`diode/client.go`, [diode/client.goR182-R198](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R182-R198))
* Removed the hardcoded `SDKVersion` constant and updated all references to use the new dynamic value. (`diode/client.go`, [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L36-L38); `diode/dryrun.go`, [[2]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aL63-R71)

**Client Initialization and Metadata:**

* Updated `GRPCClient` and `DryRunClient` structs to include `sdkName` and `sdkVersion` fields, which are set during client initialization and used in metadata and requests. (`diode/client.go`, [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R261-R266) [[2]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R432-R433); `diode/dryrun.go`, [[3]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aR27-R28) [[4]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aL42-R49)
* Changed user agent string and request metadata to use the cached SDK name and version from the client structs. (`diode/client.go`, [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L431-R455) [[2]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L510-R535); `diode/dryrun.go`, [[3]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aL63-R71)
* Removed the now-unnecessary `userAgent()` helper function. (`diode/client.go`, [diode/client.goL566-L570](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L566-L570))

**Testing Enhancements:**

* Added tests to verify SDK version detection in various build environments and to ensure that SDK name and version are cached and consistent across multiple client instances for both gRPC and DryRun clients. (`diode/client_test.go`, [[1]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bR644-R714); `diode/dryrun_test.go`, [[2]](diffhunk://#diff-955649906a2a759d331a53dba7f1c3f15eeee11ee6b25ba639e2ccf512d29f23R137-R164)