### PR TITLE
feat: add metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,173 @@ func main() {
 
 See all [examples](./examples/main.go) for reference.
 
+### Using Metadata
+
+Entities support attaching custom metadata as key-value pairs. Metadata can be used to store additional context, tracking information, or custom attributes that don't fit into the standard NetBox fields.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+)
+
+func main() {
+	client, err := diode.NewClient(
+		"grpc://localhost:8080/diode",
+		"example-app",
+		"0.1.0",
+		diode.WithClientID("YOUR_CLIENT_ID"),
+		diode.WithClientSecret("YOUR_CLIENT_SECRET"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a device with metadata
+	// Note: Both the device and its nested site can have its own metadata
+	deviceEntity := &diode.Device{
+		Name: diode.String("Device A"),
+		Site: &diode.Site{
+			Name: diode.String("Site ABC"),
+			Metadata: diode.Metadata{
+				"site_region":      "us-west",
+				"site_cost_center": "CC-001",
+			},
+		},
+		DeviceType: &diode.DeviceType{
+			Model: diode.String("Device Type A"),
+		},
+		Role: &diode.DeviceRole{
+			Name: diode.String("Role ABC"),
+		},
+		Metadata: diode.Metadata{
+			"source":        "network_discovery",
+			"discovered_at": "2024-01-15T10:30:00Z",
+			"import_batch":  "batch-123",
+			"priority":      1,
+			"verified":      true,
+		},
+	}
+
+	// Create an IP address with metadata
+	ipEntity := &diode.IPAddress{
+		Address: diode.String("192.168.1.10/24"),
+		Status:  diode.String("active"),
+		Metadata: diode.Metadata{
+			"last_scan":     "2024-01-15T12:00:00Z",
+			"scan_id":       "scan-456",
+			"response_time": 23.5,
+			"reachable":     true,
+			"owner_team":    "network-ops",
+		},
+	}
+
+	// Create a site with metadata
+	siteEntity := &diode.Site{
+		Name:   diode.String("Data Center 1"),
+		Status: diode.String("active"),
+		Metadata: diode.Metadata{
+			"region":       "us-west",
+			"cost_center":  "CC-001",
+			"capacity":     500,
+			"is_primary":   true,
+			"contact_email": "dc1-ops@example.com",
+		},
+	}
+
+	entities := []diode.Entity{
+		deviceEntity,
+		ipEntity,
+		siteEntity,
+	}
+
+	resp, err := client.Ingest(context.Background(), entities)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if resp != nil && resp.Errors != nil {
+		log.Printf("Errors: %v\n", resp.Errors)
+	} else {
+		log.Printf("Success\n")
+	}
+}
+```
+
+#### Adding request-level metadata
+
+In addition to entity-level metadata, you can attach metadata to the entire ingestion request using `WithIngestMetadata`. This is useful for tracking information about the ingestion batch itself, such as the data source, batch ID, or processing context.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+)
+
+func main() {
+	client, err := diode.NewClient(
+		"grpc://localhost:8080/diode",
+		"example-app",
+		"0.1.0",
+		diode.WithClientID("YOUR_CLIENT_ID"),
+		diode.WithClientSecret("YOUR_CLIENT_SECRET"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create entities
+	entities := []diode.Entity{
+		&diode.Device{
+			Name: diode.String("Device A"),
+			Site: &diode.Site{
+				Name: diode.String("Site ABC"),
+			},
+		},
+		&diode.Device{
+			Name: diode.String("Device B"),
+			Site: &diode.Site{
+				Name: diode.String("Site XYZ"),
+			},
+		},
+	}
+
+	// Add request-level metadata to track the ingestion batch
+	resp, err := client.Ingest(
+		context.Background(),
+		entities,
+		diode.WithIngestMetadata(diode.Metadata{
+			"batch_id":      "import-2024-01-15",
+			"source_system": "network_scanner",
+			"import_type":   "automated",
+			"record_count":  2,
+			"validated":     true,
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if resp != nil && resp.Errors != nil {
+		log.Printf("Errors: %v\n", resp.Errors)
+	} else {
+		log.Printf("Success\n")
+	}
+}
+```
+
+Request-level metadata is included in the `IngestRequest` and can be useful for:
+- Tracking data sources and ingestion pipelines
+- Correlating entities within a batch
+- Debugging and auditing data imports
+- Adding contextual information for downstream processing
+
 ### TLS verification and certificates
 
 TLS verification is controlled by the target URL scheme:
@@ -180,6 +347,36 @@ _, _ = client.Ingest(context.Background(), []diode.Entity{
 _ = client.Close()
 ```
 
+#### Adding request-level metadata to dry run output
+
+You can include request-level metadata in the dry run output using `WithIngestMetadata`. This metadata will be included in the JSON output file as part of the `IngestRequest`:
+
+```go
+client, err := diode.NewDryRunClient("example-app", "/tmp")
+if err != nil {
+        log.Fatal(err)
+}
+
+// Add request-level metadata
+_, _ = client.Ingest(
+        context.Background(),
+        []diode.Entity{
+                &diode.Device{Name: diode.String("Device A")},
+        },
+        diode.WithIngestMetadata(diode.Metadata{
+                "batch_id":   "import-2024-01",
+                "source":     "csv_import",
+                "validated":  true,
+                "record_count": 150,
+        }),
+)
+_ = client.Close()
+```
+
+The resulting JSON file will include the metadata in the `IngestRequest`, making it visible when reviewing the dry run output.
+
+#### Loading and replaying dry run data
+
 Loaded entities can later be ingested using a real client:
 
 ```go
@@ -229,6 +426,47 @@ if err != nil {
 ```
 
 Each entity is serialised with protobuf field names and emitted as a log record that includes SDK and producer metadata via resource attributes so downstream collectors can enrich and forward the payload. The client raises an `OTLPClientError` when the export fails. TLS behaviour honours the existing `DIODE_SKIP_TLS_VERIFY` and `DIODE_CERT_FILE` environment variables, and the export timeout can be customised via `diode.WithOTLPTimeout`.
+
+#### Adding request-level metadata as OTLP resource attributes
+
+You can add request-level metadata to OTLP exports using `WithIngestMetadata`. This metadata is automatically mapped to OTLP resource attributes with a `diode.metadata.` prefix:
+
+```go
+client, err := diode.NewOTLPClient(
+        "grpc://localhost:4317",
+        "otlp-producer",
+        "0.0.1",
+)
+if err != nil {
+        log.Fatal(err)
+}
+defer client.Close()
+
+// Add request-level metadata
+_, err = client.Ingest(
+        context.Background(),
+        []diode.Entity{
+                &diode.Site{Name: diode.String("Site 1")},
+        },
+        diode.WithIngestMetadata(diode.Metadata{
+                "environment": "production",
+                "deployment":  "us-west-2",
+                "version":     "1.2.3",
+                "priority":    5,
+        }),
+)
+if err != nil {
+        log.Fatal(err)
+}
+```
+
+The resulting OTLP log records will include resource attributes like:
+- `diode.metadata.environment="production"`
+- `diode.metadata.deployment="us-west-2"`
+- `diode.metadata.version="1.2.3"`
+- `diode.metadata.priority=5` (as integer)
+
+These attributes are added alongside standard OTLP resource attributes (`service.name`, `service.version`, `diode.stream`, etc.), allowing downstream collectors and observability platforms to filter, route, and enrich the data based on this metadata.
 
 ### CLI to replay dry-run files
 

--- a/diode/client.go
+++ b/diode/client.go
@@ -25,6 +25,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
@@ -202,10 +204,25 @@ type Client interface {
 	Close() error
 
 	// Ingest sends an ingest request to the ingester service
-	Ingest(context.Context, []Entity) (*diodepb.IngestResponse, error)
+	Ingest(context.Context, []Entity, ...IngestOption) (*diodepb.IngestResponse, error)
 
 	// IngestProto sends an ingest request to the ingester service with proto entities
-	IngestProto(context.Context, []*diodepb.Entity) (*diodepb.IngestResponse, error)
+	IngestProto(context.Context, []*diodepb.Entity, ...IngestOption) (*diodepb.IngestResponse, error)
+}
+
+// IngestOption is a functional option for ingest operations
+type IngestOption func(*ingestConfig)
+
+// ingestConfig holds configuration for ingest operations
+type ingestConfig struct {
+	metadata Metadata
+}
+
+// WithIngestMetadata adds optional metadata to the IngestRequest
+func WithIngestMetadata(metadata Metadata) IngestOption {
+	return func(c *ingestConfig) {
+		c.metadata = metadata
+	}
 }
 
 // GRPCClient is a gRPC implementation of the ingester service
@@ -517,12 +534,18 @@ func (g *GRPCClient) Close() error {
 }
 
 // Ingest sends an ingest request to the ingester service
-func (g *GRPCClient) Ingest(ctx context.Context, entities []Entity) (*diodepb.IngestResponse, error) {
-	return g.IngestProto(ctx, convertEntitiesToProto(entities))
+func (g *GRPCClient) Ingest(ctx context.Context, entities []Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
+	return g.IngestProto(ctx, convertEntitiesToProto(entities), opts...)
 }
 
 // IngestProto sends an ingest request to the ingester service with proto entities
-func (g *GRPCClient) IngestProto(ctx context.Context, entities []*diodepb.Entity) (*diodepb.IngestResponse, error) {
+func (g *GRPCClient) IngestProto(ctx context.Context, entities []*diodepb.Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
+	// Apply options
+	cfg := &ingestConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	stream := defaultStreamName
 
 	req := &diodepb.IngestRequest{
@@ -534,6 +557,15 @@ func (g *GRPCClient) IngestProto(ctx context.Context, entities []*diodepb.Entity
 		SdkName:            g.sdkName,
 		SdkVersion:         g.sdkVersion,
 	}
+
+	// Add metadata to request if provided
+	if len(cfg.metadata) > 0 {
+		req.Metadata, _ = structpb.NewStruct(cfg.metadata)
+	}
+
+	data, _ := protojson.MarshalOptions{UseProtoNames: true, Indent: "  "}.Marshal(req)
+
+	fmt.Printf("entities: %s\n", data)
 
 	ctx = metadata.NewOutgoingContext(ctx, g.metadata)
 

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
@@ -1201,4 +1202,301 @@ func TestAuthRetryEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIngestWithMetadata(t *testing.T) {
+	defer func() {
+		_ = os.Unsetenv(DiodeClientIDEnvVarName)
+		_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+	}()
+
+	_ = os.Setenv(DiodeClientIDEnvVarName, "client-id")
+	_ = os.Setenv(DiodeClientSecretEnvVarName, "client-secret")
+
+	port, err := getFreePort()
+	require.NoError(t, err)
+
+	authServer, err := startMockAuthServer(port, "", false)
+	require.NoError(t, err)
+	defer authServer.Close()
+
+	client, err := NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+	require.NoError(t, err)
+	defer func() {
+		err := client.Close()
+		require.NoError(t, err)
+	}()
+
+	grpcClient := client.(*GRPCClient)
+
+	entities := []Entity{
+		&Device{
+			Name:     String("device-1"),
+			Metadata: Metadata{"foo": "bar"},
+			Site: &Site{
+				Name:     String("Site 1"),
+				Metadata: Metadata{"bar": "foo"},
+			},
+		},
+		&Site{Name: String("site-1")},
+	}
+
+	// Test with metadata
+	metadata := Metadata{
+		"batch_id":   "batch-123",
+		"source":     "network_discovery",
+		"priority":   1,
+		"verified":   true,
+		"importance": 42.5,
+	}
+
+	_, err = grpcClient.Ingest(context.Background(), entities, WithIngestMetadata(metadata))
+	require.NoError(t, err)
+
+	// Test without metadata (backward compatibility)
+	_, err = grpcClient.Ingest(context.Background(), entities)
+	require.NoError(t, err)
+}
+
+func TestIngestProtoWithMetadata(t *testing.T) {
+	defer func() {
+		_ = os.Unsetenv(DiodeClientIDEnvVarName)
+		_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+	}()
+
+	_ = os.Setenv(DiodeClientIDEnvVarName, "client-id")
+	_ = os.Setenv(DiodeClientSecretEnvVarName, "client-secret")
+
+	port, err := getFreePort()
+	require.NoError(t, err)
+
+	authServer, err := startMockAuthServer(port, "", false)
+	require.NoError(t, err)
+	defer authServer.Close()
+
+	client, err := NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+	require.NoError(t, err)
+	defer func() {
+		err := client.Close()
+		require.NoError(t, err)
+	}()
+
+	grpcClient := client.(*GRPCClient)
+
+	entities := []*diodepb.Entity{
+		{
+			Entity: &diodepb.Entity_Device{
+				Device: &diodepb.Device{
+					Name:        String("device-1"),
+					Description: String("Test device"),
+				},
+			},
+		},
+	}
+
+	// Test with metadata
+	metadata := Metadata{
+		"batch_id": "batch-456",
+		"source":   "manual_import",
+		"count":    10,
+	}
+
+	resp, err := grpcClient.IngestProto(context.Background(), entities, WithIngestMetadata(metadata))
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	require.Empty(t, resp.Errors)
+
+	// Test without metadata (backward compatibility)
+	resp, err = grpcClient.IngestProto(context.Background(), entities)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	require.Empty(t, resp.Errors)
+}
+
+func TestIngestProtoWithMetadataTypes(t *testing.T) {
+	defer func() {
+		_ = os.Unsetenv(DiodeClientIDEnvVarName)
+		_ = os.Unsetenv(DiodeClientSecretEnvVarName)
+	}()
+
+	_ = os.Setenv(DiodeClientIDEnvVarName, "client-id")
+	_ = os.Setenv(DiodeClientSecretEnvVarName, "client-secret")
+
+	port, err := getFreePort()
+	require.NoError(t, err)
+
+	// Create a custom mock server that captures metadata
+	var capturedMetadata *structpb.Struct
+	mockIngester := &MockIngesterWithCapture{
+		captureFunc: func(req *diodepb.IngestRequest) {
+			capturedMetadata = req.Metadata
+		},
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	diodepb.RegisterIngesterServiceServer(grpcServer, mockIngester)
+
+	httpMux := http.NewServeMux()
+	httpMux.HandleFunc("/auth/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token": "mock-token"}`))
+	})
+
+	handler := h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			httpMux.ServeHTTP(w, r)
+		}
+	}), &http2.Server{})
+
+	httpServer := &http.Server{Handler: handler}
+	go func() {
+		_ = httpServer.Serve(listener)
+	}()
+	defer func() {
+		_ = httpServer.Close()
+		grpcServer.Stop()
+	}()
+
+	client, err := NewClient(fmt.Sprintf("grpc://localhost:%s", port), "my-producer", "0.1.0")
+	require.NoError(t, err)
+	defer func() {
+		err := client.Close()
+		require.NoError(t, err)
+	}()
+
+	grpcClient := client.(*GRPCClient)
+
+	entities := []*diodepb.Entity{
+		{
+			Entity: &diodepb.Entity_Device{
+				Device: &diodepb.Device{
+					Name:        String("device-1"),
+					Description: String("Test device"),
+				},
+			},
+		},
+	}
+
+	// Test with various data types in metadata
+	metadata := Metadata{
+		// Primitives
+		"string_value": "test-string",
+		"int_value":    42,
+		"int64_value":  int64(9223372036854775807),
+		"float_value":  3.14159,
+		"bool_value":   true,
+		"null_value":   nil,
+		// Collections
+		"array_value": []any{"item1", "item2", 123, true},
+		"nested_object": map[string]any{
+			"nested_string": "nested-value",
+			"nested_int":    99,
+			"nested_array":  []any{1, 2, 3},
+		},
+		"mixed_array": []any{
+			"string",
+			123,
+			map[string]any{"key": "value"},
+			[]any{"nested", "array"},
+		},
+		// Edge cases
+		"empty_string": "",
+		"zero_int":     0,
+		"zero_float":   0.0,
+		"false_bool":   false,
+		"empty_array":  []any{},
+		"empty_object": map[string]any{},
+	}
+
+	resp, err := grpcClient.IngestProto(context.Background(), entities, WithIngestMetadata(metadata))
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	require.Empty(t, resp.Errors)
+
+	// Now verify the captured metadata
+	require.NotNil(t, capturedMetadata, "metadata should have been captured")
+	require.NotNil(t, capturedMetadata.Fields, "metadata fields should not be nil")
+
+	// Verify primitive types
+	assert.Equal(t, "test-string", capturedMetadata.Fields["string_value"].GetStringValue())
+	assert.Equal(t, float64(42), capturedMetadata.Fields["int_value"].GetNumberValue())
+	assert.Equal(t, float64(9223372036854775807), capturedMetadata.Fields["int64_value"].GetNumberValue())
+	assert.InDelta(t, 3.14159, capturedMetadata.Fields["float_value"].GetNumberValue(), 0.00001)
+	assert.Equal(t, true, capturedMetadata.Fields["bool_value"].GetBoolValue())
+	assert.Equal(t, structpb.NullValue_NULL_VALUE, capturedMetadata.Fields["null_value"].GetNullValue())
+
+	// Verify array
+	arrayValue := capturedMetadata.Fields["array_value"].GetListValue()
+	require.NotNil(t, arrayValue)
+	require.Len(t, arrayValue.Values, 4)
+	assert.Equal(t, "item1", arrayValue.Values[0].GetStringValue())
+	assert.Equal(t, "item2", arrayValue.Values[1].GetStringValue())
+	assert.Equal(t, float64(123), arrayValue.Values[2].GetNumberValue())
+	assert.Equal(t, true, arrayValue.Values[3].GetBoolValue())
+
+	// Verify nested object
+	nestedObj := capturedMetadata.Fields["nested_object"].GetStructValue()
+	require.NotNil(t, nestedObj)
+	assert.Equal(t, "nested-value", nestedObj.Fields["nested_string"].GetStringValue())
+	assert.Equal(t, float64(99), nestedObj.Fields["nested_int"].GetNumberValue())
+
+	nestedArray := nestedObj.Fields["nested_array"].GetListValue()
+	require.NotNil(t, nestedArray)
+	require.Len(t, nestedArray.Values, 3)
+	assert.Equal(t, float64(1), nestedArray.Values[0].GetNumberValue())
+	assert.Equal(t, float64(2), nestedArray.Values[1].GetNumberValue())
+	assert.Equal(t, float64(3), nestedArray.Values[2].GetNumberValue())
+
+	// Verify mixed array
+	mixedArray := capturedMetadata.Fields["mixed_array"].GetListValue()
+	require.NotNil(t, mixedArray)
+	require.Len(t, mixedArray.Values, 4)
+	assert.Equal(t, "string", mixedArray.Values[0].GetStringValue())
+	assert.Equal(t, float64(123), mixedArray.Values[1].GetNumberValue())
+
+	mixedObj := mixedArray.Values[2].GetStructValue()
+	require.NotNil(t, mixedObj)
+	assert.Equal(t, "value", mixedObj.Fields["key"].GetStringValue())
+
+	mixedNestedArray := mixedArray.Values[3].GetListValue()
+	require.NotNil(t, mixedNestedArray)
+	require.Len(t, mixedNestedArray.Values, 2)
+	assert.Equal(t, "nested", mixedNestedArray.Values[0].GetStringValue())
+	assert.Equal(t, "array", mixedNestedArray.Values[1].GetStringValue())
+
+	// Verify edge cases
+	assert.Equal(t, "", capturedMetadata.Fields["empty_string"].GetStringValue())
+	assert.Equal(t, float64(0), capturedMetadata.Fields["zero_int"].GetNumberValue())
+	assert.Equal(t, float64(0), capturedMetadata.Fields["zero_float"].GetNumberValue())
+	assert.Equal(t, false, capturedMetadata.Fields["false_bool"].GetBoolValue())
+
+	emptyArray := capturedMetadata.Fields["empty_array"].GetListValue()
+	require.NotNil(t, emptyArray)
+	assert.Empty(t, emptyArray.Values)
+
+	emptyObject := capturedMetadata.Fields["empty_object"].GetStructValue()
+	require.NotNil(t, emptyObject)
+	assert.Empty(t, emptyObject.Fields)
+}
+
+type MockIngesterWithCapture struct {
+	diodepb.UnimplementedIngesterServiceServer
+	captureFunc func(*diodepb.IngestRequest)
+}
+
+func (m *MockIngesterWithCapture) Ingest(_ context.Context, req *diodepb.IngestRequest) (*diodepb.IngestResponse, error) {
+	if m.captureFunc != nil {
+		m.captureFunc(req)
+	}
+	return &diodepb.IngestResponse{Errors: nil}, nil
 }

--- a/diode/dryrun.go
+++ b/diode/dryrun.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
@@ -56,19 +57,30 @@ func (d *DryRunClient) Close() error {
 
 // Ingest writes the given entities to stdout or a file depending on the configuration.
 // This is a wrapper around IngestProto that converts the entities to protobuf first.
-func (d *DryRunClient) Ingest(ctx context.Context, entities []Entity) (*diodepb.IngestResponse, error) {
-	return d.IngestProto(ctx, convertEntitiesToProto(entities))
+func (d *DryRunClient) Ingest(ctx context.Context, entities []Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
+	return d.IngestProto(ctx, convertEntitiesToProto(entities), opts...)
 }
 
 // IngestProto serializes entities as JSON and writes them to stdout or a file.
 // If a directory is configured, it creates a new timestamped file in that directory.
 // Otherwise, it writes to stdout.
-func (d *DryRunClient) IngestProto(_ context.Context, entities []*diodepb.Entity) (*diodepb.IngestResponse, error) {
+func (d *DryRunClient) IngestProto(_ context.Context, entities []*diodepb.Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
+	// Apply options
+	cfg := &ingestConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	wrapper := &diodepb.IngestRequest{
 		Id:         uuid.New().String(),
 		Entities:   entities,
 		SdkName:    d.sdkName,
 		SdkVersion: d.sdkVersion,
+	}
+
+	// Add metadata to request if provided
+	if len(cfg.metadata) > 0 {
+		wrapper.Metadata, _ = structpb.NewStruct(cfg.metadata)
 	}
 
 	data, err := protojson.MarshalOptions{UseProtoNames: true, Indent: "  "}.Marshal(wrapper)

--- a/diode/dryrun_test.go
+++ b/diode/dryrun_test.go
@@ -162,3 +162,48 @@ func TestDryRunClientSDKVersionCaching(t *testing.T) {
 	require.Equal(t, cachedVersion, dryRunClient2.sdkVersion)
 	require.Equal(t, cachedName, dryRunClient2.sdkName)
 }
+
+func TestDryRunClientIngestWithMetadata(t *testing.T) {
+	dir := t.TempDir()
+
+	c, err := NewDryRunClient("app", dir)
+	require.NoError(t, err)
+	drc := c.(*DryRunClient)
+
+	entities := []Entity{
+		&Device{Name: String("dev1"), Description: String("Test device")},
+	}
+
+	// Test with metadata
+	metadata := Metadata{
+		"batch_id": "batch-789",
+		"source":   "auto_discovery",
+		"priority": 2,
+		"verified": false,
+	}
+
+	_, err = drc.Ingest(context.Background(), entities, WithIngestMetadata(metadata))
+	require.NoError(t, err)
+
+	// Test without metadata (backward compatibility)
+	_, err = drc.Ingest(context.Background(), entities)
+	require.NoError(t, err)
+
+	require.NoError(t, drc.Close())
+
+	// Verify two files were created
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	// Load the first file (with metadata) and verify metadata is present
+	loaded, err := LoadDryRunEntities(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+
+	// Read the raw JSON to verify metadata is included in the IngestRequest
+	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+	require.Contains(t, string(data), "batch-789")
+	require.Contains(t, string(data), "auto_discovery")
+}

--- a/diode/dryrun_test.go
+++ b/diode/dryrun_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
 
 func TestNewDryRunClient(t *testing.T) {
@@ -201,9 +204,18 @@ func TestDryRunClientIngestWithMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, loaded, 1)
 
-	// Read the raw JSON to verify metadata is included in the IngestRequest
+	// Load the IngestRequest to verify metadata is included
 	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
 	require.NoError(t, err)
-	require.Contains(t, string(data), "batch-789")
-	require.Contains(t, string(data), "auto_discovery")
+
+	var req diodepb.IngestRequest
+	err = protojson.Unmarshal(data, &req)
+	require.NoError(t, err)
+	require.NotNil(t, req.Metadata)
+
+	metadataMap := req.Metadata.AsMap()
+	require.Equal(t, "batch-789", metadataMap["batch_id"])
+	require.Equal(t, "auto_discovery", metadataMap["source"])
+	require.Equal(t, float64(2), metadataMap["priority"])
+	require.Equal(t, false, metadataMap["verified"])
 }

--- a/diode/ingester.go
+++ b/diode/ingester.go
@@ -1,5 +1,5 @@
 // Generated code. DO NOT EDIT.
-// Timestamp: 2025-10-02 12:39:10Z
+// Timestamp: 2025-11-14 18:10:23Z
 //
 
 package diode
@@ -7,9 +7,11 @@ package diode
 import (
 	"encoding/json"
 	"fmt"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
@@ -20,6 +22,9 @@ type Entity interface {
 	ConvertToProtoEntity() *pb.Entity
 }
 
+// Metadata is a map of arbitrary key-value pairs that can be attached to entities
+type Metadata map[string]any
+
 type ASN struct {
 	Asn          *int64
 	Rir          *RIR
@@ -28,6 +33,7 @@ type ASN struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ASN) ConvertToProtoMessage() proto.Message {
@@ -39,6 +45,7 @@ func (e *ASN) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -119,6 +126,14 @@ func (e *ASN) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ASN) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ASNRange struct {
 	Name         *string
 	Slug         *string
@@ -129,6 +144,7 @@ type ASNRange struct {
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ASNRange) ConvertToProtoMessage() proto.Message {
@@ -142,6 +158,7 @@ func (e *ASNRange) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -238,6 +255,14 @@ func (e *ASNRange) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ASNRange) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Aggregate struct {
 	Prefix       *string
 	Rir          *RIR
@@ -247,6 +272,7 @@ type Aggregate struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *Aggregate) ConvertToProtoMessage() proto.Message {
@@ -259,6 +285,7 @@ func (e *Aggregate) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -347,6 +374,14 @@ func (e *Aggregate) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Aggregate) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Cable struct {
 	Type          *string
 	ATerminations []*GenericObject
@@ -361,6 +396,7 @@ type Cable struct {
 	Comments      *string
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
+	Metadata      Metadata
 }
 
 func (e *Cable) ConvertToProtoMessage() proto.Message {
@@ -378,6 +414,7 @@ func (e *Cable) ConvertToProtoMessage() proto.Message {
 		Comments:      e.GetComments(),
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -510,10 +547,19 @@ func (e *Cable) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Cable) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CablePath struct {
 	IsActive   *bool
 	IsComplete *bool
 	IsSplit    *bool
+	Metadata   Metadata
 }
 
 func (e *CablePath) ConvertToProtoMessage() proto.Message {
@@ -521,6 +567,7 @@ func (e *CablePath) ConvertToProtoMessage() proto.Message {
 		IsActive:   e.GetIsActive(),
 		IsComplete: e.GetIsComplete(),
 		IsSplit:    e.GetIsSplit(),
+		Metadata:   e.GetMetadata(),
 	}
 	return r
 }
@@ -557,6 +604,14 @@ func (e *CablePath) GetIsSplit() *bool {
 	return r
 }
 
+func (e *CablePath) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CableTermination struct {
 	Cable    *Cable
 	CableEnd *string
@@ -571,12 +626,14 @@ type CableTermination struct {
 	//  - PowerPort
 	//  - RearPort
 	Termination anyCableTerminationTerminationValue
+	Metadata    Metadata
 }
 
 func (e *CableTermination) ConvertToProtoMessage() proto.Message {
 	r := &pb.CableTermination{
 		Cable:    e.GetCable(),
 		CableEnd: e.GetCableEnd(),
+		Metadata: e.GetMetadata(),
 	}
 	if e.Termination != nil {
 		e.Termination.anyCableTerminationTerminationValueApplyTo(r)
@@ -618,6 +675,14 @@ func (e *CableTermination) GetTermination() any {
 	return r
 }
 
+func (e *CableTermination) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Circuit struct {
 	Cid             *string
 	Provider        *Provider
@@ -635,6 +700,7 @@ type Circuit struct {
 	Tags            []*Tag
 	Assignments     []*CircuitGroupAssignment
 	CustomFields    map[string]*CustomFieldValue
+	Metadata        Metadata
 }
 
 func (e *Circuit) ConvertToProtoMessage() proto.Message {
@@ -655,6 +721,7 @@ func (e *Circuit) ConvertToProtoMessage() proto.Message {
 		Tags:            e.GetTags(),
 		Assignments:     e.GetAssignments(),
 		CustomFields:    e.GetCustomFields(),
+		Metadata:        e.GetMetadata(),
 	}
 	return r
 }
@@ -809,6 +876,14 @@ func (e *Circuit) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Circuit) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CircuitGroup struct {
 	Name         *string
 	Slug         *string
@@ -816,6 +891,7 @@ type CircuitGroup struct {
 	Tenant       *Tenant
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *CircuitGroup) ConvertToProtoMessage() proto.Message {
@@ -826,6 +902,7 @@ func (e *CircuitGroup) ConvertToProtoMessage() proto.Message {
 		Tenant:       e.GetTenant(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -898,6 +975,14 @@ func (e *CircuitGroup) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *CircuitGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CircuitGroupAssignment struct {
 	Group *CircuitGroup
 	// Member can be:
@@ -906,6 +991,7 @@ type CircuitGroupAssignment struct {
 	Member   anyCircuitGroupAssignmentMemberValue
 	Priority *string
 	Tags     []*Tag
+	Metadata Metadata
 }
 
 func (e *CircuitGroupAssignment) ConvertToProtoMessage() proto.Message {
@@ -913,6 +999,7 @@ func (e *CircuitGroupAssignment) ConvertToProtoMessage() proto.Message {
 		Group:    e.GetGroup(),
 		Priority: e.GetPriority(),
 		Tags:     e.GetTags(),
+		Metadata: e.GetMetadata(),
 	}
 	if e.Member != nil {
 		e.Member.anyCircuitGroupAssignmentMemberValueApplyTo(r)
@@ -964,6 +1051,14 @@ func (e *CircuitGroupAssignment) GetTags() []*pb.Tag {
 	return r
 }
 
+func (e *CircuitGroupAssignment) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CircuitTermination struct {
 	Circuit  *Circuit
 	TermSide *string
@@ -982,6 +1077,7 @@ type CircuitTermination struct {
 	MarkConnected *bool
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
+	Metadata      Metadata
 }
 
 func (e *CircuitTermination) ConvertToProtoMessage() proto.Message {
@@ -996,6 +1092,7 @@ func (e *CircuitTermination) ConvertToProtoMessage() proto.Message {
 		MarkConnected: e.GetMarkConnected(),
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
+		Metadata:      e.GetMetadata(),
 	}
 	if e.Termination != nil {
 		e.Termination.anyCircuitTerminationTerminationValueApplyTo(r)
@@ -1113,6 +1210,14 @@ func (e *CircuitTermination) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *CircuitTermination) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CircuitType struct {
 	Name         *string
 	Slug         *string
@@ -1120,6 +1225,7 @@ type CircuitType struct {
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *CircuitType) ConvertToProtoMessage() proto.Message {
@@ -1130,6 +1236,7 @@ func (e *CircuitType) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -1202,6 +1309,14 @@ func (e *CircuitType) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *CircuitType) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Cluster struct {
 	Name   *string
 	Type   *ClusterType
@@ -1218,6 +1333,7 @@ type Cluster struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *Cluster) ConvertToProtoMessage() proto.Message {
@@ -1231,6 +1347,7 @@ func (e *Cluster) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.Scope != nil {
 		e.Scope.anyClusterScopeValueApplyTo(r)
@@ -1340,12 +1457,21 @@ func (e *Cluster) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Cluster) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ClusterGroup struct {
 	Name         *string
 	Slug         *string
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ClusterGroup) ConvertToProtoMessage() proto.Message {
@@ -1355,6 +1481,7 @@ func (e *ClusterGroup) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -1419,12 +1546,21 @@ func (e *ClusterGroup) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ClusterGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ClusterType struct {
 	Name         *string
 	Slug         *string
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ClusterType) ConvertToProtoMessage() proto.Message {
@@ -1434,6 +1570,7 @@ func (e *ClusterType) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -1498,6 +1635,14 @@ func (e *ClusterType) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ClusterType) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ConsolePort struct {
 	Device        *Device
 	Module        *Module
@@ -1509,6 +1654,7 @@ type ConsolePort struct {
 	MarkConnected *bool
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
+	Metadata      Metadata
 }
 
 func (e *ConsolePort) ConvertToProtoMessage() proto.Message {
@@ -1523,6 +1669,7 @@ func (e *ConsolePort) ConvertToProtoMessage() proto.Message {
 		MarkConnected: e.GetMarkConnected(),
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -1627,6 +1774,14 @@ func (e *ConsolePort) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ConsolePort) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ConsoleServerPort struct {
 	Device        *Device
 	Module        *Module
@@ -1638,6 +1793,7 @@ type ConsoleServerPort struct {
 	MarkConnected *bool
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
+	Metadata      Metadata
 }
 
 func (e *ConsoleServerPort) ConvertToProtoMessage() proto.Message {
@@ -1652,6 +1808,7 @@ func (e *ConsoleServerPort) ConvertToProtoMessage() proto.Message {
 		MarkConnected: e.GetMarkConnected(),
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -1756,6 +1913,14 @@ func (e *ConsoleServerPort) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ConsoleServerPort) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Contact struct {
 	Group        *ContactGroup
 	Name         *string
@@ -1769,6 +1934,7 @@ type Contact struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Groups       []*ContactGroup
+	Metadata     Metadata
 }
 
 func (e *Contact) ConvertToProtoMessage() proto.Message {
@@ -1785,6 +1951,7 @@ func (e *Contact) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Groups:       e.GetGroups(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -1907,6 +2074,14 @@ func (e *Contact) GetGroups() []*pb.ContactGroup {
 	return r
 }
 
+func (e *Contact) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ContactAssignment struct {
 	// Object can be any Entity type
 	Object       anyContactAssignmentObjectValue
@@ -1915,6 +2090,7 @@ type ContactAssignment struct {
 	Priority     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ContactAssignment) ConvertToProtoMessage() proto.Message {
@@ -1924,6 +2100,7 @@ func (e *ContactAssignment) ConvertToProtoMessage() proto.Message {
 		Priority:     e.GetPriority(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.Object != nil {
 		e.Object.anyContactAssignmentObjectValueApplyTo(r)
@@ -2001,6 +2178,14 @@ func (e *ContactAssignment) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ContactAssignment) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ContactGroup struct {
 	Name         *string
 	Slug         *string
@@ -2009,6 +2194,7 @@ type ContactGroup struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *ContactGroup) ConvertToProtoMessage() proto.Message {
@@ -2020,6 +2206,7 @@ func (e *ContactGroup) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -2100,12 +2287,21 @@ func (e *ContactGroup) GetComments() *string {
 	return r
 }
 
+func (e *ContactGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ContactRole struct {
 	Name         *string
 	Slug         *string
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ContactRole) ConvertToProtoMessage() proto.Message {
@@ -2115,6 +2311,7 @@ func (e *ContactRole) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -2175,6 +2372,14 @@ func (e *ContactRole) GetCustomFields() map[string]*pb.CustomFieldValue {
 		for k, v := range e.CustomFields {
 			r[k] = v.ConvertToProtoMessage().(*pb.CustomFieldValue)
 		}
+	}
+	return r
+}
+
+func (e *ContactRole) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
 	}
 	return r
 }
@@ -2289,6 +2494,7 @@ type Device struct {
 	Comments       *string
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *Device) ConvertToProtoMessage() proto.Message {
@@ -2320,6 +2526,7 @@ func (e *Device) ConvertToProtoMessage() proto.Message {
 		Comments:       e.GetComments(),
 		Tags:           e.GetTags(),
 		CustomFields:   e.GetCustomFields(),
+		Metadata:       e.GetMetadata(),
 	}
 	return r
 }
@@ -2560,6 +2767,14 @@ func (e *Device) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Device) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type DeviceBay struct {
 	Device          *Device
 	Name            *string
@@ -2568,6 +2783,7 @@ type DeviceBay struct {
 	InstalledDevice *Device
 	Tags            []*Tag
 	CustomFields    map[string]*CustomFieldValue
+	Metadata        Metadata
 }
 
 func (e *DeviceBay) ConvertToProtoMessage() proto.Message {
@@ -2579,6 +2795,7 @@ func (e *DeviceBay) ConvertToProtoMessage() proto.Message {
 		InstalledDevice: e.GetInstalledDevice(),
 		Tags:            e.GetTags(),
 		CustomFields:    e.GetCustomFields(),
+		Metadata:        e.GetMetadata(),
 	}
 	return r
 }
@@ -2659,6 +2876,14 @@ func (e *DeviceBay) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *DeviceBay) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type DeviceRole struct {
 	Name         *string
 	Slug         *string
@@ -2669,6 +2894,7 @@ type DeviceRole struct {
 	CustomFields map[string]*CustomFieldValue
 	Parent       *DeviceRole
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *DeviceRole) ConvertToProtoMessage() proto.Message {
@@ -2682,6 +2908,7 @@ func (e *DeviceRole) ConvertToProtoMessage() proto.Message {
 		CustomFields: e.GetCustomFields(),
 		Parent:       e.GetParent(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -2778,6 +3005,14 @@ func (e *DeviceRole) GetComments() *string {
 	return r
 }
 
+func (e *DeviceRole) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type DeviceType struct {
 	Manufacturer           *Manufacturer
 	DefaultPlatform        *Platform
@@ -2795,6 +3030,7 @@ type DeviceType struct {
 	Comments               *string
 	Tags                   []*Tag
 	CustomFields           map[string]*CustomFieldValue
+	Metadata               Metadata
 }
 
 func (e *DeviceType) ConvertToProtoMessage() proto.Message {
@@ -2815,6 +3051,7 @@ func (e *DeviceType) ConvertToProtoMessage() proto.Message {
 		Comments:               e.GetComments(),
 		Tags:                   e.GetTags(),
 		CustomFields:           e.GetCustomFields(),
+		Metadata:               e.GetMetadata(),
 	}
 	return r
 }
@@ -2967,6 +3204,14 @@ func (e *DeviceType) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *DeviceType) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type FHRPGroup struct {
 	Name         *string
 	Protocol     *string
@@ -2977,6 +3222,7 @@ type FHRPGroup struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *FHRPGroup) ConvertToProtoMessage() proto.Message {
@@ -2990,6 +3236,7 @@ func (e *FHRPGroup) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -3086,17 +3333,27 @@ func (e *FHRPGroup) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *FHRPGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type FHRPGroupAssignment struct {
 	Group *FHRPGroup
 	// Interface can be any Entity type
 	Interface anyFHRPGroupAssignmentInterfaceValue
 	Priority  *int64
+	Metadata  Metadata
 }
 
 func (e *FHRPGroupAssignment) ConvertToProtoMessage() proto.Message {
 	r := &pb.FHRPGroupAssignment{
 		Group:    e.GetGroup(),
 		Priority: e.GetPriority(),
+		Metadata: e.GetMetadata(),
 	}
 	if e.Interface != nil {
 		e.Interface.anyFHRPGroupAssignmentInterfaceValueApplyTo(r)
@@ -3138,6 +3395,14 @@ func (e *FHRPGroupAssignment) GetPriority() int64 {
 	return r
 }
 
+func (e *FHRPGroupAssignment) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type FrontPort struct {
 	Device           *Device
 	Module           *Module
@@ -3151,6 +3416,7 @@ type FrontPort struct {
 	MarkConnected    *bool
 	Tags             []*Tag
 	CustomFields     map[string]*CustomFieldValue
+	Metadata         Metadata
 }
 
 func (e *FrontPort) ConvertToProtoMessage() proto.Message {
@@ -3167,6 +3433,7 @@ func (e *FrontPort) ConvertToProtoMessage() proto.Message {
 		MarkConnected:    e.GetMarkConnected(),
 		Tags:             e.GetTags(),
 		CustomFields:     e.GetCustomFields(),
+		Metadata:         e.GetMetadata(),
 	}
 	return r
 }
@@ -3287,6 +3554,14 @@ func (e *FrontPort) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *FrontPort) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type GenericObject struct {
 	// Object can be any Entity type
 	Object anyGenericObjectObjectValue
@@ -3320,6 +3595,7 @@ type IKEPolicy struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Proposals    []*IKEProposal
+	Metadata     Metadata
 }
 
 func (e *IKEPolicy) ConvertToProtoMessage() proto.Message {
@@ -3333,6 +3609,7 @@ func (e *IKEPolicy) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Proposals:    e.GetProposals(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -3431,6 +3708,14 @@ func (e *IKEPolicy) GetProposals() []*pb.IKEProposal {
 	return r
 }
 
+func (e *IKEPolicy) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type IKEProposal struct {
 	Name                    *string
 	Description             *string
@@ -3442,6 +3727,7 @@ type IKEProposal struct {
 	Comments                *string
 	Tags                    []*Tag
 	CustomFields            map[string]*CustomFieldValue
+	Metadata                Metadata
 }
 
 func (e *IKEProposal) ConvertToProtoMessage() proto.Message {
@@ -3456,6 +3742,7 @@ func (e *IKEProposal) ConvertToProtoMessage() proto.Message {
 		Comments:                e.GetComments(),
 		Tags:                    e.GetTags(),
 		CustomFields:            e.GetCustomFields(),
+		Metadata:                e.GetMetadata(),
 	}
 	return r
 }
@@ -3560,6 +3847,14 @@ func (e *IKEProposal) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *IKEProposal) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type IPAddress struct {
 	Address *string
 	Vrf     *VRF
@@ -3577,6 +3872,7 @@ type IPAddress struct {
 	Comments       *string
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *IPAddress) ConvertToProtoMessage() proto.Message {
@@ -3592,6 +3888,7 @@ func (e *IPAddress) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.AssignedObject != nil {
 		e.AssignedObject.anyIPAddressAssignedObjectValueApplyTo(r)
@@ -3717,6 +4014,14 @@ func (e *IPAddress) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *IPAddress) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type IPRange struct {
 	StartAddress  *string
 	EndAddress    *string
@@ -3730,6 +4035,7 @@ type IPRange struct {
 	MarkUtilized  *bool
 	CustomFields  map[string]*CustomFieldValue
 	MarkPopulated *bool
+	Metadata      Metadata
 }
 
 func (e *IPRange) ConvertToProtoMessage() proto.Message {
@@ -3746,6 +4052,7 @@ func (e *IPRange) ConvertToProtoMessage() proto.Message {
 		MarkUtilized:  e.GetMarkUtilized(),
 		CustomFields:  e.GetCustomFields(),
 		MarkPopulated: e.GetMarkPopulated(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -3866,6 +4173,14 @@ func (e *IPRange) GetMarkPopulated() *bool {
 	return r
 }
 
+func (e *IPRange) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type IPSecPolicy struct {
 	Name         *string
 	Description  *string
@@ -3874,6 +4189,7 @@ type IPSecPolicy struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Proposals    []*IPSecProposal
+	Metadata     Metadata
 }
 
 func (e *IPSecPolicy) ConvertToProtoMessage() proto.Message {
@@ -3885,6 +4201,7 @@ func (e *IPSecPolicy) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Proposals:    e.GetProposals(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -3967,6 +4284,14 @@ func (e *IPSecPolicy) GetProposals() []*pb.IPSecProposal {
 	return r
 }
 
+func (e *IPSecPolicy) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type IPSecProfile struct {
 	Name         *string
 	Description  *string
@@ -3976,6 +4301,7 @@ type IPSecProfile struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *IPSecProfile) ConvertToProtoMessage() proto.Message {
@@ -3988,6 +4314,7 @@ func (e *IPSecProfile) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -4076,6 +4403,14 @@ func (e *IPSecProfile) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *IPSecProfile) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type IPSecProposal struct {
 	Name                    *string
 	Description             *string
@@ -4086,6 +4421,7 @@ type IPSecProposal struct {
 	Comments                *string
 	Tags                    []*Tag
 	CustomFields            map[string]*CustomFieldValue
+	Metadata                Metadata
 }
 
 func (e *IPSecProposal) ConvertToProtoMessage() proto.Message {
@@ -4099,6 +4435,7 @@ func (e *IPSecProposal) ConvertToProtoMessage() proto.Message {
 		Comments:                e.GetComments(),
 		Tags:                    e.GetTags(),
 		CustomFields:            e.GetCustomFields(),
+		Metadata:                e.GetMetadata(),
 	}
 	return r
 }
@@ -4195,6 +4532,14 @@ func (e *IPSecProposal) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *IPSecProposal) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Interface struct {
 	Device                *Device
 	Module                *Module
@@ -4230,6 +4575,7 @@ type Interface struct {
 	Vdcs                  []*VirtualDeviceContext
 	TaggedVlans           []*VLAN
 	WirelessLans          []*WirelessLAN
+	Metadata              Metadata
 }
 
 func (e *Interface) ConvertToProtoMessage() proto.Message {
@@ -4268,6 +4614,7 @@ func (e *Interface) ConvertToProtoMessage() proto.Message {
 		Vdcs:                  e.GetVdcs(),
 		TaggedVlans:           e.GetTaggedVlans(),
 		WirelessLans:          e.GetWirelessLans(),
+		Metadata:              e.GetMetadata(),
 	}
 	return r
 }
@@ -4570,6 +4917,14 @@ func (e *Interface) GetWirelessLans() []*pb.WirelessLAN {
 	return r
 }
 
+func (e *Interface) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type InventoryItem struct {
 	Device       *Device
 	Parent       *InventoryItem
@@ -4594,6 +4949,7 @@ type InventoryItem struct {
 	Component    anyInventoryItemComponentValue
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *InventoryItem) ConvertToProtoMessage() proto.Message {
@@ -4612,6 +4968,7 @@ func (e *InventoryItem) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.Component != nil {
 		e.Component.anyInventoryItemComponentValueApplyTo(r)
@@ -4761,6 +5118,14 @@ func (e *InventoryItem) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *InventoryItem) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type InventoryItemRole struct {
 	Name         *string
 	Slug         *string
@@ -4768,6 +5133,7 @@ type InventoryItemRole struct {
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *InventoryItemRole) ConvertToProtoMessage() proto.Message {
@@ -4778,6 +5144,7 @@ func (e *InventoryItemRole) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -4850,6 +5217,14 @@ func (e *InventoryItemRole) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *InventoryItemRole) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type L2VPN struct {
 	Identifier    *int64
 	Name          *string
@@ -4863,6 +5238,7 @@ type L2VPN struct {
 	ImportTargets []*RouteTarget
 	ExportTargets []*RouteTarget
 	Status        *string
+	Metadata      Metadata
 }
 
 func (e *L2VPN) ConvertToProtoMessage() proto.Message {
@@ -4879,6 +5255,7 @@ func (e *L2VPN) ConvertToProtoMessage() proto.Message {
 		ImportTargets: e.GetImportTargets(),
 		ExportTargets: e.GetExportTargets(),
 		Status:        e.GetStatus(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -5003,12 +5380,21 @@ func (e *L2VPN) GetStatus() *string {
 	return r
 }
 
+func (e *L2VPN) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type L2VPNTermination struct {
 	L2Vpn *L2VPN
 	// AssignedObject can be any Entity type
 	AssignedObject anyL2VPNTerminationAssignedObjectValue
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *L2VPNTermination) ConvertToProtoMessage() proto.Message {
@@ -5016,6 +5402,7 @@ func (e *L2VPNTermination) ConvertToProtoMessage() proto.Message {
 		L2Vpn:        e.GetL2Vpn(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.AssignedObject != nil {
 		e.AssignedObject.anyL2VPNTerminationAssignedObjectValueApplyTo(r)
@@ -5077,6 +5464,14 @@ func (e *L2VPNTermination) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *L2VPNTermination) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Location struct {
 	Name         *string
 	Slug         *string
@@ -5089,6 +5484,7 @@ type Location struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *Location) ConvertToProtoMessage() proto.Message {
@@ -5104,6 +5500,7 @@ func (e *Location) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -5216,6 +5613,14 @@ func (e *Location) GetComments() *string {
 	return r
 }
 
+func (e *Location) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type MACAddress struct {
 	MacAddress *string
 	// AssignedObject can be:
@@ -5226,6 +5631,7 @@ type MACAddress struct {
 	Comments       *string
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *MACAddress) ConvertToProtoMessage() proto.Message {
@@ -5235,6 +5641,7 @@ func (e *MACAddress) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.AssignedObject != nil {
 		e.AssignedObject.anyMACAddressAssignedObjectValueApplyTo(r)
@@ -5312,12 +5719,21 @@ func (e *MACAddress) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *MACAddress) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Manufacturer struct {
 	Name         *string
 	Slug         *string
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *Manufacturer) ConvertToProtoMessage() proto.Message {
@@ -5327,6 +5743,7 @@ func (e *Manufacturer) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -5391,6 +5808,14 @@ func (e *Manufacturer) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Manufacturer) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Module struct {
 	Device       *Device
 	ModuleBay    *ModuleBay
@@ -5402,6 +5827,7 @@ type Module struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *Module) ConvertToProtoMessage() proto.Message {
@@ -5416,6 +5842,7 @@ func (e *Module) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -5520,6 +5947,14 @@ func (e *Module) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Module) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ModuleBay struct {
 	Device          *Device
 	Module          *Module
@@ -5530,6 +5965,7 @@ type ModuleBay struct {
 	Description     *string
 	Tags            []*Tag
 	CustomFields    map[string]*CustomFieldValue
+	Metadata        Metadata
 }
 
 func (e *ModuleBay) ConvertToProtoMessage() proto.Message {
@@ -5543,6 +5979,7 @@ func (e *ModuleBay) ConvertToProtoMessage() proto.Message {
 		Description:     e.GetDescription(),
 		Tags:            e.GetTags(),
 		CustomFields:    e.GetCustomFields(),
+		Metadata:        e.GetMetadata(),
 	}
 	return r
 }
@@ -5639,6 +6076,14 @@ func (e *ModuleBay) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ModuleBay) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ModuleType struct {
 	Manufacturer *Manufacturer
 	Model        *string
@@ -5652,6 +6097,7 @@ type ModuleType struct {
 	CustomFields map[string]*CustomFieldValue
 	Profile      *ModuleTypeProfile
 	Attributes   *string
+	Metadata     Metadata
 }
 
 func (e *ModuleType) ConvertToProtoMessage() proto.Message {
@@ -5668,6 +6114,7 @@ func (e *ModuleType) ConvertToProtoMessage() proto.Message {
 		CustomFields: e.GetCustomFields(),
 		Profile:      e.GetProfile(),
 		Attributes:   e.GetAttributes(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -5788,6 +6235,14 @@ func (e *ModuleType) GetAttributes() *string {
 	return r
 }
 
+func (e *ModuleType) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Platform struct {
 	Name         *string
 	Slug         *string
@@ -5797,6 +6252,7 @@ type Platform struct {
 	CustomFields map[string]*CustomFieldValue
 	Parent       *Platform
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *Platform) ConvertToProtoMessage() proto.Message {
@@ -5809,6 +6265,7 @@ func (e *Platform) ConvertToProtoMessage() proto.Message {
 		CustomFields: e.GetCustomFields(),
 		Parent:       e.GetParent(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -5897,6 +6354,14 @@ func (e *Platform) GetComments() *string {
 	return r
 }
 
+func (e *Platform) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type PowerFeed struct {
 	PowerPanel     *PowerPanel
 	Rack           *Rack
@@ -5914,6 +6379,7 @@ type PowerFeed struct {
 	Comments       *string
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *PowerFeed) ConvertToProtoMessage() proto.Message {
@@ -5934,6 +6400,7 @@ func (e *PowerFeed) ConvertToProtoMessage() proto.Message {
 		Comments:       e.GetComments(),
 		Tags:           e.GetTags(),
 		CustomFields:   e.GetCustomFields(),
+		Metadata:       e.GetMetadata(),
 	}
 	return r
 }
@@ -6086,6 +6553,14 @@ func (e *PowerFeed) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *PowerFeed) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type PowerOutlet struct {
 	Device        *Device
 	Module        *Module
@@ -6100,6 +6575,7 @@ type PowerOutlet struct {
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
 	Status        *string
+	Metadata      Metadata
 }
 
 func (e *PowerOutlet) ConvertToProtoMessage() proto.Message {
@@ -6117,6 +6593,7 @@ func (e *PowerOutlet) ConvertToProtoMessage() proto.Message {
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
 		Status:        e.GetStatus(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -6245,6 +6722,14 @@ func (e *PowerOutlet) GetStatus() *string {
 	return r
 }
 
+func (e *PowerOutlet) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type PowerPanel struct {
 	Site         *Site
 	Location     *Location
@@ -6253,6 +6738,7 @@ type PowerPanel struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *PowerPanel) ConvertToProtoMessage() proto.Message {
@@ -6264,6 +6750,7 @@ func (e *PowerPanel) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -6344,6 +6831,14 @@ func (e *PowerPanel) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *PowerPanel) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type PowerPort struct {
 	Device        *Device
 	Module        *Module
@@ -6356,6 +6851,7 @@ type PowerPort struct {
 	MarkConnected *bool
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
+	Metadata      Metadata
 }
 
 func (e *PowerPort) ConvertToProtoMessage() proto.Message {
@@ -6371,6 +6867,7 @@ func (e *PowerPort) ConvertToProtoMessage() proto.Message {
 		MarkConnected: e.GetMarkConnected(),
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -6483,6 +6980,14 @@ func (e *PowerPort) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *PowerPort) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Prefix struct {
 	Prefix *string
 	Vrf    *VRF
@@ -6502,6 +7007,7 @@ type Prefix struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *Prefix) ConvertToProtoMessage() proto.Message {
@@ -6518,6 +7024,7 @@ func (e *Prefix) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.Scope != nil {
 		e.Scope.anyPrefixScopeValueApplyTo(r)
@@ -6651,6 +7158,14 @@ func (e *Prefix) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Prefix) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Provider struct {
 	Name         *string
 	Slug         *string
@@ -6660,6 +7175,7 @@ type Provider struct {
 	CustomFields map[string]*CustomFieldValue
 	Accounts     []*ProviderAccount
 	Asns         []*ASN
+	Metadata     Metadata
 }
 
 func (e *Provider) ConvertToProtoMessage() proto.Message {
@@ -6672,6 +7188,7 @@ func (e *Provider) ConvertToProtoMessage() proto.Message {
 		CustomFields: e.GetCustomFields(),
 		Accounts:     e.GetAccounts(),
 		Asns:         e.GetAsns(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -6764,6 +7281,14 @@ func (e *Provider) GetAsns() []*pb.ASN {
 	return r
 }
 
+func (e *Provider) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ProviderAccount struct {
 	Provider     *Provider
 	Name         *string
@@ -6772,6 +7297,7 @@ type ProviderAccount struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ProviderAccount) ConvertToProtoMessage() proto.Message {
@@ -6783,6 +7309,7 @@ func (e *ProviderAccount) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -6863,6 +7390,14 @@ func (e *ProviderAccount) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ProviderAccount) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ProviderNetwork struct {
 	Provider     *Provider
 	Name         *string
@@ -6871,6 +7406,7 @@ type ProviderNetwork struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ProviderNetwork) ConvertToProtoMessage() proto.Message {
@@ -6882,6 +7418,7 @@ func (e *ProviderNetwork) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -6962,6 +7499,14 @@ func (e *ProviderNetwork) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ProviderNetwork) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type RIR struct {
 	Name         *string
 	Slug         *string
@@ -6969,6 +7514,7 @@ type RIR struct {
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *RIR) ConvertToProtoMessage() proto.Message {
@@ -6979,6 +7525,7 @@ func (e *RIR) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -7051,6 +7598,14 @@ func (e *RIR) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *RIR) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Rack struct {
 	Name          *string
 	FacilityId    *string
@@ -7080,6 +7635,7 @@ type Rack struct {
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
 	OuterHeight   *int64
+	Metadata      Metadata
 }
 
 func (e *Rack) ConvertToProtoMessage() proto.Message {
@@ -7112,6 +7668,7 @@ func (e *Rack) ConvertToProtoMessage() proto.Message {
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
 		OuterHeight:   e.GetOuterHeight(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -7360,6 +7917,14 @@ func (e *Rack) GetOuterHeight() *int64 {
 	return r
 }
 
+func (e *Rack) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type RackReservation struct {
 	Rack         *Rack
 	Units        []int64
@@ -7369,6 +7934,7 @@ type RackReservation struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Status       *string
+	Metadata     Metadata
 }
 
 func (e *RackReservation) ConvertToProtoMessage() proto.Message {
@@ -7381,6 +7947,7 @@ func (e *RackReservation) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Status:       e.GetStatus(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -7471,6 +8038,14 @@ func (e *RackReservation) GetStatus() *string {
 	return r
 }
 
+func (e *RackReservation) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type RackRole struct {
 	Name         *string
 	Slug         *string
@@ -7478,6 +8053,7 @@ type RackRole struct {
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *RackRole) ConvertToProtoMessage() proto.Message {
@@ -7488,6 +8064,7 @@ func (e *RackRole) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -7560,6 +8137,14 @@ func (e *RackRole) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *RackRole) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type RackType struct {
 	Manufacturer  *Manufacturer
 	Model         *string
@@ -7581,6 +8166,7 @@ type RackType struct {
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
 	OuterHeight   *int64
+	Metadata      Metadata
 }
 
 func (e *RackType) ConvertToProtoMessage() proto.Message {
@@ -7605,6 +8191,7 @@ func (e *RackType) ConvertToProtoMessage() proto.Message {
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
 		OuterHeight:   e.GetOuterHeight(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -7789,6 +8376,14 @@ func (e *RackType) GetOuterHeight() *int64 {
 	return r
 }
 
+func (e *RackType) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type RearPort struct {
 	Device        *Device
 	Module        *Module
@@ -7801,6 +8396,7 @@ type RearPort struct {
 	MarkConnected *bool
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
+	Metadata      Metadata
 }
 
 func (e *RearPort) ConvertToProtoMessage() proto.Message {
@@ -7816,6 +8412,7 @@ func (e *RearPort) ConvertToProtoMessage() proto.Message {
 		MarkConnected: e.GetMarkConnected(),
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -7928,6 +8525,14 @@ func (e *RearPort) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *RearPort) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Region struct {
 	Name         *string
 	Slug         *string
@@ -7936,6 +8541,7 @@ type Region struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *Region) ConvertToProtoMessage() proto.Message {
@@ -7947,6 +8553,7 @@ func (e *Region) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -8027,6 +8634,14 @@ func (e *Region) GetComments() *string {
 	return r
 }
 
+func (e *Region) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Role struct {
 	Name         *string
 	Slug         *string
@@ -8034,6 +8649,7 @@ type Role struct {
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *Role) ConvertToProtoMessage() proto.Message {
@@ -8044,6 +8660,7 @@ func (e *Role) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -8116,6 +8733,14 @@ func (e *Role) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Role) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type RouteTarget struct {
 	Name         *string
 	Tenant       *Tenant
@@ -8123,6 +8748,7 @@ type RouteTarget struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *RouteTarget) ConvertToProtoMessage() proto.Message {
@@ -8133,6 +8759,7 @@ func (e *RouteTarget) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -8205,6 +8832,14 @@ func (e *RouteTarget) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *RouteTarget) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Service struct {
 	Device         *Device
 	VirtualMachine *VirtualMachine
@@ -8221,6 +8856,7 @@ type Service struct {
 	//  - FHRPGroup
 	//  - VirtualMachine
 	ParentObject anyServiceParentObjectValue
+	Metadata     Metadata
 }
 
 func (e *Service) ConvertToProtoMessage() proto.Message {
@@ -8235,6 +8871,7 @@ func (e *Service) ConvertToProtoMessage() proto.Message {
 		Tags:           e.GetTags(),
 		CustomFields:   e.GetCustomFields(),
 		Ipaddresses:    e.GetIpaddresses(),
+		Metadata:       e.GetMetadata(),
 	}
 	if e.ParentObject != nil {
 		e.ParentObject.anyServiceParentObjectValueApplyTo(r)
@@ -8356,6 +8993,14 @@ func (e *Service) GetParentObject() any {
 	return r
 }
 
+func (e *Service) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Site struct {
 	Name            *string
 	Slug            *string
@@ -8374,6 +9019,7 @@ type Site struct {
 	Tags            []*Tag
 	CustomFields    map[string]*CustomFieldValue
 	Asns            []*ASN
+	Metadata        Metadata
 }
 
 func (e *Site) ConvertToProtoMessage() proto.Message {
@@ -8395,6 +9041,7 @@ func (e *Site) ConvertToProtoMessage() proto.Message {
 		Tags:            e.GetTags(),
 		CustomFields:    e.GetCustomFields(),
 		Asns:            e.GetAsns(),
+		Metadata:        e.GetMetadata(),
 	}
 	return r
 }
@@ -8557,6 +9204,14 @@ func (e *Site) GetAsns() []*pb.ASN {
 	return r
 }
 
+func (e *Site) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type SiteGroup struct {
 	Name         *string
 	Slug         *string
@@ -8565,6 +9220,7 @@ type SiteGroup struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *SiteGroup) ConvertToProtoMessage() proto.Message {
@@ -8576,6 +9232,7 @@ func (e *SiteGroup) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -8656,6 +9313,14 @@ func (e *SiteGroup) GetComments() *string {
 	return r
 }
 
+func (e *SiteGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Tag struct {
 	Name        *string
 	Slug        *string
@@ -8663,6 +9328,7 @@ type Tag struct {
 	Description *string
 	Weight      *int64
 	ObjectTypes []string
+	Metadata    Metadata
 }
 
 func (e *Tag) ConvertToProtoMessage() proto.Message {
@@ -8673,6 +9339,7 @@ func (e *Tag) ConvertToProtoMessage() proto.Message {
 		Description: e.GetDescription(),
 		Weight:      e.GetWeight(),
 		ObjectTypes: e.GetObjectTypes(),
+		Metadata:    e.GetMetadata(),
 	}
 	return r
 }
@@ -8735,6 +9402,14 @@ func (e *Tag) GetObjectTypes() []string {
 	return r
 }
 
+func (e *Tag) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Tenant struct {
 	Name         *string
 	Slug         *string
@@ -8743,6 +9418,7 @@ type Tenant struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *Tenant) ConvertToProtoMessage() proto.Message {
@@ -8754,6 +9430,7 @@ func (e *Tenant) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -8834,6 +9511,14 @@ func (e *Tenant) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Tenant) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type TenantGroup struct {
 	Name         *string
 	Slug         *string
@@ -8842,6 +9527,7 @@ type TenantGroup struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *TenantGroup) ConvertToProtoMessage() proto.Message {
@@ -8853,6 +9539,7 @@ func (e *TenantGroup) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -8933,6 +9620,14 @@ func (e *TenantGroup) GetComments() *string {
 	return r
 }
 
+func (e *TenantGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type Tunnel struct {
 	Name          *string
 	Status        *string
@@ -8945,6 +9640,7 @@ type Tunnel struct {
 	Comments      *string
 	Tags          []*Tag
 	CustomFields  map[string]*CustomFieldValue
+	Metadata      Metadata
 }
 
 func (e *Tunnel) ConvertToProtoMessage() proto.Message {
@@ -8960,6 +9656,7 @@ func (e *Tunnel) ConvertToProtoMessage() proto.Message {
 		Comments:      e.GetComments(),
 		Tags:          e.GetTags(),
 		CustomFields:  e.GetCustomFields(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -9072,12 +9769,21 @@ func (e *Tunnel) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *Tunnel) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type TunnelGroup struct {
 	Name         *string
 	Slug         *string
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *TunnelGroup) ConvertToProtoMessage() proto.Message {
@@ -9087,6 +9793,7 @@ func (e *TunnelGroup) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -9151,6 +9858,14 @@ func (e *TunnelGroup) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *TunnelGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type TunnelTermination struct {
 	Tunnel *Tunnel
 	Role   *string
@@ -9159,6 +9874,7 @@ type TunnelTermination struct {
 	OutsideIp    *IPAddress
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *TunnelTermination) ConvertToProtoMessage() proto.Message {
@@ -9168,6 +9884,7 @@ func (e *TunnelTermination) ConvertToProtoMessage() proto.Message {
 		OutsideIp:    e.GetOutsideIp(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.Termination != nil {
 		e.Termination.anyTunnelTerminationTerminationValueApplyTo(r)
@@ -9245,6 +9962,14 @@ func (e *TunnelTermination) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *TunnelTermination) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VLAN struct {
 	Site         *Site
 	Group        *VLANGroup
@@ -9259,6 +9984,7 @@ type VLAN struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *VLAN) ConvertToProtoMessage() proto.Message {
@@ -9276,6 +10002,7 @@ func (e *VLAN) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -9404,6 +10131,14 @@ func (e *VLAN) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *VLAN) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VLANGroup struct {
 	Name *string
 	Slug *string
@@ -9421,6 +10156,7 @@ type VLANGroup struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Tenant       *Tenant
+	Metadata     Metadata
 }
 
 func (e *VLANGroup) ConvertToProtoMessage() proto.Message {
@@ -9432,6 +10168,7 @@ func (e *VLANGroup) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Tenant:       e.GetTenant(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.Scope != nil {
 		e.Scope.anyVLANGroupScopeValueApplyTo(r)
@@ -9527,15 +10264,25 @@ func (e *VLANGroup) GetTenant() *pb.Tenant {
 	return r
 }
 
+func (e *VLANGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VLANTranslationPolicy struct {
 	Name        *string
 	Description *string
+	Metadata    Metadata
 }
 
 func (e *VLANTranslationPolicy) ConvertToProtoMessage() proto.Message {
 	r := &pb.VLANTranslationPolicy{
 		Name:        e.GetName(),
 		Description: e.GetDescription(),
+		Metadata:    e.GetMetadata(),
 	}
 	return r
 }
@@ -9564,11 +10311,20 @@ func (e *VLANTranslationPolicy) GetDescription() *string {
 	return r
 }
 
+func (e *VLANTranslationPolicy) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VLANTranslationRule struct {
 	Policy      *VLANTranslationPolicy
 	LocalVid    *int64
 	RemoteVid   *int64
 	Description *string
+	Metadata    Metadata
 }
 
 func (e *VLANTranslationRule) ConvertToProtoMessage() proto.Message {
@@ -9577,6 +10333,7 @@ func (e *VLANTranslationRule) ConvertToProtoMessage() proto.Message {
 		LocalVid:    e.GetLocalVid(),
 		RemoteVid:   e.GetRemoteVid(),
 		Description: e.GetDescription(),
+		Metadata:    e.GetMetadata(),
 	}
 	return r
 }
@@ -9621,6 +10378,14 @@ func (e *VLANTranslationRule) GetDescription() *string {
 	return r
 }
 
+func (e *VLANTranslationRule) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VMInterface struct {
 	VirtualMachine        *VirtualMachine
 	Name                  *string
@@ -9638,6 +10403,7 @@ type VMInterface struct {
 	Tags                  []*Tag
 	CustomFields          map[string]*CustomFieldValue
 	TaggedVlans           []*VLAN
+	Metadata              Metadata
 }
 
 func (e *VMInterface) ConvertToProtoMessage() proto.Message {
@@ -9658,6 +10424,7 @@ func (e *VMInterface) ConvertToProtoMessage() proto.Message {
 		Tags:                  e.GetTags(),
 		CustomFields:          e.GetCustomFields(),
 		TaggedVlans:           e.GetTaggedVlans(),
+		Metadata:              e.GetMetadata(),
 	}
 	return r
 }
@@ -9812,6 +10579,14 @@ func (e *VMInterface) GetTaggedVlans() []*pb.VLAN {
 	return r
 }
 
+func (e *VMInterface) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VRF struct {
 	Name          *string
 	Rd            *string
@@ -9823,6 +10598,7 @@ type VRF struct {
 	CustomFields  map[string]*CustomFieldValue
 	ImportTargets []*RouteTarget
 	ExportTargets []*RouteTarget
+	Metadata      Metadata
 }
 
 func (e *VRF) ConvertToProtoMessage() proto.Message {
@@ -9837,6 +10613,7 @@ func (e *VRF) ConvertToProtoMessage() proto.Message {
 		CustomFields:  e.GetCustomFields(),
 		ImportTargets: e.GetImportTargets(),
 		ExportTargets: e.GetExportTargets(),
+		Metadata:      e.GetMetadata(),
 	}
 	return r
 }
@@ -9945,6 +10722,14 @@ func (e *VRF) GetExportTargets() []*pb.RouteTarget {
 	return r
 }
 
+func (e *VRF) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VirtualChassis struct {
 	Name         *string
 	Domain       *string
@@ -9953,6 +10738,7 @@ type VirtualChassis struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *VirtualChassis) ConvertToProtoMessage() proto.Message {
@@ -9964,6 +10750,7 @@ func (e *VirtualChassis) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -10044,6 +10831,14 @@ func (e *VirtualChassis) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *VirtualChassis) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VirtualCircuit struct {
 	Cid             *string
 	ProviderNetwork *ProviderNetwork
@@ -10055,6 +10850,7 @@ type VirtualCircuit struct {
 	Comments        *string
 	Tags            []*Tag
 	CustomFields    map[string]*CustomFieldValue
+	Metadata        Metadata
 }
 
 func (e *VirtualCircuit) ConvertToProtoMessage() proto.Message {
@@ -10069,6 +10865,7 @@ func (e *VirtualCircuit) ConvertToProtoMessage() proto.Message {
 		Comments:        e.GetComments(),
 		Tags:            e.GetTags(),
 		CustomFields:    e.GetCustomFields(),
+		Metadata:        e.GetMetadata(),
 	}
 	return r
 }
@@ -10173,6 +10970,14 @@ func (e *VirtualCircuit) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *VirtualCircuit) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VirtualCircuitTermination struct {
 	VirtualCircuit *VirtualCircuit
 	Role           *string
@@ -10180,6 +10985,7 @@ type VirtualCircuitTermination struct {
 	Description    *string
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *VirtualCircuitTermination) ConvertToProtoMessage() proto.Message {
@@ -10190,6 +10996,7 @@ func (e *VirtualCircuitTermination) ConvertToProtoMessage() proto.Message {
 		Description:    e.GetDescription(),
 		Tags:           e.GetTags(),
 		CustomFields:   e.GetCustomFields(),
+		Metadata:       e.GetMetadata(),
 	}
 	return r
 }
@@ -10262,6 +11069,14 @@ func (e *VirtualCircuitTermination) GetCustomFields() map[string]*pb.CustomField
 	return r
 }
 
+func (e *VirtualCircuitTermination) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VirtualCircuitType struct {
 	Name         *string
 	Slug         *string
@@ -10269,6 +11084,7 @@ type VirtualCircuitType struct {
 	Description  *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *VirtualCircuitType) ConvertToProtoMessage() proto.Message {
@@ -10279,6 +11095,7 @@ func (e *VirtualCircuitType) ConvertToProtoMessage() proto.Message {
 		Description:  e.GetDescription(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -10351,6 +11168,14 @@ func (e *VirtualCircuitType) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *VirtualCircuitType) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VirtualDeviceContext struct {
 	Name         *string
 	Device       *Device
@@ -10363,6 +11188,7 @@ type VirtualDeviceContext struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *VirtualDeviceContext) ConvertToProtoMessage() proto.Message {
@@ -10378,6 +11204,7 @@ func (e *VirtualDeviceContext) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -10490,6 +11317,14 @@ func (e *VirtualDeviceContext) GetCustomFields() map[string]*pb.CustomFieldValue
 	return r
 }
 
+func (e *VirtualDeviceContext) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VirtualDisk struct {
 	VirtualMachine *VirtualMachine
 	Name           *string
@@ -10497,6 +11332,7 @@ type VirtualDisk struct {
 	Size           *int64
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *VirtualDisk) ConvertToProtoMessage() proto.Message {
@@ -10507,6 +11343,7 @@ func (e *VirtualDisk) ConvertToProtoMessage() proto.Message {
 		Size:           e.GetSize(),
 		Tags:           e.GetTags(),
 		CustomFields:   e.GetCustomFields(),
+		Metadata:       e.GetMetadata(),
 	}
 	return r
 }
@@ -10579,6 +11416,14 @@ func (e *VirtualDisk) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *VirtualDisk) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type VirtualMachine struct {
 	Name         *string
 	Status       *string
@@ -10598,6 +11443,7 @@ type VirtualMachine struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *VirtualMachine) ConvertToProtoMessage() proto.Message {
@@ -10620,6 +11466,7 @@ func (e *VirtualMachine) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -10788,6 +11635,14 @@ func (e *VirtualMachine) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *VirtualMachine) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type WirelessLAN struct {
 	Ssid        *string
 	Description *string
@@ -10807,6 +11662,7 @@ type WirelessLAN struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *WirelessLAN) ConvertToProtoMessage() proto.Message {
@@ -10823,6 +11679,7 @@ func (e *WirelessLAN) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.Scope != nil {
 		e.Scope.anyWirelessLANScopeValueApplyTo(r)
@@ -10956,6 +11813,14 @@ func (e *WirelessLAN) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *WirelessLAN) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type WirelessLANGroup struct {
 	Name         *string
 	Slug         *string
@@ -10964,6 +11829,7 @@ type WirelessLANGroup struct {
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
 	Comments     *string
+	Metadata     Metadata
 }
 
 func (e *WirelessLANGroup) ConvertToProtoMessage() proto.Message {
@@ -10975,6 +11841,7 @@ func (e *WirelessLANGroup) ConvertToProtoMessage() proto.Message {
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
 		Comments:     e.GetComments(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -11055,6 +11922,14 @@ func (e *WirelessLANGroup) GetComments() *string {
 	return r
 }
 
+func (e *WirelessLANGroup) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type WirelessLink struct {
 	InterfaceA   *Interface
 	InterfaceB   *Interface
@@ -11070,6 +11945,7 @@ type WirelessLink struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *WirelessLink) ConvertToProtoMessage() proto.Message {
@@ -11088,6 +11964,7 @@ func (e *WirelessLink) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -11224,6 +12101,14 @@ func (e *WirelessLink) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *WirelessLink) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CustomField struct {
 	Type                *string
 	RelatedObjectType   *string
@@ -11247,6 +12132,7 @@ type CustomField struct {
 	ChoiceSet           *CustomFieldChoiceSet
 	Comments            *string
 	ObjectTypes         []string
+	Metadata            Metadata
 }
 
 func (e *CustomField) ConvertToProtoMessage() proto.Message {
@@ -11273,6 +12159,7 @@ func (e *CustomField) ConvertToProtoMessage() proto.Message {
 		ChoiceSet:           e.GetChoiceSet(),
 		Comments:            e.GetComments(),
 		ObjectTypes:         e.GetObjectTypes(),
+		Metadata:            e.GetMetadata(),
 	}
 	return r
 }
@@ -11463,12 +12350,21 @@ func (e *CustomField) GetObjectTypes() []string {
 	return r
 }
 
+func (e *CustomField) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CustomFieldChoiceSet struct {
 	Name                *string
 	Description         *string
 	BaseChoices         *string
 	OrderAlphabetically *bool
 	ExtraChoices        []string
+	Metadata            Metadata
 }
 
 func (e *CustomFieldChoiceSet) ConvertToProtoMessage() proto.Message {
@@ -11478,6 +12374,7 @@ func (e *CustomFieldChoiceSet) ConvertToProtoMessage() proto.Message {
 		BaseChoices:         e.GetBaseChoices(),
 		OrderAlphabetically: e.GetOrderAlphabetically(),
 		ExtraChoices:        e.GetExtraChoices(),
+		Metadata:            e.GetMetadata(),
 	}
 	return r
 }
@@ -11532,6 +12429,14 @@ func (e *CustomFieldChoiceSet) GetExtraChoices() []string {
 	return r
 }
 
+func (e *CustomFieldChoiceSet) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type JournalEntry struct {
 	// AssignedObject can be any Entity type
 	AssignedObject anyJournalEntryAssignedObjectValue
@@ -11539,6 +12444,7 @@ type JournalEntry struct {
 	Comments       *string
 	Tags           []*Tag
 	CustomFields   map[string]*CustomFieldValue
+	Metadata       Metadata
 }
 
 func (e *JournalEntry) ConvertToProtoMessage() proto.Message {
@@ -11547,6 +12453,7 @@ func (e *JournalEntry) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	if e.AssignedObject != nil {
 		e.AssignedObject.anyJournalEntryAssignedObjectValueApplyTo(r)
@@ -11616,6 +12523,14 @@ func (e *JournalEntry) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *JournalEntry) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type ModuleTypeProfile struct {
 	Name         *string
 	Description  *string
@@ -11623,6 +12538,7 @@ type ModuleTypeProfile struct {
 	Comments     *string
 	Tags         []*Tag
 	CustomFields map[string]*CustomFieldValue
+	Metadata     Metadata
 }
 
 func (e *ModuleTypeProfile) ConvertToProtoMessage() proto.Message {
@@ -11633,6 +12549,7 @@ func (e *ModuleTypeProfile) ConvertToProtoMessage() proto.Message {
 		Comments:     e.GetComments(),
 		Tags:         e.GetTags(),
 		CustomFields: e.GetCustomFields(),
+		Metadata:     e.GetMetadata(),
 	}
 	return r
 }
@@ -11705,6 +12622,14 @@ func (e *ModuleTypeProfile) GetCustomFields() map[string]*pb.CustomFieldValue {
 	return r
 }
 
+func (e *ModuleTypeProfile) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
+	}
+	return r
+}
+
 type CustomLink struct {
 	Name        *string
 	Enabled     *bool
@@ -11715,6 +12640,7 @@ type CustomLink struct {
 	ButtonClass *string
 	NewWindow   *bool
 	ObjectTypes []string
+	Metadata    Metadata
 }
 
 func (e *CustomLink) ConvertToProtoMessage() proto.Message {
@@ -11728,6 +12654,7 @@ func (e *CustomLink) ConvertToProtoMessage() proto.Message {
 		ButtonClass: e.GetButtonClass(),
 		NewWindow:   e.GetNewWindow(),
 		ObjectTypes: e.GetObjectTypes(),
+		Metadata:    e.GetMetadata(),
 	}
 	return r
 }
@@ -11810,6 +12737,14 @@ func (e *CustomLink) GetObjectTypes() []string {
 		for _, v := range e.ObjectTypes {
 			r = append(r, v)
 		}
+	}
+	return r
+}
+
+func (e *CustomLink) GetMetadata() *structpb.Struct {
+	var r *structpb.Struct
+	if e != nil && e.Metadata != nil {
+		r, _ = structpb.NewStruct(e.Metadata)
 	}
 	return r
 }

--- a/diode/ingester_test.go
+++ b/diode/ingester_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
@@ -1526,6 +1527,462 @@ func TestVirtualDiskMethods(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expected, tt.method(tt.virtualDisk))
+		})
+	}
+}
+
+func TestMetadataConversion(t *testing.T) {
+	tests := []struct {
+		name            string
+		entity          Entity
+		metadata        Metadata
+		getMetadataFunc func(*diodepb.Entity) *structpb.Struct
+	}{
+		{
+			name: "ASN with metadata",
+			entity: &ASN{
+				Asn: Int64(64512),
+				Metadata: Metadata{
+					"source":      "import",
+					"imported_at": "2024-01-01T00:00:00Z",
+					"priority":    1,
+				},
+			},
+			metadata: Metadata{
+				"source":      "import",
+				"imported_at": "2024-01-01T00:00:00Z",
+				"priority":    1,
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetAsn().GetMetadata()
+			},
+		},
+		{
+			name: "Device with metadata",
+			entity: &Device{
+				Name: String("device-1"),
+				Metadata: Metadata{
+					"environment": "production",
+					"owner":       "team-a",
+					"cost_center": 12345,
+				},
+			},
+			metadata: Metadata{
+				"environment": "production",
+				"owner":       "team-a",
+				"cost_center": 12345,
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetDevice().GetMetadata()
+			},
+		},
+		{
+			name: "IPAddress with metadata",
+			entity: &IPAddress{
+				Address: String("192.168.1.1/24"),
+				Metadata: Metadata{
+					"last_seen":  "2024-01-01T00:00:00Z",
+					"discovered": true,
+					"scan_id":    "scan-123",
+				},
+			},
+			metadata: Metadata{
+				"last_seen":  "2024-01-01T00:00:00Z",
+				"discovered": true,
+				"scan_id":    "scan-123",
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetIpAddress().GetMetadata()
+			},
+		},
+		{
+			name: "Site with metadata",
+			entity: &Site{
+				Name: String("site-1"),
+				Metadata: Metadata{
+					"region":    "us-west",
+					"capacity":  500,
+					"is_active": true,
+				},
+			},
+			metadata: Metadata{
+				"region":    "us-west",
+				"capacity":  500,
+				"is_active": true,
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetSite().GetMetadata()
+			},
+		},
+		{
+			name: "Interface with metadata",
+			entity: &Interface{
+				Name: String("eth0"),
+				Metadata: Metadata{
+					"monitored":    true,
+					"vlan_id":      100,
+					"uplink_speed": "10G",
+				},
+			},
+			metadata: Metadata{
+				"monitored":    true,
+				"vlan_id":      100,
+				"uplink_speed": "10G",
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetInterface().GetMetadata()
+			},
+		},
+		{
+			name: "VirtualMachine with metadata",
+			entity: &VirtualMachine{
+				Name: String("vm-1"),
+				Metadata: Metadata{
+					"hypervisor": "vmware",
+					"cluster_id": "cluster-001",
+					"tier":       2,
+				},
+			},
+			metadata: Metadata{
+				"hypervisor": "vmware",
+				"cluster_id": "cluster-001",
+				"tier":       2,
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetVirtualMachine().GetMetadata()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			protoEntity := tt.entity.ConvertToProtoEntity()
+			metadata := tt.getMetadataFunc(protoEntity)
+
+			require.NotNil(t, metadata)
+
+			for key, expectedValue := range tt.metadata {
+				actualValue := metadata.Fields[key]
+				require.NotNil(t, actualValue, "metadata key %s should be present", key)
+
+				switch v := expectedValue.(type) {
+				case string:
+					require.Equal(t, v, actualValue.GetStringValue())
+				case int:
+					require.Equal(t, float64(v), actualValue.GetNumberValue())
+				case bool:
+					require.Equal(t, v, actualValue.GetBoolValue())
+				}
+			}
+		})
+	}
+}
+
+func TestMetadataConversionNil(t *testing.T) {
+	tests := []struct {
+		name            string
+		entity          Entity
+		getMetadataFunc func(*diodepb.Entity) *structpb.Struct
+	}{
+		{
+			name:   "ASN without metadata",
+			entity: &ASN{Asn: Int64(64512)},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetAsn().GetMetadata()
+			},
+		},
+		{
+			name:   "Device without metadata",
+			entity: &Device{Name: String("device-1")},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetDevice().GetMetadata()
+			},
+		},
+		{
+			name:   "IPAddress without metadata",
+			entity: &IPAddress{Address: String("192.168.1.1/24")},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetIpAddress().GetMetadata()
+			},
+		},
+		{
+			name:   "Site without metadata",
+			entity: &Site{Name: String("site-1")},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetSite().GetMetadata()
+			},
+		},
+		{
+			name:   "Interface without metadata",
+			entity: &Interface{Name: String("eth0")},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetInterface().GetMetadata()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			protoEntity := tt.entity.ConvertToProtoEntity()
+
+			metadata := tt.getMetadataFunc(protoEntity)
+			require.Nil(t, metadata)
+		})
+	}
+}
+
+func TestMetadataConversionEmpty(t *testing.T) {
+	tests := []struct {
+		name            string
+		entity          Entity
+		getMetadataFunc func(*diodepb.Entity) *structpb.Struct
+	}{
+		{
+			name: "ASN with empty metadata",
+			entity: &ASN{
+				Asn:      Int64(64512),
+				Metadata: Metadata{},
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetAsn().GetMetadata()
+			},
+		},
+		{
+			name: "Device with empty metadata",
+			entity: &Device{
+				Name:     String("device-1"),
+				Metadata: Metadata{},
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetDevice().GetMetadata()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			protoEntity := tt.entity.ConvertToProtoEntity()
+			metadata := tt.getMetadataFunc(protoEntity)
+
+			require.NotNil(t, metadata)
+			require.Empty(t, metadata.Fields)
+		})
+	}
+}
+
+func TestMetadataConversionComplexTypes(t *testing.T) {
+	tests := []struct {
+		name            string
+		entity          Entity
+		metadata        Metadata
+		getMetadataFunc func(*diodepb.Entity) *structpb.Struct
+	}{
+		{
+			name: "Device with nested metadata",
+			entity: &Device{
+				Name: String("device-1"),
+				Metadata: Metadata{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"timeout": 30,
+					},
+					"tags": []interface{}{"production", "critical"},
+				},
+			},
+			metadata: Metadata{
+				"config": map[string]interface{}{
+					"enabled": true,
+					"timeout": 30,
+				},
+				"tags": []interface{}{"production", "critical"},
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetDevice().GetMetadata()
+			},
+		},
+		{
+			name: "IPAddress with mixed types",
+			entity: &IPAddress{
+				Address: String("10.0.0.1/24"),
+				Metadata: Metadata{
+					"null_value":   nil,
+					"string_value": "test",
+					"number_value": 42.5,
+					"bool_value":   false,
+				},
+			},
+			metadata: Metadata{
+				"null_value":   nil,
+				"string_value": "test",
+				"number_value": 42.5,
+				"bool_value":   false,
+			},
+			getMetadataFunc: func(e *diodepb.Entity) *structpb.Struct {
+				return e.GetIpAddress().GetMetadata()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			protoEntity := tt.entity.ConvertToProtoEntity()
+			metadata := tt.getMetadataFunc(protoEntity)
+
+			require.NotNil(t, metadata)
+
+			for key := range tt.metadata {
+				_, exists := metadata.Fields[key]
+				require.True(t, exists, "metadata key %s should be present", key)
+			}
+		})
+	}
+}
+
+func TestMetadataConversionNestedEntities(t *testing.T) {
+	tests := []struct {
+		name             string
+		entity           Entity
+		parentMetadata   Metadata
+		nestedMetadata   Metadata
+		verifyNestedFunc func(*testing.T, *diodepb.Entity)
+	}{
+		{
+			name: "Device with Site both having metadata",
+			entity: &Device{
+				Name: String("device-1"),
+				Site: &Site{
+					Name: String("site-1"),
+					Metadata: Metadata{
+						"site_region":   "us-west",
+						"site_capacity": 1000,
+					},
+				},
+				Metadata: Metadata{
+					"device_owner": "team-a",
+					"device_tier":  1,
+				},
+			},
+			parentMetadata: Metadata{
+				"device_owner": "team-a",
+				"device_tier":  1,
+			},
+			nestedMetadata: Metadata{
+				"site_region":   "us-west",
+				"site_capacity": 1000,
+			},
+			verifyNestedFunc: func(t *testing.T, protoEntity *diodepb.Entity) {
+				deviceEntity := protoEntity.GetDevice()
+				require.NotNil(t, deviceEntity)
+
+				site := deviceEntity.GetSite()
+				require.NotNil(t, site)
+				require.Equal(t, "site-1", site.GetName())
+			},
+		},
+		{
+			name: "IPAddress with Interface both having metadata",
+			entity: &IPAddress{
+				Address: String("192.168.1.1/24"),
+				AssignedObject: &Interface{
+					Name: String("eth0"),
+					Metadata: Metadata{
+						"interface_speed": "10G",
+						"interface_vlan":  100,
+					},
+				},
+				Metadata: Metadata{
+					"ip_discovered": true,
+					"ip_scan_id":    "scan-123",
+				},
+			},
+			parentMetadata: Metadata{
+				"ip_discovered": true,
+				"ip_scan_id":    "scan-123",
+			},
+			nestedMetadata: Metadata{
+				"interface_speed": "10G",
+				"interface_vlan":  100,
+			},
+			verifyNestedFunc: func(t *testing.T, protoEntity *diodepb.Entity) {
+				ipEntity := protoEntity.GetIpAddress()
+				require.NotNil(t, ipEntity)
+
+				assignedObj := ipEntity.GetAssignedObjectInterface()
+				require.NotNil(t, assignedObj)
+				require.Equal(t, "eth0", assignedObj.GetName())
+			},
+		},
+		{
+			name: "VirtualMachine with Cluster both having metadata",
+			entity: &VirtualMachine{
+				Name: String("vm-1"),
+				Cluster: &Cluster{
+					Name: String("cluster-1"),
+					Metadata: Metadata{
+						"cluster_size": 5,
+						"cluster_type": "production",
+					},
+				},
+				Metadata: Metadata{
+					"vm_hypervisor": "vmware",
+					"vm_template":   "ubuntu-20.04",
+				},
+			},
+			parentMetadata: Metadata{
+				"vm_hypervisor": "vmware",
+				"vm_template":   "ubuntu-20.04",
+			},
+			nestedMetadata: Metadata{
+				"cluster_size": 5,
+				"cluster_type": "production",
+			},
+			verifyNestedFunc: func(t *testing.T, protoEntity *diodepb.Entity) {
+				vmEntity := protoEntity.GetVirtualMachine()
+				require.NotNil(t, vmEntity)
+
+				cluster := vmEntity.GetCluster()
+				require.NotNil(t, cluster)
+				require.Equal(t, "cluster-1", cluster.GetName())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to proto entity
+			protoEntity := tt.entity.ConvertToProtoEntity()
+
+			// Get the parent entity's metadata from the specific entity type
+			var parentMetadata *structpb.Struct
+			switch protoEntity.GetEntity().(type) {
+			case *diodepb.Entity_Device:
+				parentMetadata = protoEntity.GetDevice().GetMetadata()
+			case *diodepb.Entity_IpAddress:
+				parentMetadata = protoEntity.GetIpAddress().GetMetadata()
+			case *diodepb.Entity_VirtualMachine:
+				parentMetadata = protoEntity.GetVirtualMachine().GetMetadata()
+			}
+
+			// Verify parent entity metadata is present
+			require.NotNil(t, parentMetadata, "parent entity should have metadata")
+
+			// Verify parent metadata fields
+			for key, expectedValue := range tt.parentMetadata {
+				actualValue := parentMetadata.Fields[key]
+				require.NotNil(t, actualValue, "parent metadata key %s should be present", key)
+
+				switch v := expectedValue.(type) {
+				case string:
+					require.Equal(t, v, actualValue.GetStringValue())
+				case int:
+					require.Equal(t, float64(v), actualValue.GetNumberValue())
+				case bool:
+					require.Equal(t, v, actualValue.GetBoolValue())
+				}
+			}
+
+			// Verify nested entity structure
+			tt.verifyNestedFunc(t, protoEntity)
 		})
 	}
 }

--- a/diode/otlp_client.go
+++ b/diode/otlp_client.go
@@ -171,12 +171,19 @@ func (c *OTLPClient) Close() error {
 }
 
 // Ingest converts the provided entities to proto messages before exporting them.
-func (c *OTLPClient) Ingest(ctx context.Context, entities []Entity) (*diodepb.IngestResponse, error) {
-	return c.IngestProto(ctx, convertEntitiesToProto(entities))
+func (c *OTLPClient) Ingest(ctx context.Context, entities []Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
+	return c.IngestProto(ctx, convertEntitiesToProto(entities), opts...)
 }
 
 // IngestProto exports proto entities as OTLP log records.
-func (c *OTLPClient) IngestProto(ctx context.Context, entities []*diodepb.Entity) (*diodepb.IngestResponse, error) {
+// IngestRequest metadata from IngestOption will be added as OTLP resource attributes.
+func (c *OTLPClient) IngestProto(ctx context.Context, entities []*diodepb.Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
+	// Apply options to get request-level metadata
+	cfg := &ingestConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	logRecords := make([]*logspb.LogRecord, 0, len(entities))
 	for _, entity := range entities {
 		if entity == nil {
@@ -193,7 +200,7 @@ func (c *OTLPClient) IngestProto(ctx context.Context, entities []*diodepb.Entity
 		return &diodepb.IngestResponse{}, nil
 	}
 
-	request := c.buildExportRequest(logRecords)
+	request := c.buildExportRequest(logRecords, cfg.metadata)
 
 	exportCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
@@ -230,12 +237,12 @@ func (c *OTLPClient) entityToLogRecord(entity *diodepb.Entity) (*logspb.LogRecor
 	}, nil
 }
 
-func (c *OTLPClient) buildExportRequest(logRecords []*logspb.LogRecord) *logsservicepb.ExportLogsServiceRequest {
+func (c *OTLPClient) buildExportRequest(logRecords []*logspb.LogRecord, requestMetadata Metadata) *logsservicepb.ExportLogsServiceRequest {
 	return &logsservicepb.ExportLogsServiceRequest{
 		ResourceLogs: []*logspb.ResourceLogs{
 			{
 				Resource: &resourcepb.Resource{
-					Attributes: c.resourceAttributes(),
+					Attributes: c.resourceAttributes(requestMetadata),
 				},
 				ScopeLogs: []*logspb.ScopeLogs{
 					{
@@ -251,14 +258,58 @@ func (c *OTLPClient) buildExportRequest(logRecords []*logspb.LogRecord) *logsser
 	}
 }
 
-func (c *OTLPClient) resourceAttributes() []*commonpb.KeyValue {
-	return []*commonpb.KeyValue{
+func (c *OTLPClient) resourceAttributes(requestMetadata Metadata) []*commonpb.KeyValue {
+	attrs := []*commonpb.KeyValue{
 		stringKV("service.name", c.appName),
 		stringKV("service.version", c.appVersion),
 		stringKV("os.description", c.platform),
 		stringKV("process.runtime.version", c.goVersion),
 		stringKV("diode.stream", c.stream),
 	}
+
+	// Add request-level metadata as resource attributes with "diode.metadata." prefix
+	if len(requestMetadata) > 0 {
+		for key, value := range requestMetadata {
+			attrs = append(attrs, metadataValueToKV(fmt.Sprintf("diode.metadata.%s", key), value))
+		}
+	}
+
+	return attrs
+}
+
+// metadataValueToKV converts a metadata value to an OTLP KeyValue
+func metadataValueToKV(key string, value interface{}) *commonpb.KeyValue {
+	kv := &commonpb.KeyValue{Key: key}
+
+	switch v := value.(type) {
+	case string:
+		kv.Value = &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{StringValue: v},
+		}
+	case int:
+		kv.Value = &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_IntValue{IntValue: int64(v)},
+		}
+	case int64:
+		kv.Value = &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_IntValue{IntValue: v},
+		}
+	case float64:
+		kv.Value = &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_DoubleValue{DoubleValue: v},
+		}
+	case bool:
+		kv.Value = &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_BoolValue{BoolValue: v},
+		}
+	default:
+		// For complex types, convert to string representation
+		kv.Value = &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{StringValue: fmt.Sprintf("%v", v)},
+		}
+	}
+
+	return kv
 }
 
 func (c *OTLPClient) resolveEntityType(entity *diodepb.Entity) string {

--- a/diode/otlp_client_test.go
+++ b/diode/otlp_client_test.go
@@ -160,3 +160,124 @@ func attributesToMap(attributes []*commonpb.KeyValue) map[string]string {
 	}
 	return result
 }
+
+func TestOTLPClientIngestWithMetadata(t *testing.T) {
+	service := &mockLogsService{}
+	target, cleanup := startMockOTLPServer(t, service)
+	defer cleanup()
+
+	client, err := NewOTLPClient(target, "otlp-producer", "1.2.3")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	ctx := context.Background()
+
+	md := Metadata{
+		"batch_id": "batch-999",
+		"source":   "otlp_test",
+		"priority": 5,
+		"enabled":  true,
+		// Additional type tests
+		"int64_value":   int64(9223372036854775807),
+		"float_value":   3.14159,
+		"bool_false":    false,
+		"empty_string":  "",
+		"zero_int":      0,
+		"zero_float":    0.0,
+		"array_value":   []any{"item1", "item2", 123},
+		"nested_object": map[string]any{"key": "value"},
+		"nil_value":     nil,
+	}
+
+	resp, err := client.Ingest(ctx, []Entity{
+		&Site{Name: String("Test Site"), Metadata: Metadata{"foo": "bar"}},
+	}, WithIngestMetadata(md))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	service.mu.Lock()
+	require.Len(t, service.requests, 1)
+
+	req := service.requests[0]
+	require.Len(t, req.ResourceLogs, 1)
+
+	resourceLogs := req.ResourceLogs[0]
+	require.NotNil(t, resourceLogs.Resource)
+
+	// Verify standard resource attributes
+	resourceAttr := attributesToMap(resourceLogs.Resource.Attributes)
+	assert.Equal(t, "otlp-producer", resourceAttr["service.name"])
+	assert.Equal(t, "1.2.3", resourceAttr["service.version"])
+
+	// Verify metadata is added to resource attributes with diode.metadata prefix
+	assert.Equal(t, "batch-999", resourceAttr["diode.metadata.batch_id"])
+	assert.Equal(t, "otlp_test", resourceAttr["diode.metadata.source"])
+
+	// Verify all metadata types are handled correctly
+	foundTypes := make(map[string]bool)
+	for _, attr := range resourceLogs.Resource.Attributes {
+		switch attr.Key {
+		case "diode.metadata.priority":
+			assert.Equal(t, int64(5), attr.Value.GetIntValue())
+			foundTypes["priority"] = true
+		case "diode.metadata.enabled":
+			assert.Equal(t, true, attr.Value.GetBoolValue())
+			foundTypes["enabled"] = true
+		case "diode.metadata.int64_value":
+			assert.Equal(t, int64(9223372036854775807), attr.Value.GetIntValue())
+			foundTypes["int64"] = true
+		case "diode.metadata.float_value":
+			assert.InDelta(t, 3.14159, attr.Value.GetDoubleValue(), 0.00001)
+			foundTypes["float"] = true
+		case "diode.metadata.bool_false":
+			assert.Equal(t, false, attr.Value.GetBoolValue())
+			foundTypes["bool_false"] = true
+		case "diode.metadata.zero_int":
+			assert.Equal(t, int64(0), attr.Value.GetIntValue())
+			foundTypes["zero_int"] = true
+		case "diode.metadata.zero_float":
+			assert.Equal(t, float64(0), attr.Value.GetDoubleValue())
+			foundTypes["zero_float"] = true
+		}
+	}
+
+	// Verify all expected primitive types were found
+	assert.True(t, foundTypes["priority"], "int metadata should be present")
+	assert.True(t, foundTypes["enabled"], "bool true metadata should be present")
+	assert.True(t, foundTypes["int64"], "int64 metadata should be present")
+	assert.True(t, foundTypes["float"], "float metadata should be present")
+	assert.True(t, foundTypes["bool_false"], "bool false metadata should be present")
+	assert.True(t, foundTypes["zero_int"], "zero int metadata should be present")
+	assert.True(t, foundTypes["zero_float"], "zero float metadata should be present")
+
+	// Verify string types (including empty string)
+	assert.Equal(t, "", resourceAttr["diode.metadata.empty_string"])
+
+	// Verify complex types are converted to strings (using fmt.Sprintf("%v", value))
+	assert.Contains(t, resourceAttr["diode.metadata.array_value"], "item1")
+	assert.Contains(t, resourceAttr["diode.metadata.array_value"], "item2")
+	assert.Contains(t, resourceAttr["diode.metadata.nested_object"], "key")
+	assert.Contains(t, resourceAttr["diode.metadata.nested_object"], "value")
+
+	// Verify nil is converted to string "<nil>"
+	assert.Equal(t, "<nil>", resourceAttr["diode.metadata.nil_value"])
+
+	service.mu.Unlock()
+
+	resp, err = client.Ingest(ctx, []Entity{
+		&Site{Name: String("Test Site 2")},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	require.Len(t, service.requests, 2)
+
+	req2 := service.requests[1]
+	resourceAttr2 := attributesToMap(req2.ResourceLogs[0].Resource.Attributes)
+	assert.NotContains(t, resourceAttr2, "diode.metadata.batch_id")
+	assert.NotContains(t, resourceAttr2, "diode.metadata.source")
+}

--- a/diode/v1/diodepb/ingester.pb.go
+++ b/diode/v1/diodepb/ingester.pb.go
@@ -6,7 +6,7 @@
 
 // Generated Code. DO NOT EDIT.
 // Source: NetBox v4.4.2
-// Timestamp: 2025-10-02 12:39:08Z
+// Timestamp: 2025-11-14 18:10:21Z
 
 package diodepb
 
@@ -14,6 +14,8 @@ import (
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -1582,6 +1584,7 @@ type IngestRequest struct {
 	ProducerAppVersion string                 `protobuf:"bytes,5,opt,name=producer_app_version,json=producerAppVersion,proto3" json:"producer_app_version,omitempty"`
 	SdkName            string                 `protobuf:"bytes,6,opt,name=sdk_name,json=sdkName,proto3" json:"sdk_name,omitempty"`
 	SdkVersion         string                 `protobuf:"bytes,7,opt,name=sdk_version,json=sdkVersion,proto3" json:"sdk_version,omitempty"`
+	Metadata           *structpb.Struct       `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -1665,6 +1668,13 @@ func (x *IngestRequest) GetSdkVersion() string {
 	return ""
 }
 
+func (x *IngestRequest) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type IngestResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Errors        []string               `protobuf:"bytes,1,rep,name=errors,proto3" json:"errors,omitempty"`
@@ -1718,6 +1728,7 @@ type ASN struct {
 	Comments      *string                      `protobuf:"bytes,5,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1801,6 +1812,13 @@ func (x *ASN) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ASN) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ASNRange struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1812,6 +1830,7 @@ type ASNRange struct {
 	Description   *string                      `protobuf:"bytes,7,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,8,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,9,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1909,6 +1928,13 @@ func (x *ASNRange) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ASNRange) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Aggregate struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Prefix        string                       `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
@@ -1919,6 +1945,7 @@ type Aggregate struct {
 	Comments      *string                      `protobuf:"bytes,6,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,7,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,8,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,9,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2009,6 +2036,13 @@ func (x *Aggregate) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Aggregate) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Cable struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Type          *string                      `protobuf:"bytes,1,opt,name=type,proto3,oneof" json:"type,omitempty"`
@@ -2024,6 +2058,7 @@ type Cable struct {
 	Comments      *string                      `protobuf:"bytes,11,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,12,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,13,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,14,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2149,11 +2184,19 @@ func (x *Cable) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Cable) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type CablePath struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	IsActive      *bool                  `protobuf:"varint,1,opt,name=is_active,json=isActive,proto3,oneof" json:"is_active,omitempty"`
 	IsComplete    *bool                  `protobuf:"varint,2,opt,name=is_complete,json=isComplete,proto3,oneof" json:"is_complete,omitempty"`
 	IsSplit       *bool                  `protobuf:"varint,3,opt,name=is_split,json=isSplit,proto3,oneof" json:"is_split,omitempty"`
+	Metadata      *structpb.Struct       `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2209,6 +2252,13 @@ func (x *CablePath) GetIsSplit() bool {
 	return false
 }
 
+func (x *CablePath) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type CableTermination struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Cable    *Cable                 `protobuf:"bytes,1,opt,name=cable,proto3" json:"cable,omitempty"`
@@ -2225,6 +2275,7 @@ type CableTermination struct {
 	//	*CableTermination_TerminationPowerPort
 	//	*CableTermination_TerminationRearPort
 	Termination   isCableTermination_Termination `protobuf_oneof:"termination"`
+	Metadata      *structpb.Struct               `protobuf:"bytes,12,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2361,6 +2412,13 @@ func (x *CableTermination) GetTerminationRearPort() *RearPort {
 	return nil
 }
 
+func (x *CableTermination) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isCableTermination_Termination interface {
 	isCableTermination_Termination()
 }
@@ -2437,6 +2495,7 @@ type Circuit struct {
 	Tags            []*Tag                       `protobuf:"bytes,14,rep,name=tags,proto3" json:"tags,omitempty"`
 	Assignments     []*CircuitGroupAssignment    `protobuf:"bytes,15,rep,name=assignments,proto3" json:"assignments,omitempty"`
 	CustomFields    map[string]*CustomFieldValue `protobuf:"bytes,16,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata        *structpb.Struct             `protobuf:"bytes,17,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -2583,6 +2642,13 @@ func (x *Circuit) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Circuit) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type CircuitGroup struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -2591,6 +2657,7 @@ type CircuitGroup struct {
 	Tenant        *Tenant                      `protobuf:"bytes,4,opt,name=tenant,proto3,oneof" json:"tenant,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2667,6 +2734,13 @@ func (x *CircuitGroup) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *CircuitGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type CircuitGroupAssignment struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Group *CircuitGroup          `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
@@ -2677,6 +2751,7 @@ type CircuitGroupAssignment struct {
 	Member        isCircuitGroupAssignment_Member `protobuf_oneof:"member"`
 	Priority      *string                         `protobuf:"bytes,4,opt,name=priority,proto3,oneof" json:"priority,omitempty"`
 	Tags          []*Tag                          `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
+	Metadata      *structpb.Struct                `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2757,6 +2832,13 @@ func (x *CircuitGroupAssignment) GetTags() []*Tag {
 	return nil
 }
 
+func (x *CircuitGroupAssignment) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isCircuitGroupAssignment_Member interface {
 	isCircuitGroupAssignment_Member()
 }
@@ -2793,6 +2875,7 @@ type CircuitTermination struct {
 	MarkConnected *bool                            `protobuf:"varint,13,opt,name=mark_connected,json=markConnected,proto3,oneof" json:"mark_connected,omitempty"`
 	Tags          []*Tag                           `protobuf:"bytes,14,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue     `protobuf:"bytes,15,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct                 `protobuf:"bytes,16,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2949,6 +3032,13 @@ func (x *CircuitTermination) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *CircuitTermination) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isCircuitTermination_Termination interface {
 	isCircuitTermination_Termination()
 }
@@ -2991,6 +3081,7 @@ type CircuitType struct {
 	Description   *string                      `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3067,6 +3158,13 @@ func (x *CircuitType) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *CircuitType) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Cluster struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Name   string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -3085,6 +3183,7 @@ type Cluster struct {
 	Comments      *string                      `protobuf:"bytes,11,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,12,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,13,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,14,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3225,6 +3324,13 @@ func (x *Cluster) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Cluster) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isCluster_Scope interface {
 	isCluster_Scope()
 }
@@ -3260,6 +3366,7 @@ type ClusterGroup struct {
 	Description   *string                      `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,5,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3329,6 +3436,13 @@ func (x *ClusterGroup) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ClusterGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ClusterType struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -3336,6 +3450,7 @@ type ClusterType struct {
 	Description   *string                      `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,5,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3405,6 +3520,13 @@ func (x *ClusterType) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ClusterType) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ConsolePort struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Device        *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -3417,6 +3539,7 @@ type ConsolePort struct {
 	MarkConnected *bool                        `protobuf:"varint,8,opt,name=mark_connected,json=markConnected,proto3,oneof" json:"mark_connected,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,10,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,11,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3521,6 +3644,13 @@ func (x *ConsolePort) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ConsolePort) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ConsoleServerPort struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Device        *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -3533,6 +3663,7 @@ type ConsoleServerPort struct {
 	MarkConnected *bool                        `protobuf:"varint,8,opt,name=mark_connected,json=markConnected,proto3,oneof" json:"mark_connected,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,10,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,11,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3637,6 +3768,13 @@ func (x *ConsoleServerPort) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ConsoleServerPort) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Contact struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Deprecated: Marked as deprecated in diode/v1/ingester.proto.
@@ -3652,6 +3790,7 @@ type Contact struct {
 	Tags          []*Tag                       `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,11,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Groups        []*ContactGroup              `protobuf:"bytes,12,rep,name=groups,proto3" json:"groups,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,13,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3771,6 +3910,13 @@ func (x *Contact) GetGroups() []*ContactGroup {
 	return nil
 }
 
+func (x *Contact) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ContactAssignment struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Object:
@@ -3874,6 +4020,7 @@ type ContactAssignment struct {
 	Priority      *string                      `protobuf:"bytes,91,opt,name=priority,proto3,oneof" json:"priority,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,92,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,93,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,99,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4787,6 +4934,13 @@ func (x *ContactAssignment) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ContactAssignment) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isContactAssignment_Object interface {
 	isContactAssignment_Object()
 }
@@ -5358,6 +5512,7 @@ type ContactGroup struct {
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Comments      *string                      `protobuf:"bytes,7,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5441,6 +5596,13 @@ func (x *ContactGroup) GetComments() string {
 	return ""
 }
 
+func (x *ContactGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ContactRole struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -5448,6 +5610,7 @@ type ContactRole struct {
 	Description   *string                      `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,5,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5513,6 +5676,13 @@ func (x *ContactRole) GetTags() []*Tag {
 func (x *ContactRole) GetCustomFields() map[string]*CustomFieldValue {
 	if x != nil {
 		return x.CustomFields
+	}
+	return nil
+}
+
+func (x *ContactRole) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
 	}
 	return nil
 }
@@ -7326,6 +7496,7 @@ type Device struct {
 	Comments       *string                      `protobuf:"bytes,25,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags           []*Tag                       `protobuf:"bytes,26,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue `protobuf:"bytes,27,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct             `protobuf:"bytes,28,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -7549,6 +7720,13 @@ func (x *Device) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Device) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type DeviceBay struct {
 	state           protoimpl.MessageState       `protogen:"open.v1"`
 	Device          *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -7558,6 +7736,7 @@ type DeviceBay struct {
 	InstalledDevice *Device                      `protobuf:"bytes,5,opt,name=installed_device,json=installedDevice,proto3,oneof" json:"installed_device,omitempty"`
 	Tags            []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields    map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata        *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -7641,6 +7820,13 @@ func (x *DeviceBay) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *DeviceBay) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type DeviceRole struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -7652,6 +7838,7 @@ type DeviceRole struct {
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Parent        *DeviceRole                  `protobuf:"bytes,8,opt,name=parent,proto3,oneof" json:"parent,omitempty"`
 	Comments      *string                      `protobuf:"bytes,9,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7749,6 +7936,13 @@ func (x *DeviceRole) GetComments() string {
 	return ""
 }
 
+func (x *DeviceRole) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type DeviceType struct {
 	state                  protoimpl.MessageState       `protogen:"open.v1"`
 	Manufacturer           *Manufacturer                `protobuf:"bytes,1,opt,name=manufacturer,proto3" json:"manufacturer,omitempty"`
@@ -7767,6 +7961,7 @@ type DeviceType struct {
 	Comments               *string                      `protobuf:"bytes,14,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags                   []*Tag                       `protobuf:"bytes,15,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields           map[string]*CustomFieldValue `protobuf:"bytes,16,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata               *structpb.Struct             `protobuf:"bytes,17,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -7913,6 +8108,13 @@ func (x *DeviceType) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *DeviceType) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type FHRPGroup struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          *string                      `protobuf:"bytes,1,opt,name=name,proto3,oneof" json:"name,omitempty"`
@@ -7924,6 +8126,7 @@ type FHRPGroup struct {
 	Comments      *string                      `protobuf:"bytes,7,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,8,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,9,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8017,6 +8220,13 @@ func (x *FHRPGroup) GetTags() []*Tag {
 func (x *FHRPGroup) GetCustomFields() map[string]*CustomFieldValue {
 	if x != nil {
 		return x.CustomFields
+	}
+	return nil
+}
+
+func (x *FHRPGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
 	}
 	return nil
 }
@@ -8121,6 +8331,7 @@ type FHRPGroupAssignment struct {
 	//	*FHRPGroupAssignment_InterfaceCustomLink
 	Interface     isFHRPGroupAssignment_Interface `protobuf_oneof:"interface"`
 	Priority      int64                           `protobuf:"varint,90,opt,name=priority,proto3" json:"priority,omitempty"`
+	Metadata      *structpb.Struct                `protobuf:"bytes,96,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -9013,6 +9224,13 @@ func (x *FHRPGroupAssignment) GetPriority() int64 {
 	return 0
 }
 
+func (x *FHRPGroupAssignment) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isFHRPGroupAssignment_Interface interface {
 	isFHRPGroupAssignment_Interface()
 }
@@ -9589,6 +9807,7 @@ type FrontPort struct {
 	MarkConnected    *bool                        `protobuf:"varint,10,opt,name=mark_connected,json=markConnected,proto3,oneof" json:"mark_connected,omitempty"`
 	Tags             []*Tag                       `protobuf:"bytes,11,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields     map[string]*CustomFieldValue `protobuf:"bytes,12,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata         *structpb.Struct             `protobuf:"bytes,13,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -9703,6 +9922,13 @@ func (x *FrontPort) GetTags() []*Tag {
 func (x *FrontPort) GetCustomFields() map[string]*CustomFieldValue {
 	if x != nil {
 		return x.CustomFields
+	}
+	return nil
+}
+
+func (x *FrontPort) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
 	}
 	return nil
 }
@@ -11256,6 +11482,7 @@ type IKEPolicy struct {
 	Tags          []*Tag                       `protobuf:"bytes,7,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,8,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Proposals     []*IKEProposal               `protobuf:"bytes,9,rep,name=proposals,proto3" json:"proposals,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -11353,6 +11580,13 @@ func (x *IKEPolicy) GetProposals() []*IKEProposal {
 	return nil
 }
 
+func (x *IKEPolicy) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type IKEProposal struct {
 	state                   protoimpl.MessageState       `protogen:"open.v1"`
 	Name                    string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -11365,6 +11599,7 @@ type IKEProposal struct {
 	Comments                *string                      `protobuf:"bytes,8,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags                    []*Tag                       `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields            map[string]*CustomFieldValue `protobuf:"bytes,10,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata                *structpb.Struct             `protobuf:"bytes,11,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -11469,6 +11704,13 @@ func (x *IKEProposal) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *IKEProposal) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type IPAddress struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Address string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
@@ -11488,6 +11730,7 @@ type IPAddress struct {
 	Comments       *string                      `protobuf:"bytes,12,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags           []*Tag                       `protobuf:"bytes,13,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue `protobuf:"bytes,14,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct             `protobuf:"bytes,15,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -11633,6 +11876,13 @@ func (x *IPAddress) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *IPAddress) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isIPAddress_AssignedObject interface {
 	isIPAddress_AssignedObject()
 }
@@ -11669,6 +11919,7 @@ type IPRange struct {
 	MarkUtilized  *bool                        `protobuf:"varint,10,opt,name=mark_utilized,json=markUtilized,proto3,oneof" json:"mark_utilized,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,11,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	MarkPopulated *bool                        `protobuf:"varint,12,opt,name=mark_populated,json=markPopulated,proto3,oneof" json:"mark_populated,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,13,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -11787,6 +12038,13 @@ func (x *IPRange) GetMarkPopulated() bool {
 	return false
 }
 
+func (x *IPRange) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type IPSecPolicy struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -11796,6 +12054,7 @@ type IPSecPolicy struct {
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Proposals     []*IPSecProposal             `protobuf:"bytes,7,rep,name=proposals,proto3" json:"proposals,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -11879,6 +12138,13 @@ func (x *IPSecPolicy) GetProposals() []*IPSecProposal {
 	return nil
 }
 
+func (x *IPSecPolicy) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type IPSecProfile struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -11889,6 +12155,7 @@ type IPSecProfile struct {
 	Comments      *string                      `protobuf:"bytes,6,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,7,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,8,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,9,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -11979,6 +12246,13 @@ func (x *IPSecProfile) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *IPSecProfile) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type IPSecProposal struct {
 	state                   protoimpl.MessageState       `protogen:"open.v1"`
 	Name                    string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -11990,6 +12264,7 @@ type IPSecProposal struct {
 	Comments                *string                      `protobuf:"bytes,7,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags                    []*Tag                       `protobuf:"bytes,8,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields            map[string]*CustomFieldValue `protobuf:"bytes,9,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata                *structpb.Struct             `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -12087,6 +12362,13 @@ func (x *IPSecProposal) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *IPSecProposal) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Interface struct {
 	state                 protoimpl.MessageState       `protogen:"open.v1"`
 	Device                *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -12123,6 +12405,7 @@ type Interface struct {
 	Vdcs                  []*VirtualDeviceContext      `protobuf:"bytes,32,rep,name=vdcs,proto3" json:"vdcs,omitempty"`
 	TaggedVlans           []*VLAN                      `protobuf:"bytes,33,rep,name=tagged_vlans,json=taggedVlans,proto3" json:"tagged_vlans,omitempty"`
 	WirelessLans          []*WirelessLAN               `protobuf:"bytes,34,rep,name=wireless_lans,json=wirelessLans,proto3" json:"wireless_lans,omitempty"`
+	Metadata              *structpb.Struct             `protobuf:"bytes,35,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -12395,6 +12678,13 @@ func (x *Interface) GetWirelessLans() []*WirelessLAN {
 	return nil
 }
 
+func (x *Interface) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type InventoryItem struct {
 	state        protoimpl.MessageState `protogen:"open.v1"`
 	Device       *Device                `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -12421,6 +12711,7 @@ type InventoryItem struct {
 	Component     isInventoryItem_Component    `protobuf_oneof:"component"`
 	Tags          []*Tag                       `protobuf:"bytes,20,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,21,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,22,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -12623,6 +12914,13 @@ func (x *InventoryItem) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *InventoryItem) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isInventoryItem_Component interface {
 	isInventoryItem_Component()
 }
@@ -12677,6 +12975,7 @@ type InventoryItemRole struct {
 	Description   *string                      `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -12753,6 +13052,13 @@ func (x *InventoryItemRole) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *InventoryItemRole) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type L2VPN struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Identifier    *int64                       `protobuf:"varint,1,opt,name=identifier,proto3,oneof" json:"identifier,omitempty"`
@@ -12767,6 +13073,7 @@ type L2VPN struct {
 	ImportTargets []*RouteTarget               `protobuf:"bytes,10,rep,name=import_targets,json=importTargets,proto3" json:"import_targets,omitempty"`
 	ExportTargets []*RouteTarget               `protobuf:"bytes,11,rep,name=export_targets,json=exportTargets,proto3" json:"export_targets,omitempty"`
 	Status        *string                      `protobuf:"bytes,12,opt,name=status,proto3,oneof" json:"status,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,13,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -12885,6 +13192,13 @@ func (x *L2VPN) GetStatus() string {
 	return ""
 }
 
+func (x *L2VPN) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type L2VPNTermination struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	L2Vpn *L2VPN                 `protobuf:"bytes,1,opt,name=l2vpn,proto3" json:"l2vpn,omitempty"`
@@ -12986,6 +13300,7 @@ type L2VPNTermination struct {
 	AssignedObject isL2VPNTermination_AssignedObject `protobuf_oneof:"assigned_object"`
 	Tags           []*Tag                            `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue      `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct                  `protobuf:"bytes,97,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -13885,6 +14200,13 @@ func (x *L2VPNTermination) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *L2VPNTermination) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isL2VPNTermination_AssignedObject interface {
 	isL2VPNTermination_AssignedObject()
 }
@@ -14461,6 +14783,7 @@ type Location struct {
 	Tags          []*Tag                       `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,10,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Comments      *string                      `protobuf:"bytes,11,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,12,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -14572,6 +14895,13 @@ func (x *Location) GetComments() string {
 	return ""
 }
 
+func (x *Location) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type MACAddress struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	MacAddress string                 `protobuf:"bytes,1,opt,name=mac_address,json=macAddress,proto3" json:"mac_address,omitempty"`
@@ -14584,6 +14914,7 @@ type MACAddress struct {
 	Comments       *string                      `protobuf:"bytes,5,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags           []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -14678,6 +15009,13 @@ func (x *MACAddress) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *MACAddress) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isMACAddress_AssignedObject interface {
 	isMACAddress_AssignedObject()
 }
@@ -14701,6 +15039,7 @@ type Manufacturer struct {
 	Description   *string                      `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,5,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -14770,6 +15109,13 @@ func (x *Manufacturer) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Manufacturer) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Module struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Device        *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -14782,6 +15128,7 @@ type Module struct {
 	Comments      *string                      `protobuf:"bytes,8,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,10,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,11,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -14886,6 +15233,13 @@ func (x *Module) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Module) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ModuleBay struct {
 	state           protoimpl.MessageState       `protogen:"open.v1"`
 	Device          *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -14897,6 +15251,7 @@ type ModuleBay struct {
 	Description     *string                      `protobuf:"bytes,7,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags            []*Tag                       `protobuf:"bytes,8,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields    map[string]*CustomFieldValue `protobuf:"bytes,9,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata        *structpb.Struct             `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -14994,6 +15349,13 @@ func (x *ModuleBay) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ModuleBay) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ModuleType struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Manufacturer  *Manufacturer                `protobuf:"bytes,1,opt,name=manufacturer,proto3" json:"manufacturer,omitempty"`
@@ -15008,6 +15370,7 @@ type ModuleType struct {
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,10,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Profile       *ModuleTypeProfile           `protobuf:"bytes,11,opt,name=profile,proto3,oneof" json:"profile,omitempty"`
 	Attributes    *string                      `protobuf:"bytes,12,opt,name=attributes,proto3,oneof" json:"attributes,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,13,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15126,6 +15489,13 @@ func (x *ModuleType) GetAttributes() string {
 	return ""
 }
 
+func (x *ModuleType) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Platform struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -15136,6 +15506,7 @@ type Platform struct {
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Parent        *Platform                    `protobuf:"bytes,7,opt,name=parent,proto3,oneof" json:"parent,omitempty"`
 	Comments      *string                      `protobuf:"bytes,8,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,9,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15226,6 +15597,13 @@ func (x *Platform) GetComments() string {
 	return ""
 }
 
+func (x *Platform) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type PowerFeed struct {
 	state          protoimpl.MessageState       `protogen:"open.v1"`
 	PowerPanel     *PowerPanel                  `protobuf:"bytes,1,opt,name=power_panel,json=powerPanel,proto3" json:"power_panel,omitempty"`
@@ -15244,6 +15622,7 @@ type PowerFeed struct {
 	Comments       *string                      `protobuf:"bytes,14,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags           []*Tag                       `protobuf:"bytes,15,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue `protobuf:"bytes,16,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct             `protobuf:"bytes,17,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -15390,6 +15769,13 @@ func (x *PowerFeed) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *PowerFeed) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type PowerOutlet struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Device        *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -15405,6 +15791,7 @@ type PowerOutlet struct {
 	Tags          []*Tag                       `protobuf:"bytes,11,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,12,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Status        *string                      `protobuf:"bytes,13,opt,name=status,proto3,oneof" json:"status,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,14,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15530,6 +15917,13 @@ func (x *PowerOutlet) GetStatus() string {
 	return ""
 }
 
+func (x *PowerOutlet) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type PowerPanel struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Site          *Site                        `protobuf:"bytes,1,opt,name=site,proto3" json:"site,omitempty"`
@@ -15539,6 +15933,7 @@ type PowerPanel struct {
 	Comments      *string                      `protobuf:"bytes,5,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15622,6 +16017,13 @@ func (x *PowerPanel) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *PowerPanel) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type PowerPort struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Device        *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -15635,6 +16037,7 @@ type PowerPort struct {
 	MarkConnected *bool                        `protobuf:"varint,9,opt,name=mark_connected,json=markConnected,proto3,oneof" json:"mark_connected,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,11,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,12,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15746,6 +16149,13 @@ func (x *PowerPort) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *PowerPort) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Prefix struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Prefix string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
@@ -15767,6 +16177,7 @@ type Prefix struct {
 	Comments      *string                      `protobuf:"bytes,14,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,15,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,16,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,17,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15928,6 +16339,13 @@ func (x *Prefix) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Prefix) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isPrefix_Scope interface {
 	isPrefix_Scope()
 }
@@ -15966,6 +16384,7 @@ type Provider struct {
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Accounts      []*ProviderAccount           `protobuf:"bytes,7,rep,name=accounts,proto3" json:"accounts,omitempty"`
 	Asns          []*ASN                       `protobuf:"bytes,8,rep,name=asns,proto3" json:"asns,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,9,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16056,6 +16475,13 @@ func (x *Provider) GetAsns() []*ASN {
 	return nil
 }
 
+func (x *Provider) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ProviderAccount struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Provider      *Provider                    `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
@@ -16065,6 +16491,7 @@ type ProviderAccount struct {
 	Comments      *string                      `protobuf:"bytes,5,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16148,6 +16575,13 @@ func (x *ProviderAccount) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ProviderAccount) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ProviderNetwork struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Provider      *Provider                    `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
@@ -16157,6 +16591,7 @@ type ProviderNetwork struct {
 	Comments      *string                      `protobuf:"bytes,5,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16240,6 +16675,13 @@ func (x *ProviderNetwork) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ProviderNetwork) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type RIR struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -16248,6 +16690,7 @@ type RIR struct {
 	Description   *string                      `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16324,6 +16767,13 @@ func (x *RIR) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *RIR) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Rack struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -16354,6 +16804,7 @@ type Rack struct {
 	Tags          []*Tag                       `protobuf:"bytes,26,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,27,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	OuterHeight   *int64                       `protobuf:"varint,28,opt,name=outer_height,json=outerHeight,proto3,oneof" json:"outer_height,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,29,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16584,6 +17035,13 @@ func (x *Rack) GetOuterHeight() int64 {
 	return 0
 }
 
+func (x *Rack) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type RackReservation struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Rack          *Rack                        `protobuf:"bytes,1,opt,name=rack,proto3" json:"rack,omitempty"`
@@ -16594,6 +17052,7 @@ type RackReservation struct {
 	Tags          []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Status        *string                      `protobuf:"bytes,8,opt,name=status,proto3,oneof" json:"status,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,9,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16684,6 +17143,13 @@ func (x *RackReservation) GetStatus() string {
 	return ""
 }
 
+func (x *RackReservation) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type RackRole struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -16692,6 +17158,7 @@ type RackRole struct {
 	Description   *string                      `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16768,6 +17235,13 @@ func (x *RackRole) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *RackRole) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type RackType struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Manufacturer  *Manufacturer                `protobuf:"bytes,1,opt,name=manufacturer,proto3" json:"manufacturer,omitempty"`
@@ -16790,6 +17264,7 @@ type RackType struct {
 	Tags          []*Tag                       `protobuf:"bytes,18,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,19,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	OuterHeight   *int64                       `protobuf:"varint,20,opt,name=outer_height,json=outerHeight,proto3,oneof" json:"outer_height,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,21,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16964,6 +17439,13 @@ func (x *RackType) GetOuterHeight() int64 {
 	return 0
 }
 
+func (x *RackType) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type RearPort struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Device        *Device                      `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
@@ -16977,6 +17459,7 @@ type RearPort struct {
 	MarkConnected *bool                        `protobuf:"varint,9,opt,name=mark_connected,json=markConnected,proto3,oneof" json:"mark_connected,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,11,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,12,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17088,6 +17571,13 @@ func (x *RearPort) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *RearPort) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Region struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -17097,6 +17587,7 @@ type Region struct {
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Comments      *string                      `protobuf:"bytes,7,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17180,6 +17671,13 @@ func (x *Region) GetComments() string {
 	return ""
 }
 
+func (x *Region) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Role struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -17188,6 +17686,7 @@ type Role struct {
 	Description   *string                      `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17264,6 +17763,13 @@ func (x *Role) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Role) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type RouteTarget struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -17272,6 +17778,7 @@ type RouteTarget struct {
 	Comments      *string                      `protobuf:"bytes,4,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17348,6 +17855,13 @@ func (x *RouteTarget) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *RouteTarget) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Service struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Deprecated: Marked as deprecated in diode/v1/ingester.proto.
@@ -17368,6 +17882,7 @@ type Service struct {
 	//	*Service_ParentObjectFhrpGroup
 	//	*Service_ParentObjectVirtualMachine
 	ParentObject  isService_ParentObject `protobuf_oneof:"parent_object"`
+	Metadata      *structpb.Struct       `protobuf:"bytes,14,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17508,6 +18023,13 @@ func (x *Service) GetParentObjectVirtualMachine() *VirtualMachine {
 	return nil
 }
 
+func (x *Service) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isService_ParentObject interface {
 	isService_ParentObject()
 }
@@ -17549,6 +18071,7 @@ type Site struct {
 	Tags            []*Tag                       `protobuf:"bytes,15,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields    map[string]*CustomFieldValue `protobuf:"bytes,16,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Asns            []*ASN                       `protobuf:"bytes,17,rep,name=asns,proto3" json:"asns,omitempty"`
+	Metadata        *structpb.Struct             `protobuf:"bytes,18,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -17702,6 +18225,13 @@ func (x *Site) GetAsns() []*ASN {
 	return nil
 }
 
+func (x *Site) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type SiteGroup struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -17711,6 +18241,7 @@ type SiteGroup struct {
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Comments      *string                      `protobuf:"bytes,7,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17794,6 +18325,13 @@ func (x *SiteGroup) GetComments() string {
 	return ""
 }
 
+func (x *SiteGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Tag struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -17802,6 +18340,7 @@ type Tag struct {
 	Description   *string                `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Weight        *int64                 `protobuf:"varint,5,opt,name=weight,proto3,oneof" json:"weight,omitempty"`
 	ObjectTypes   []string               `protobuf:"bytes,6,rep,name=object_types,json=objectTypes,proto3" json:"object_types,omitempty"`
+	Metadata      *structpb.Struct       `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17878,6 +18417,13 @@ func (x *Tag) GetObjectTypes() []string {
 	return nil
 }
 
+func (x *Tag) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Tenant struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -17887,6 +18433,7 @@ type Tenant struct {
 	Comments      *string                      `protobuf:"bytes,5,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17970,6 +18517,13 @@ func (x *Tenant) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Tenant) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type TenantGroup struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -17979,6 +18533,7 @@ type TenantGroup struct {
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Comments      *string                      `protobuf:"bytes,7,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -18062,6 +18617,13 @@ func (x *TenantGroup) GetComments() string {
 	return ""
 }
 
+func (x *TenantGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type Tunnel struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -18075,6 +18637,7 @@ type Tunnel struct {
 	Comments      *string                      `protobuf:"bytes,9,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,11,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,12,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -18186,6 +18749,13 @@ func (x *Tunnel) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *Tunnel) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type TunnelGroup struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -18193,6 +18763,7 @@ type TunnelGroup struct {
 	Description   *string                      `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,5,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -18258,6 +18829,13 @@ func (x *TunnelGroup) GetTags() []*Tag {
 func (x *TunnelGroup) GetCustomFields() map[string]*CustomFieldValue {
 	if x != nil {
 		return x.CustomFields
+	}
+	return nil
+}
+
+func (x *TunnelGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
 	}
 	return nil
 }
@@ -18365,6 +18943,7 @@ type TunnelTermination struct {
 	OutsideIp     *IPAddress                      `protobuf:"bytes,91,opt,name=outside_ip,json=outsideIp,proto3,oneof" json:"outside_ip,omitempty"`
 	Tags          []*Tag                          `protobuf:"bytes,92,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue    `protobuf:"bytes,93,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct                `protobuf:"bytes,99,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -19278,6 +19857,13 @@ func (x *TunnelTermination) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *TunnelTermination) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isTunnelTermination_Termination interface {
 	isTunnelTermination_Termination()
 }
@@ -19855,6 +20441,7 @@ type VLAN struct {
 	Comments      *string                      `protobuf:"bytes,11,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,12,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,13,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,14,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -19980,6 +20567,13 @@ func (x *VLAN) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *VLAN) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VLANGroup struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -19999,6 +20593,7 @@ type VLANGroup struct {
 	Tags          []*Tag                       `protobuf:"bytes,12,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,13,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Tenant        *Tenant                      `protobuf:"bytes,14,opt,name=tenant,proto3,oneof" json:"tenant,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,15,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -20152,6 +20747,13 @@ func (x *VLANGroup) GetTenant() *Tenant {
 	return nil
 }
 
+func (x *VLANGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isVLANGroup_Scope interface {
 	isVLANGroup_Scope()
 }
@@ -20202,6 +20804,7 @@ type VLANTranslationPolicy struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Description   *string                `protobuf:"bytes,2,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	Metadata      *structpb.Struct       `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -20250,12 +20853,20 @@ func (x *VLANTranslationPolicy) GetDescription() string {
 	return ""
 }
 
+func (x *VLANTranslationPolicy) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VLANTranslationRule struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Policy        *VLANTranslationPolicy `protobuf:"bytes,1,opt,name=policy,proto3" json:"policy,omitempty"`
 	LocalVid      int64                  `protobuf:"varint,2,opt,name=local_vid,json=localVid,proto3" json:"local_vid,omitempty"`
 	RemoteVid     int64                  `protobuf:"varint,3,opt,name=remote_vid,json=remoteVid,proto3" json:"remote_vid,omitempty"`
 	Description   *string                `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	Metadata      *structpb.Struct       `protobuf:"bytes,5,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -20318,6 +20929,13 @@ func (x *VLANTranslationRule) GetDescription() string {
 	return ""
 }
 
+func (x *VLANTranslationRule) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VMInterface struct {
 	state                 protoimpl.MessageState       `protogen:"open.v1"`
 	VirtualMachine        *VirtualMachine              `protobuf:"bytes,1,opt,name=virtual_machine,json=virtualMachine,proto3" json:"virtual_machine,omitempty"`
@@ -20336,6 +20954,7 @@ type VMInterface struct {
 	Tags                  []*Tag                       `protobuf:"bytes,14,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields          map[string]*CustomFieldValue `protobuf:"bytes,15,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	TaggedVlans           []*VLAN                      `protobuf:"bytes,16,rep,name=tagged_vlans,json=taggedVlans,proto3" json:"tagged_vlans,omitempty"`
+	Metadata              *structpb.Struct             `protobuf:"bytes,17,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -20482,6 +21101,13 @@ func (x *VMInterface) GetTaggedVlans() []*VLAN {
 	return nil
 }
 
+func (x *VMInterface) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VRF struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -20494,6 +21120,7 @@ type VRF struct {
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,8,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	ImportTargets []*RouteTarget               `protobuf:"bytes,9,rep,name=import_targets,json=importTargets,proto3" json:"import_targets,omitempty"`
 	ExportTargets []*RouteTarget               `protobuf:"bytes,10,rep,name=export_targets,json=exportTargets,proto3" json:"export_targets,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,11,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -20598,6 +21225,13 @@ func (x *VRF) GetExportTargets() []*RouteTarget {
 	return nil
 }
 
+func (x *VRF) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VirtualChassis struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -20607,6 +21241,7 @@ type VirtualChassis struct {
 	Comments      *string                      `protobuf:"bytes,5,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,7,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -20690,6 +21325,13 @@ func (x *VirtualChassis) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *VirtualChassis) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VirtualCircuit struct {
 	state           protoimpl.MessageState       `protogen:"open.v1"`
 	Cid             string                       `protobuf:"bytes,1,opt,name=cid,proto3" json:"cid,omitempty"`
@@ -20702,6 +21344,7 @@ type VirtualCircuit struct {
 	Comments        *string                      `protobuf:"bytes,8,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags            []*Tag                       `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields    map[string]*CustomFieldValue `protobuf:"bytes,10,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata        *structpb.Struct             `protobuf:"bytes,11,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -20806,6 +21449,13 @@ func (x *VirtualCircuit) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *VirtualCircuit) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VirtualCircuitTermination struct {
 	state          protoimpl.MessageState       `protogen:"open.v1"`
 	VirtualCircuit *VirtualCircuit              `protobuf:"bytes,1,opt,name=virtual_circuit,json=virtualCircuit,proto3" json:"virtual_circuit,omitempty"`
@@ -20814,6 +21464,7 @@ type VirtualCircuitTermination struct {
 	Description    *string                      `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags           []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -20890,6 +21541,13 @@ func (x *VirtualCircuitTermination) GetCustomFields() map[string]*CustomFieldVal
 	return nil
 }
 
+func (x *VirtualCircuitTermination) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VirtualCircuitType struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -20898,6 +21556,7 @@ type VirtualCircuitType struct {
 	Description   *string                      `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -20974,6 +21633,13 @@ func (x *VirtualCircuitType) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *VirtualCircuitType) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VirtualDeviceContext struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -20987,6 +21653,7 @@ type VirtualDeviceContext struct {
 	Comments      *string                      `protobuf:"bytes,9,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,11,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,12,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -21098,6 +21765,13 @@ func (x *VirtualDeviceContext) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *VirtualDeviceContext) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VirtualDisk struct {
 	state          protoimpl.MessageState       `protogen:"open.v1"`
 	VirtualMachine *VirtualMachine              `protobuf:"bytes,1,opt,name=virtual_machine,json=virtualMachine,proto3" json:"virtual_machine,omitempty"`
@@ -21106,6 +21780,7 @@ type VirtualDisk struct {
 	Size           int64                        `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
 	Tags           []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -21182,6 +21857,13 @@ func (x *VirtualDisk) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *VirtualDisk) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type VirtualMachine struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	Name          string                       `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -21202,6 +21884,7 @@ type VirtualMachine struct {
 	Comments      *string                      `protobuf:"bytes,16,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,17,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,18,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,19,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -21362,6 +22045,13 @@ func (x *VirtualMachine) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *VirtualMachine) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type WirelessLAN struct {
 	state       protoimpl.MessageState `protogen:"open.v1"`
 	Ssid        string                 `protobuf:"bytes,1,opt,name=ssid,proto3" json:"ssid,omitempty"`
@@ -21383,6 +22073,7 @@ type WirelessLAN struct {
 	Comments      *string                      `protobuf:"bytes,14,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,15,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,16,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,17,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -21544,6 +22235,13 @@ func (x *WirelessLAN) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *WirelessLAN) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isWirelessLAN_Scope interface {
 	isWirelessLAN_Scope()
 }
@@ -21581,6 +22279,7 @@ type WirelessLANGroup struct {
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Comments      *string                      `protobuf:"bytes,7,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,8,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -21664,6 +22363,13 @@ func (x *WirelessLANGroup) GetComments() string {
 	return ""
 }
 
+func (x *WirelessLANGroup) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type WirelessLink struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	InterfaceA    *Interface                   `protobuf:"bytes,1,opt,name=interface_a,json=interfaceA,proto3" json:"interface_a,omitempty"`
@@ -21680,6 +22386,7 @@ type WirelessLink struct {
 	Comments      *string                      `protobuf:"bytes,12,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,13,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,14,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,15,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -21812,6 +22519,13 @@ func (x *WirelessLink) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *WirelessLink) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type CustomField struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	Type                string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
@@ -21836,6 +22550,7 @@ type CustomField struct {
 	ChoiceSet           *CustomFieldChoiceSet  `protobuf:"bytes,20,opt,name=choice_set,json=choiceSet,proto3,oneof" json:"choice_set,omitempty"`
 	Comments            *string                `protobuf:"bytes,21,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	ObjectTypes         []string               `protobuf:"bytes,22,rep,name=object_types,json=objectTypes,proto3" json:"object_types,omitempty"`
+	Metadata            *structpb.Struct       `protobuf:"bytes,23,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -22024,6 +22739,13 @@ func (x *CustomField) GetObjectTypes() []string {
 	return nil
 }
 
+func (x *CustomField) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type CustomFieldChoiceSet struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	Name                string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -22031,6 +22753,7 @@ type CustomFieldChoiceSet struct {
 	BaseChoices         *string                `protobuf:"bytes,3,opt,name=base_choices,json=baseChoices,proto3,oneof" json:"base_choices,omitempty"`
 	OrderAlphabetically *bool                  `protobuf:"varint,4,opt,name=order_alphabetically,json=orderAlphabetically,proto3,oneof" json:"order_alphabetically,omitempty"`
 	ExtraChoices        []string               `protobuf:"bytes,5,rep,name=extra_choices,json=extraChoices,proto3" json:"extra_choices,omitempty"`
+	Metadata            *structpb.Struct       `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -22096,6 +22819,13 @@ func (x *CustomFieldChoiceSet) GetOrderAlphabetically() bool {
 func (x *CustomFieldChoiceSet) GetExtraChoices() []string {
 	if x != nil {
 		return x.ExtraChoices
+	}
+	return nil
+}
+
+func (x *CustomFieldChoiceSet) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
 	}
 	return nil
 }
@@ -22202,6 +22932,7 @@ type JournalEntry struct {
 	Comments       string                        `protobuf:"bytes,94,opt,name=comments,proto3" json:"comments,omitempty"`
 	Tags           []*Tag                        `protobuf:"bytes,95,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields   map[string]*CustomFieldValue  `protobuf:"bytes,96,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata       *structpb.Struct              `protobuf:"bytes,98,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -23108,6 +23839,13 @@ func (x *JournalEntry) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *JournalEntry) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type isJournalEntry_AssignedObject interface {
 	isJournalEntry_AssignedObject()
 }
@@ -23678,6 +24416,7 @@ type ModuleTypeProfile struct {
 	Comments      *string                      `protobuf:"bytes,4,opt,name=comments,proto3,oneof" json:"comments,omitempty"`
 	Tags          []*Tag                       `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
 	CustomFields  map[string]*CustomFieldValue `protobuf:"bytes,6,rep,name=custom_fields,json=customFields,proto3" json:"custom_fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata      *structpb.Struct             `protobuf:"bytes,7,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -23754,6 +24493,13 @@ func (x *ModuleTypeProfile) GetCustomFields() map[string]*CustomFieldValue {
 	return nil
 }
 
+func (x *ModuleTypeProfile) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type CustomLink struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -23765,6 +24511,7 @@ type CustomLink struct {
 	ButtonClass   *string                `protobuf:"bytes,7,opt,name=button_class,json=buttonClass,proto3,oneof" json:"button_class,omitempty"`
 	NewWindow     *bool                  `protobuf:"varint,8,opt,name=new_window,json=newWindow,proto3,oneof" json:"new_window,omitempty"`
 	ObjectTypes   []string               `protobuf:"bytes,9,rep,name=object_types,json=objectTypes,proto3" json:"object_types,omitempty"`
+	Metadata      *structpb.Struct       `protobuf:"bytes,10,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -23862,11 +24609,35 @@ func (x *CustomLink) GetObjectTypes() []string {
 	return nil
 }
 
+func (x *CustomLink) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+var file_diode_v1_ingester_proto_extTypes = []protoimpl.ExtensionInfo{
+	{
+		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtensionType: (*bool)(nil),
+		Field:         50001,
+		Name:          "diode.v1.netbox_supported",
+		Tag:           "varint,50001,opt,name=netbox_supported",
+		Filename:      "diode/v1/ingester.proto",
+	},
+}
+
+// Extension fields to descriptorpb.FieldOptions.
+var (
+	// optional bool netbox_supported = 50001;
+	E_NetboxSupported = &file_diode_v1_ingester_proto_extTypes[0]
+)
+
 var File_diode_v1_ingester_proto protoreflect.FileDescriptor
 
 const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
-	"\x17diode/v1/ingester.proto\x12\bdiode.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\"\xed+\n" +
+	"\x17diode/v1/ingester.proto\x12\bdiode.v1\x1a google/protobuf/descriptor.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\"\xed+\n" +
 	"\x06Entity\x12D\n" +
 	"\ttimestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampB\n" +
 	"\xfaB\a\xb2\x01\x04\b\x018\x01R\ttimestamp\x12!\n" +
@@ -23981,7 +24752,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x13module_type_profile\x18] \x01(\v2\x1b.diode.v1.ModuleTypeProfileH\x00R\x11moduleTypeProfile\x127\n" +
 	"\vcustom_link\x18^ \x01(\v2\x14.diode.v1.CustomLinkH\x00R\n" +
 	"customLinkB\b\n" +
-	"\x06entity\"\xe4\x02\n" +
+	"\x06entity\"\x99\x03\n" +
 	"\rIngestRequest\x12\"\n" +
 	"\x06stream\x18\x01 \x01(\tB\n" +
 	"\xfaB\ar\x05\x10\x01\x18\xff\x01R\x06stream\x129\n" +
@@ -23994,9 +24765,10 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bsdk_name\x18\x06 \x01(\tB\n" +
 	"\xfaB\ar\x05\x10\x01\x18\xff\x01R\asdkName\x12=\n" +
 	"\vsdk_version\x18\a \x01(\tB\x1c\xfaB\x19r\x172\x15^(\\d)+\\.(\\d)+\\.(\\d)+$R\n" +
-	"sdkVersion\"(\n" +
+	"sdkVersion\x123\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructR\bmetadata\"(\n" +
 	"\x0eIngestResponse\x12\x16\n" +
-	"\x06errors\x18\x01 \x03(\tR\x06errors\"\xaa\x03\n" +
+	"\x06errors\x18\x01 \x03(\tR\x06errors\"\xe5\x03\n" +
 	"\x03ASN\x12\x10\n" +
 	"\x03asn\x18\x01 \x01(\x03R\x03asn\x12$\n" +
 	"\x03rir\x18\x02 \x01(\v2\r.diode.v1.RIRH\x00R\x03rir\x88\x01\x01\x12-\n" +
@@ -24004,14 +24776,15 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x02R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x05 \x01(\tH\x03R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12D\n" +
-	"\rcustom_fields\x18\a \x03(\v2\x1f.diode.v1.ASN.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2\x1f.diode.v1.ASN.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x06\n" +
 	"\x04_rirB\t\n" +
 	"\a_tenantB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xb7\x03\n" +
+	"\t_comments\"\xf2\x03\n" +
 	"\bASNRange\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x1f\n" +
@@ -24021,12 +24794,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x06tenant\x18\x06 \x01(\v2\x10.diode.v1.TenantH\x00R\x06tenant\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\a \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\b \x03(\v2\r.diode.v1.TagR\x04tags\x12I\n" +
-	"\rcustom_fields\x18\t \x03(\v2$.diode.v1.ASNRange.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\t \x03(\v2$.diode.v1.ASNRange.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_tenantB\x0e\n" +
-	"\f_description\"\xfe\x03\n" +
+	"\f_description\"\xb9\x04\n" +
 	"\tAggregate\x12\x16\n" +
 	"\x06prefix\x18\x01 \x01(\tR\x06prefix\x12\x1f\n" +
 	"\x03rir\x18\x02 \x01(\v2\r.diode.v1.RIRR\x03rir\x12-\n" +
@@ -24036,14 +24811,15 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x05 \x01(\tH\x02R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x06 \x01(\tH\x03R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\a \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\b \x03(\v2%.diode.v1.Aggregate.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\b \x03(\v2%.diode.v1.Aggregate.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\t \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_tenantB\r\n" +
 	"\v_date_addedB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xf1\a\n" +
+	"\t_comments\"\xac\b\n" +
 	"\x05Cable\x12\xdd\x01\n" +
 	"\x04type\x18\x01 \x01(\tB\xc3\x01\xfaB\xbf\x01r\xbc\x01R\x03aocR\x04cat3R\x04cat5R\x05cat5eR\x04cat6R\x05cat6aR\x04cat7R\x05cat7aR\x04cat8R\acoaxialR\n" +
 	"dac-activeR\vdac-passiveR\x03mmfR\ammf-om1R\ammf-om2R\ammf-om3R\ammf-om4R\ammf-om5R\vmrj21-trunkR\x05powerR\x03smfR\asmf-os1R\asmf-os2R\x03usbH\x00R\x04type\x88\x01\x01\x12>\n" +
@@ -24060,7 +24836,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	" \x01(\tH\aR\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\v \x01(\tH\bR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\f \x03(\v2\r.diode.v1.TagR\x04tags\x12F\n" +
-	"\rcustom_fields\x18\r \x03(\v2!.diode.v1.Cable.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\r \x03(\v2!.diode.v1.Cable.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x0e \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -24072,16 +24849,17 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\a_lengthB\x0e\n" +
 	"\f_length_unitB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\x9e\x01\n" +
+	"\t_comments\"\xd9\x01\n" +
 	"\tCablePath\x12 \n" +
 	"\tis_active\x18\x01 \x01(\bH\x00R\bisActive\x88\x01\x01\x12$\n" +
 	"\vis_complete\x18\x02 \x01(\bH\x01R\n" +
 	"isComplete\x88\x01\x01\x12\x1e\n" +
-	"\bis_split\x18\x03 \x01(\bH\x02R\aisSplit\x88\x01\x01B\f\n" +
+	"\bis_split\x18\x03 \x01(\bH\x02R\aisSplit\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\x04 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\f\n" +
 	"\n" +
 	"_is_activeB\x0e\n" +
 	"\f_is_completeB\v\n" +
-	"\t_is_split\"\xe3\x06\n" +
+	"\t_is_split\"\x9e\a\n" +
 	"\x10CableTermination\x12%\n" +
 	"\x05cable\x18\x01 \x01(\v2\x0f.diode.v1.CableR\x05cable\x12(\n" +
 	"\tcable_end\x18\x02 \x01(\tB\v\xfaB\br\x06R\x01AR\x01BR\bcableEnd\x12f\n" +
@@ -24094,8 +24872,9 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x18termination_power_outlet\x18\t \x01(\v2\x15.diode.v1.PowerOutletH\x00R\x16terminationPowerOutlet\x12K\n" +
 	"\x16termination_power_port\x18\n" +
 	" \x01(\v2\x13.diode.v1.PowerPortH\x00R\x14terminationPowerPort\x12H\n" +
-	"\x15termination_rear_port\x18\v \x01(\v2\x12.diode.v1.RearPortH\x00R\x13terminationRearPortB\r\n" +
-	"\vtermination\"\xe6\b\n" +
+	"\x15termination_rear_port\x18\v \x01(\v2\x12.diode.v1.RearPortH\x00R\x13terminationRearPort\x129\n" +
+	"\bmetadata\x18\f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\r\n" +
+	"\vtermination\"\xa1\t\n" +
 	"\aCircuit\x12\x10\n" +
 	"\x03cid\x18\x01 \x01(\tR\x03cid\x12.\n" +
 	"\bprovider\x18\x02 \x01(\v2\x12.diode.v1.ProviderR\bprovider\x12I\n" +
@@ -24114,7 +24893,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\r \x01(\tH\tR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0e \x03(\v2\r.diode.v1.TagR\x04tags\x12B\n" +
 	"\vassignments\x18\x0f \x03(\v2 .diode.v1.CircuitGroupAssignmentR\vassignments\x12H\n" +
-	"\rcustom_fields\x18\x10 \x03(\v2#.diode.v1.Circuit.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x10 \x03(\v2#.diode.v1.Circuit.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x11 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x13\n" +
@@ -24127,27 +24907,29 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\f_descriptionB\v\n" +
 	"\t_distanceB\x10\n" +
 	"\x0e_distance_unitB\v\n" +
-	"\t_comments\"\xf6\x02\n" +
+	"\t_comments\"\xb1\x03\n" +
 	"\fCircuitGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12-\n" +
 	"\x06tenant\x18\x04 \x01(\v2\x10.diode.v1.TenantH\x01R\x06tenant\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12M\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2(.diode.v1.CircuitGroup.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2(.diode.v1.CircuitGroup.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
 	"\f_descriptionB\t\n" +
-	"\a_tenant\"\xde\x02\n" +
+	"\a_tenant\"\x99\x03\n" +
 	"\x16CircuitGroupAssignment\x12,\n" +
 	"\x05group\x18\x01 \x01(\v2\x16.diode.v1.CircuitGroupR\x05group\x12:\n" +
 	"\x0emember_circuit\x18\x02 \x01(\v2\x11.diode.v1.CircuitH\x00R\rmemberCircuit\x12P\n" +
 	"\x16member_virtual_circuit\x18\x03 \x01(\v2\x18.diode.v1.VirtualCircuitH\x00R\x14memberVirtualCircuit\x12N\n" +
 	"\bpriority\x18\x04 \x01(\tB-\xfaB*r(R\binactiveR\aprimaryR\tsecondaryR\btertiaryH\x01R\bpriority\x88\x01\x01\x12!\n" +
-	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tagsB\b\n" +
+	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x129\n" +
+	"\bmetadata\x18\x06 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\b\n" +
 	"\x06memberB\v\n" +
-	"\t_priority\"\x8c\b\n" +
+	"\t_priority\"\xc7\b\n" +
 	"\x12CircuitTermination\x12+\n" +
 	"\acircuit\x18\x01 \x01(\v2\x11.diode.v1.CircuitR\acircuit\x12(\n" +
 	"\tterm_side\x18\x02 \x01(\tB\v\xfaB\br\x06R\x01AR\x01ZR\btermSide\x12G\n" +
@@ -24166,7 +24948,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\f \x01(\tH\x05R\vdescription\x88\x01\x01\x12*\n" +
 	"\x0emark_connected\x18\r \x01(\bH\x06R\rmarkConnected\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0e \x03(\v2\r.diode.v1.TagR\x04tags\x12S\n" +
-	"\rcustom_fields\x18\x0f \x03(\v2..diode.v1.CircuitTermination.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x0f \x03(\v2..diode.v1.CircuitTermination.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x10 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\r\n" +
@@ -24177,19 +24960,20 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
 	"\b_pp_infoB\x0e\n" +
 	"\f_descriptionB\x11\n" +
-	"\x0f_mark_connected\"\xdf\x02\n" +
+	"\x0f_mark_connected\"\x9a\x03\n" +
 	"\vCircuitType\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x19\n" +
 	"\x05color\x18\x03 \x01(\tH\x00R\x05color\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.CircuitType.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.CircuitType.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
 	"\x06_colorB\x0e\n" +
-	"\f_description\"\xc0\x06\n" +
+	"\f_description\"\xfb\x06\n" +
 	"\aCluster\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12)\n" +
 	"\x04type\x18\x02 \x01(\v2\x15.diode.v1.ClusterTypeR\x04type\x121\n" +
@@ -24205,7 +24989,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	" \x01(\tH\x04R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\v \x01(\tH\x05R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\f \x03(\v2\r.diode.v1.TagR\x04tags\x12H\n" +
-	"\rcustom_fields\x18\r \x03(\v2#.diode.v1.Cluster.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\r \x03(\v2#.diode.v1.Cluster.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x0e \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -24214,27 +24999,29 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\a_statusB\t\n" +
 	"\a_tenantB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xbc\x02\n" +
+	"\t_comments\"\xf7\x02\n" +
 	"\fClusterGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x04 \x03(\v2\r.diode.v1.TagR\x04tags\x12M\n" +
-	"\rcustom_fields\x18\x05 \x03(\v2(.diode.v1.ClusterGroup.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x05 \x03(\v2(.diode.v1.ClusterGroup.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x06 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
-	"\f_description\"\xba\x02\n" +
+	"\f_description\"\xf5\x02\n" +
 	"\vClusterType\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x04 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
-	"\rcustom_fields\x18\x05 \x03(\v2'.diode.v1.ClusterType.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x05 \x03(\v2'.diode.v1.ClusterType.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x06 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
-	"\f_description\"\xed\x05\n" +
+	"\f_description\"\xa8\x06\n" +
 	"\vConsolePort\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -24249,7 +25036,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0emark_connected\x18\b \x01(\bH\x05R\rmarkConnected\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\t \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
 	"\rcustom_fields\x18\n" +
-	" \x03(\v2'.diode.v1.ConsolePort.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	" \x03(\v2'.diode.v1.ConsolePort.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\v \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -24258,7 +25046,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x05_typeB\b\n" +
 	"\x06_speedB\x0e\n" +
 	"\f_descriptionB\x11\n" +
-	"\x0f_mark_connected\"\xf9\x05\n" +
+	"\x0f_mark_connected\"\xb4\x06\n" +
 	"\x11ConsoleServerPort\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -24273,7 +25061,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0emark_connected\x18\b \x01(\bH\x05R\rmarkConnected\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\t \x03(\v2\r.diode.v1.TagR\x04tags\x12R\n" +
 	"\rcustom_fields\x18\n" +
-	" \x03(\v2-.diode.v1.ConsoleServerPort.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	" \x03(\v2-.diode.v1.ConsoleServerPort.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\v \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -24282,7 +25071,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x05_typeB\b\n" +
 	"\x06_speedB\x0e\n" +
 	"\f_descriptionB\x11\n" +
-	"\x0f_mark_connected\"\xf9\x04\n" +
+	"\x0f_mark_connected\"\xb4\x05\n" +
 	"\aContact\x125\n" +
 	"\x05group\x18\x01 \x01(\v2\x16.diode.v1.ContactGroupB\x02\x18\x01H\x00R\x05group\x88\x01\x01\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x19\n" +
@@ -24296,7 +25085,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04tags\x18\n" +
 	" \x03(\v2\r.diode.v1.TagR\x04tags\x12H\n" +
 	"\rcustom_fields\x18\v \x03(\v2#.diode.v1.Contact.CustomFieldsEntryR\fcustomFields\x12.\n" +
-	"\x06groups\x18\f \x03(\v2\x16.diode.v1.ContactGroupR\x06groups\x1a[\n" +
+	"\x06groups\x18\f \x03(\v2\x16.diode.v1.ContactGroupR\x06groups\x129\n" +
+	"\bmetadata\x18\r \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
@@ -24308,7 +25098,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\b_addressB\a\n" +
 	"\x05_linkB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\x828\n" +
+	"\t_comments\"\xbd8\n" +
 	"\x11ContactAssignment\x12.\n" +
 	"\n" +
 	"object_asn\x18\x01 \x01(\v2\r.diode.v1.ASNH\x00R\tobjectAsn\x12>\n" +
@@ -24416,13 +25206,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04role\x18Z \x01(\v2\x15.diode.v1.ContactRoleH\x01R\x04role\x88\x01\x01\x12N\n" +
 	"\bpriority\x18[ \x01(\tB-\xfaB*r(R\binactiveR\aprimaryR\tsecondaryR\btertiaryH\x02R\bpriority\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\\ \x03(\v2\r.diode.v1.TagR\x04tags\x12R\n" +
-	"\rcustom_fields\x18] \x03(\v2-.diode.v1.ContactAssignment.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18] \x03(\v2-.diode.v1.ContactAssignment.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18c \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
 	"\x06objectB\a\n" +
 	"\x05_roleB\v\n" +
-	"\t_priority\"\xaa\x03\n" +
+	"\t_priority\"\xe5\x03\n" +
 	"\fContactGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x123\n" +
@@ -24430,19 +25221,21 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12M\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2(.diode.v1.ContactGroup.CustomFieldsEntryR\fcustomFields\x12\x1f\n" +
-	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_parentB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xba\x02\n" +
+	"\t_comments\"\xf5\x02\n" +
 	"\vContactRole\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x04 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
-	"\rcustom_fields\x18\x05 \x03(\v2'.diode.v1.ContactRole.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x05 \x03(\v2'.diode.v1.ContactRole.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x06 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
@@ -24575,7 +25368,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04json\x18\v \x01(\tH\x00R\x04json\x12\x1e\n" +
 	"\tselection\x18\f \x01(\tH\x00R\tselection\x12>\n" +
 	"\x06object\x18\r \x01(\v2$.diode.v1.CustomFieldObjectReferenceH\x00R\x06objectB\a\n" +
-	"\x05value\"\xf1\r\n" +
+	"\x05value\"\xac\x0e\n" +
 	"\x06Device\x12\x17\n" +
 	"\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x125\n" +
 	"\vdevice_type\x18\x02 \x01(\v2\x14.diode.v1.DeviceTypeR\n" +
@@ -24610,7 +25403,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x18 \x01(\tH\x14R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x19 \x01(\tH\x15R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x1a \x03(\v2\r.diode.v1.TagR\x04tags\x12G\n" +
-	"\rcustom_fields\x18\x1b \x03(\v2\".diode.v1.Device.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x1b \x03(\v2\".diode.v1.Device.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x1c \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -24639,7 +25433,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\f_vc_positionB\x0e\n" +
 	"\f_vc_priorityB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xc8\x03\n" +
+	"\t_comments\"\x83\x04\n" +
 	"\tDeviceBay\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x19\n" +
@@ -24647,13 +25441,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12@\n" +
 	"\x10installed_device\x18\x05 \x01(\v2\x10.diode.v1.DeviceH\x02R\x0finstalledDevice\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\a \x03(\v2%.diode.v1.DeviceBay.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2%.diode.v1.DeviceBay.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
 	"\x06_labelB\x0e\n" +
 	"\f_descriptionB\x13\n" +
-	"\x11_installed_device\"\xf3\x03\n" +
+	"\x11_installed_device\"\xae\x04\n" +
 	"\n" +
 	"DeviceRole\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
@@ -24664,7 +25459,9 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12K\n" +
 	"\rcustom_fields\x18\a \x03(\v2&.diode.v1.DeviceRole.CustomFieldsEntryR\fcustomFields\x121\n" +
 	"\x06parent\x18\b \x01(\v2\x14.diode.v1.DeviceRoleH\x03R\x06parent\x88\x01\x01\x12\x1f\n" +
-	"\bcomments\x18\t \x01(\tH\x04R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\t \x01(\tH\x04R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
@@ -24673,7 +25470,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\b_vm_roleB\x0e\n" +
 	"\f_descriptionB\t\n" +
 	"\a_parentB\v\n" +
-	"\t_comments\"\xfc\b\n" +
+	"\t_comments\"\xb7\t\n" +
 	"\n" +
 	"DeviceType\x12:\n" +
 	"\fmanufacturer\x18\x01 \x01(\v2\x16.diode.v1.ManufacturerR\fmanufacturer\x12B\n" +
@@ -24695,7 +25492,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x0e \x01(\tH\n" +
 	"R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0f \x03(\v2\r.diode.v1.TagR\x04tags\x12K\n" +
-	"\rcustom_fields\x18\x10 \x03(\v2&.diode.v1.DeviceType.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x10 \x03(\v2&.diode.v1.DeviceType.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x11 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x13\n" +
@@ -24710,7 +25508,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\a_weightB\x0e\n" +
 	"\f_weight_unitB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xc2\x04\n" +
+	"\t_comments\"\xfd\x04\n" +
 	"\tFHRPGroup\x12\x17\n" +
 	"\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x12S\n" +
 	"\bprotocol\x18\x02 \x01(\tB7\xfaB4r2R\x04carpR\tclusterxlR\x04glbpR\x04hsrpR\x05otherR\x05vrrp2R\x05vrrp3R\bprotocol\x12\x19\n" +
@@ -24720,7 +25518,9 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x06 \x01(\tH\x03R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\a \x01(\tH\x04R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\b \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\t \x03(\v2%.diode.v1.FHRPGroup.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\t \x03(\v2%.diode.v1.FHRPGroup.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -24729,7 +25529,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"_auth_typeB\v\n" +
 	"\t_auth_keyB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xe59\n" +
+	"\t_comments\"\xa0:\n" +
 	"\x13FHRPGroupAssignment\x12)\n" +
 	"\x05group\x18\x01 \x01(\v2\x13.diode.v1.FHRPGroupR\x05group\x124\n" +
 	"\rinterface_asn\x18\x02 \x01(\v2\r.diode.v1.ASNH\x00R\finterfaceAsn\x12D\n" +
@@ -24826,8 +25626,9 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x17interface_journal_entry\x18] \x01(\v2\x16.diode.v1.JournalEntryH\x00R\x15interfaceJournalEntry\x12`\n" +
 	"\x1dinterface_module_type_profile\x18^ \x01(\v2\x1b.diode.v1.ModuleTypeProfileH\x00R\x1ainterfaceModuleTypeProfile\x12J\n" +
 	"\x15interface_custom_link\x18_ \x01(\v2\x14.diode.v1.CustomLinkH\x00R\x13interfaceCustomLink\x12\x1a\n" +
-	"\bpriority\x18Z \x01(\x03R\bpriorityB\v\n" +
-	"\tinterface\"\xd1\b\n" +
+	"\bpriority\x18Z \x01(\x03R\bpriority\x129\n" +
+	"\bmetadata\x18` \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\v\n" +
+	"\tinterface\"\x8c\t\n" +
 	"\tFrontPort\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -24843,7 +25644,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0emark_connected\x18\n" +
 	" \x01(\bH\x05R\rmarkConnected\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\v \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\f \x03(\v2%.diode.v1.FrontPort.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\f \x03(\v2%.diode.v1.FrontPort.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\r \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -24956,7 +25758,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x14object_journal_entry\x18[ \x01(\v2\x16.diode.v1.JournalEntryH\x00R\x12objectJournalEntry\x12Z\n" +
 	"\x1aobject_module_type_profile\x18\\ \x01(\v2\x1b.diode.v1.ModuleTypeProfileH\x00R\x17objectModuleTypeProfile\x12D\n" +
 	"\x12object_custom_link\x18] \x01(\v2\x14.diode.v1.CustomLinkH\x00R\x10objectCustomLinkB\b\n" +
-	"\x06object\"\xa1\x04\n" +
+	"\x06object\"\xdc\x04\n" +
 	"\tIKEPolicy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x12#\n" +
@@ -24967,14 +25769,16 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x06 \x01(\tH\x03R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\a \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
 	"\rcustom_fields\x18\b \x03(\v2%.diode.v1.IKEPolicy.CustomFieldsEntryR\fcustomFields\x123\n" +
-	"\tproposals\x18\t \x03(\v2\x15.diode.v1.IKEProposalR\tproposals\x1a[\n" +
+	"\tproposals\x18\t \x03(\v2\x15.diode.v1.IKEProposalR\tproposals\x129\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
 	"\f_descriptionB\a\n" +
 	"\x05_modeB\x10\n" +
 	"\x0e_preshared_keyB\v\n" +
-	"\t_comments\"\x8e\a\n" +
+	"\t_comments\"\xc9\a\n" +
 	"\vIKEProposal\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x12x\n" +
@@ -24987,14 +25791,15 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\b \x01(\tH\x03R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\t \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
 	"\rcustom_fields\x18\n" +
-	" \x03(\v2'.diode.v1.IKEProposal.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	" \x03(\v2'.diode.v1.IKEProposal.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\v \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
 	"\f_descriptionB\x1b\n" +
 	"\x19_authentication_algorithmB\x0e\n" +
 	"\f_sa_lifetimeB\v\n" +
-	"\t_comments\"\x85\b\n" +
+	"\t_comments\"\xc0\b\n" +
 	"\tIPAddress\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12$\n" +
 	"\x03vrf\x18\x02 \x01(\v2\r.diode.v1.VRFH\x01R\x03vrf\x88\x01\x01\x12-\n" +
@@ -25012,7 +25817,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\v \x01(\tH\aR\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\f \x01(\tH\bR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\r \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\x0e \x03(\v2%.diode.v1.IPAddress.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x0e \x03(\v2%.diode.v1.IPAddress.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x0f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x11\n" +
@@ -25024,7 +25830,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\v_nat_insideB\v\n" +
 	"\t_dns_nameB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xe0\x05\n" +
+	"\t_comments\"\x9b\x06\n" +
 	"\aIPRange\x12#\n" +
 	"\rstart_address\x18\x01 \x01(\tR\fstartAddress\x12\x1f\n" +
 	"\vend_address\x18\x02 \x01(\tR\n" +
@@ -25040,7 +25846,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\rmark_utilized\x18\n" +
 	" \x01(\bH\x06R\fmarkUtilized\x88\x01\x01\x12H\n" +
 	"\rcustom_fields\x18\v \x03(\v2#.diode.v1.IPRange.CustomFieldsEntryR\fcustomFields\x12*\n" +
-	"\x0emark_populated\x18\f \x01(\bH\aR\rmarkPopulated\x88\x01\x01\x1a[\n" +
+	"\x0emark_populated\x18\f \x01(\bH\aR\rmarkPopulated\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\r \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x06\n" +
@@ -25051,7 +25858,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\f_descriptionB\v\n" +
 	"\t_commentsB\x10\n" +
 	"\x0e_mark_utilizedB\x11\n" +
-	"\x0f_mark_populated\"\xf2\x03\n" +
+	"\x0f_mark_populated\"\xad\x04\n" +
 	"\vIPSecPolicy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x12W\n" +
@@ -25059,14 +25866,15 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x04 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.IPSecPolicy.CustomFieldsEntryR\fcustomFields\x125\n" +
-	"\tproposals\x18\a \x03(\v2\x17.diode.v1.IPSecProposalR\tproposals\x1a[\n" +
+	"\tproposals\x18\a \x03(\v2\x17.diode.v1.IPSecProposalR\tproposals\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
 	"\f_descriptionB\f\n" +
 	"\n" +
 	"_pfs_groupB\v\n" +
-	"\t_comments\"\xe8\x03\n" +
+	"\t_comments\"\xa3\x04\n" +
 	"\fIPSecProfile\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x12\"\n" +
@@ -25076,12 +25884,13 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\fipsec_policy\x18\x05 \x01(\v2\x15.diode.v1.IPSecPolicyR\vipsecPolicy\x12\x1f\n" +
 	"\bcomments\x18\x06 \x01(\tH\x01R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\a \x03(\v2\r.diode.v1.TagR\x04tags\x12M\n" +
-	"\rcustom_fields\x18\b \x03(\v2(.diode.v1.IPSecProfile.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\b \x03(\v2(.diode.v1.IPSecProfile.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\t \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xc4\x06\n" +
+	"\t_comments\"\xff\x06\n" +
 	"\rIPSecProposal\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x12\x9e\x01\n" +
@@ -25091,7 +25900,9 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x10sa_lifetime_data\x18\x06 \x01(\x03H\x04R\x0esaLifetimeData\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\a \x01(\tH\x05R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\b \x03(\v2\r.diode.v1.TagR\x04tags\x12N\n" +
-	"\rcustom_fields\x18\t \x03(\v2).diode.v1.IPSecProposal.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\t \x03(\v2).diode.v1.IPSecProposal.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
@@ -25100,7 +25911,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x19_authentication_algorithmB\x16\n" +
 	"\x14_sa_lifetime_secondsB\x13\n" +
 	"\x11_sa_lifetime_dataB\v\n" +
-	"\t_comments\"\xda?\n" +
+	"\t_comments\"\x95@\n" +
 	"\tInterface\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -25166,7 +25977,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\rcustom_fields\x18\x1f \x03(\v2%.diode.v1.Interface.CustomFieldsEntryR\fcustomFields\x122\n" +
 	"\x04vdcs\x18  \x03(\v2\x1e.diode.v1.VirtualDeviceContextR\x04vdcs\x121\n" +
 	"\ftagged_vlans\x18! \x03(\v2\x0e.diode.v1.VLANR\vtaggedVlans\x12:\n" +
-	"\rwireless_lans\x18\" \x03(\v2\x15.diode.v1.WirelessLANR\fwirelessLans\x1a[\n" +
+	"\rwireless_lans\x18\" \x03(\v2\x15.diode.v1.WirelessLANR\fwirelessLans\x129\n" +
+	"\bmetadata\x18# \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -25198,7 +26010,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\v_qinq_svlanB\x1a\n" +
 	"\x18_vlan_translation_policyB\x11\n" +
 	"\x0f_mark_connectedB\x06\n" +
-	"\x04_vrf\"\x98\v\n" +
+	"\x04_vrf\"\xd3\v\n" +
 	"\rInventoryItem\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x124\n" +
 	"\x06parent\x18\x02 \x01(\v2\x17.diode.v1.InventoryItemH\x01R\x06parent\x88\x01\x01\x12\x12\n" +
@@ -25224,7 +26036,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x14component_power_port\x18\x12 \x01(\v2\x13.diode.v1.PowerPortH\x00R\x12componentPowerPort\x12D\n" +
 	"\x13component_rear_port\x18\x13 \x01(\v2\x12.diode.v1.RearPortH\x00R\x11componentRearPort\x12!\n" +
 	"\x04tags\x18\x14 \x03(\v2\r.diode.v1.TagR\x04tags\x12N\n" +
-	"\rcustom_fields\x18\x15 \x03(\v2).diode.v1.InventoryItem.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x15 \x03(\v2).diode.v1.InventoryItem.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x16 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\v\n" +
@@ -25240,19 +26053,20 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
 	"_asset_tagB\r\n" +
 	"\v_discoveredB\x0e\n" +
-	"\f_description\"\xeb\x02\n" +
+	"\f_description\"\xa6\x03\n" +
 	"\x11InventoryItemRole\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x19\n" +
 	"\x05color\x18\x03 \x01(\tH\x00R\x05color\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12R\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2-.diode.v1.InventoryItemRole.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2-.diode.v1.InventoryItemRole.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
 	"\x06_colorB\x0e\n" +
-	"\f_description\"\xb4\x06\n" +
+	"\f_description\"\xef\x06\n" +
 	"\x05L2VPN\x12#\n" +
 	"\n" +
 	"identifier\x18\x01 \x01(\x03H\x00R\n" +
@@ -25269,7 +26083,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0eimport_targets\x18\n" +
 	" \x03(\v2\x15.diode.v1.RouteTargetR\rimportTargets\x12<\n" +
 	"\x0eexport_targets\x18\v \x03(\v2\x15.diode.v1.RouteTargetR\rexportTargets\x12D\n" +
-	"\x06status\x18\f \x01(\tB'\xfaB$r\"R\x06activeR\x0fdecommissioningR\aplannedH\x05R\x06status\x88\x01\x01\x1a[\n" +
+	"\x06status\x18\f \x01(\tB'\xfaB$r\"R\x06activeR\x0fdecommissioningR\aplannedH\x05R\x06status\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\r \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\r\n" +
@@ -25278,7 +26093,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\f_descriptionB\v\n" +
 	"\t_commentsB\t\n" +
 	"\a_tenantB\t\n" +
-	"\a_status\"\x9bC\n" +
+	"\a_status\"\xd6C\n" +
 	"\x10L2VPNTermination\x12%\n" +
 	"\x05l2vpn\x18\x01 \x01(\v2\x0f.diode.v1.L2VPNR\x05l2vpn\x12Q\n" +
 	"\x19assigned_object_interface\x18\x02 \x01(\v2\x13.diode.v1.InterfaceH\x00R\x17assignedObjectInterface\x12B\n" +
@@ -25376,11 +26191,12 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x1dassigned_object_wireless_link\x18_ \x01(\v2\x16.diode.v1.WirelessLinkH\x00R\x1aassignedObjectWirelessLink\x12U\n" +
 	"\x1bassigned_object_custom_link\x18` \x01(\v2\x14.diode.v1.CustomLinkH\x00R\x18assignedObjectCustomLink\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12Q\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2,.diode.v1.L2VPNTermination.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2,.diode.v1.L2VPNTermination.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x11\n" +
-	"\x0fassigned_object\"\x8d\x05\n" +
+	"\x0fassigned_object\"\xc8\x05\n" +
 	"\bLocation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\"\n" +
@@ -25393,7 +26209,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04tags\x18\t \x03(\v2\r.diode.v1.TagR\x04tags\x12I\n" +
 	"\rcustom_fields\x18\n" +
 	" \x03(\v2$.diode.v1.Location.CustomFieldsEntryR\fcustomFields\x12\x1f\n" +
-	"\bcomments\x18\v \x01(\tH\x05R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\v \x01(\tH\x05R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -25402,7 +26219,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\a_tenantB\v\n" +
 	"\t_facilityB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\x9f\x04\n" +
+	"\t_comments\"\xda\x04\n" +
 	"\n" +
 	"MACAddress\x12\x1f\n" +
 	"\vmac_address\x18\x01 \x01(\tR\n" +
@@ -25412,23 +26229,25 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x05 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12K\n" +
-	"\rcustom_fields\x18\a \x03(\v2&.diode.v1.MACAddress.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2&.diode.v1.MACAddress.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x11\n" +
 	"\x0fassigned_objectB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xbc\x02\n" +
+	"\t_comments\"\xf7\x02\n" +
 	"\fManufacturer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x04 \x03(\v2\r.diode.v1.TagR\x04tags\x12M\n" +
-	"\rcustom_fields\x18\x05 \x03(\v2(.diode.v1.Manufacturer.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x05 \x03(\v2(.diode.v1.Manufacturer.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x06 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
-	"\f_description\"\x8d\x05\n" +
+	"\f_description\"\xc8\x05\n" +
 	"\x06Module\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x122\n" +
 	"\n" +
@@ -25442,7 +26261,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\b \x01(\tH\x04R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\t \x03(\v2\r.diode.v1.TagR\x04tags\x12G\n" +
 	"\rcustom_fields\x18\n" +
-	" \x03(\v2\".diode.v1.Module.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	" \x03(\v2\".diode.v1.Module.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\v \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -25451,7 +26271,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
 	"_asset_tagB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xb0\x04\n" +
+	"\t_comments\"\xeb\x04\n" +
 	"\tModuleBay\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -25461,7 +26281,9 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bposition\x18\x06 \x01(\tH\x03R\bposition\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\a \x01(\tH\x04R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\b \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\t \x03(\v2%.diode.v1.ModuleBay.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\t \x03(\v2%.diode.v1.ModuleBay.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -25469,7 +26291,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x11_installed_moduleB\b\n" +
 	"\x06_labelB\v\n" +
 	"\t_positionB\x0e\n" +
-	"\f_description\"\xbb\x06\n" +
+	"\f_description\"\xf6\x06\n" +
 	"\n" +
 	"ModuleType\x12:\n" +
 	"\fmanufacturer\x18\x01 \x01(\v2\x16.diode.v1.ManufacturerR\fmanufacturer\x12\x14\n" +
@@ -25488,7 +26310,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\aprofile\x18\v \x01(\v2\x1b.diode.v1.ModuleTypeProfileH\x06R\aprofile\x88\x01\x01\x12#\n" +
 	"\n" +
 	"attributes\x18\f \x01(\tH\aR\n" +
-	"attributes\x88\x01\x01\x1a[\n" +
+	"attributes\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\r \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
@@ -25501,7 +26324,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\t_commentsB\n" +
 	"\n" +
 	"\b_profileB\r\n" +
-	"\v_attributes\"\xf0\x03\n" +
+	"\v_attributes\"\xab\x04\n" +
 	"\bPlatform\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12?\n" +
@@ -25510,14 +26333,15 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12I\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2$.diode.v1.Platform.CustomFieldsEntryR\fcustomFields\x12/\n" +
 	"\x06parent\x18\a \x01(\v2\x12.diode.v1.PlatformH\x02R\x06parent\x88\x01\x01\x12\x1f\n" +
-	"\bcomments\x18\b \x01(\tH\x03R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\b \x01(\tH\x03R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\t \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0f\n" +
 	"\r_manufacturerB\x0e\n" +
 	"\f_descriptionB\t\n" +
 	"\a_parentB\v\n" +
-	"\t_comments\"\xd9\a\n" +
+	"\t_comments\"\x94\b\n" +
 	"\tPowerFeed\x125\n" +
 	"\vpower_panel\x18\x01 \x01(\v2\x14.diode.v1.PowerPanelR\n" +
 	"powerPanel\x12'\n" +
@@ -25538,7 +26362,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"R\x06tenant\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x0e \x01(\tH\vR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0f \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\x10 \x03(\v2%.diode.v1.PowerFeed.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x10 \x03(\v2%.diode.v1.PowerFeed.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x11 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -25554,7 +26379,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0f_mark_connectedB\x0e\n" +
 	"\f_descriptionB\t\n" +
 	"\a_tenantB\v\n" +
-	"\t_comments\"\xd8\x10\n" +
+	"\t_comments\"\x93\x11\n" +
 	"\vPowerOutlet\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -25584,7 +26409,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	" \x01(\bH\aR\rmarkConnected\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\v \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
 	"\rcustom_fields\x18\f \x03(\v2'.diode.v1.PowerOutlet.CustomFieldsEntryR\fcustomFields\x12=\n" +
-	"\x06status\x18\r \x01(\tB \xfaB\x1dr\x1bR\bdisabledR\aenabledR\x06faultyH\bR\x06status\x88\x01\x01\x1a[\n" +
+	"\x06status\x18\r \x01(\tB \xfaB\x1dr\x1bR\bdisabledR\aenabledR\x06faultyH\bR\x06status\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\x0e \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -25596,7 +26422,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\t_feed_legB\x0e\n" +
 	"\f_descriptionB\x11\n" +
 	"\x0f_mark_connectedB\t\n" +
-	"\a_status\"\xb8\x03\n" +
+	"\a_status\"\xf3\x03\n" +
 	"\n" +
 	"PowerPanel\x12\"\n" +
 	"\x04site\x18\x01 \x01(\v2\x0e.diode.v1.SiteR\x04site\x123\n" +
@@ -25605,13 +26431,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x05 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12K\n" +
-	"\rcustom_fields\x18\a \x03(\v2&.diode.v1.PowerPanel.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2&.diode.v1.PowerPanel.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\v\n" +
 	"\t_locationB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\x90\x10\n" +
+	"\t_comments\"\xcb\x10\n" +
 	"\tPowerPort\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -25636,7 +26463,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0emark_connected\x18\t \x01(\bH\x06R\rmarkConnected\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\n" +
 	" \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
-	"\rcustom_fields\x18\v \x03(\v2%.diode.v1.PowerPort.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\v \x03(\v2%.diode.v1.PowerPort.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -25646,7 +26474,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\r_maximum_drawB\x11\n" +
 	"\x0f_allocated_drawB\x0e\n" +
 	"\f_descriptionB\x11\n" +
-	"\x0f_mark_connected\"\xc7\a\n" +
+	"\x0f_mark_connected\"\x82\b\n" +
 	"\x06Prefix\x12\x16\n" +
 	"\x06prefix\x18\x01 \x01(\tR\x06prefix\x12$\n" +
 	"\x03vrf\x18\x02 \x01(\v2\r.diode.v1.VRFH\x01R\x03vrf\x88\x01\x01\x12;\n" +
@@ -25666,7 +26494,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\r \x01(\tH\bR\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x0e \x01(\tH\tR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0f \x03(\v2\r.diode.v1.TagR\x04tags\x12G\n" +
-	"\rcustom_fields\x18\x10 \x03(\v2\".diode.v1.Prefix.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x10 \x03(\v2\".diode.v1.Prefix.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x11 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -25680,7 +26509,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\b_is_poolB\x10\n" +
 	"\x0e_mark_utilizedB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xbc\x03\n" +
+	"\t_comments\"\xf7\x03\n" +
 	"\bProvider\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12%\n" +
@@ -25689,12 +26518,13 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12I\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2$.diode.v1.Provider.CustomFieldsEntryR\fcustomFields\x125\n" +
 	"\baccounts\x18\a \x03(\v2\x19.diode.v1.ProviderAccountR\baccounts\x12!\n" +
-	"\x04asns\x18\b \x03(\v2\r.diode.v1.ASNR\x04asns\x1a[\n" +
+	"\x04asns\x18\b \x03(\v2\r.diode.v1.ASNR\x04asns\x129\n" +
+	"\bmetadata\x18\t \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xb4\x03\n" +
+	"\t_comments\"\xef\x03\n" +
 	"\x0fProviderAccount\x12.\n" +
 	"\bprovider\x18\x01 \x01(\v2\x12.diode.v1.ProviderR\bprovider\x12\x17\n" +
 	"\x04name\x18\x02 \x01(\tH\x00R\x04name\x88\x01\x01\x12\x18\n" +
@@ -25702,13 +26532,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x05 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12P\n" +
-	"\rcustom_fields\x18\a \x03(\v2+.diode.v1.ProviderAccount.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2+.diode.v1.ProviderAccount.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
 	"\x05_nameB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xbf\x03\n" +
+	"\t_comments\"\xfa\x03\n" +
 	"\x0fProviderNetwork\x12.\n" +
 	"\bprovider\x18\x01 \x01(\v2\x12.diode.v1.ProviderR\bprovider\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\"\n" +
@@ -25717,13 +26548,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x05 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12P\n" +
-	"\rcustom_fields\x18\a \x03(\v2+.diode.v1.ProviderNetwork.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2+.diode.v1.ProviderNetwork.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\r\n" +
 	"\v_service_idB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xdd\x02\n" +
+	"\t_comments\"\x98\x03\n" +
 	"\x03RIR\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\"\n" +
@@ -25731,12 +26563,13 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"is_private\x18\x03 \x01(\bH\x00R\tisPrivate\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12D\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2\x1f.diode.v1.RIR.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2\x1f.diode.v1.RIR.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\r\n" +
 	"\v_is_privateB\x0e\n" +
-	"\f_description\"\xec\r\n" +
+	"\f_description\"\xa7\x0e\n" +
 	"\x04Rack\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12$\n" +
 	"\vfacility_id\x18\x02 \x01(\tH\x00R\n" +
@@ -25780,7 +26613,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x19 \x01(\tH\x16R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x1a \x03(\v2\r.diode.v1.TagR\x04tags\x12E\n" +
 	"\rcustom_fields\x18\x1b \x03(\v2 .diode.v1.Rack.CustomFieldsEntryR\fcustomFields\x12&\n" +
-	"\fouter_height\x18\x1c \x01(\x03H\x17R\vouterHeight\x88\x01\x01\x1a[\n" +
+	"\fouter_height\x18\x1c \x01(\x03H\x17R\vouterHeight\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\x1d \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
@@ -25810,7 +26644,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\b_airflowB\x0e\n" +
 	"\f_descriptionB\v\n" +
 	"\t_commentsB\x0f\n" +
-	"\r_outer_height\"\xee\x03\n" +
+	"\r_outer_height\"\xa9\x04\n" +
 	"\x0fRackReservation\x12\"\n" +
 	"\x04rack\x18\x01 \x01(\v2\x0e.diode.v1.RackR\x04rack\x12\x14\n" +
 	"\x05units\x18\x02 \x03(\x03R\x05units\x12-\n" +
@@ -25819,25 +26653,28 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x05 \x01(\tH\x01R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12P\n" +
 	"\rcustom_fields\x18\a \x03(\v2+.diode.v1.RackReservation.CustomFieldsEntryR\fcustomFields\x12:\n" +
-	"\x06status\x18\b \x01(\tB\x1d\xfaB\x1ar\x18R\x06activeR\apendingR\x05staleH\x02R\x06status\x88\x01\x01\x1a[\n" +
+	"\x06status\x18\b \x01(\tB\x1d\xfaB\x1ar\x18R\x06activeR\apendingR\x05staleH\x02R\x06status\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\t \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_tenantB\v\n" +
 	"\t_commentsB\t\n" +
-	"\a_status\"\xd9\x02\n" +
+	"\a_status\"\x94\x03\n" +
 	"\bRackRole\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x19\n" +
 	"\x05color\x18\x03 \x01(\tH\x00R\x05color\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12I\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2$.diode.v1.RackRole.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2$.diode.v1.RackRole.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
 	"\x06_colorB\x0e\n" +
-	"\f_description\"\xed\t\n" +
+	"\f_description\"\xa8\n" +
+	"\n" +
 	"\bRackType\x12:\n" +
 	"\fmanufacturer\x18\x01 \x01(\v2\x16.diode.v1.ManufacturerR\fmanufacturer\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x12\n" +
@@ -25871,7 +26708,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x11 \x01(\tH\rR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x12 \x03(\v2\r.diode.v1.TagR\x04tags\x12I\n" +
 	"\rcustom_fields\x18\x13 \x03(\v2$.diode.v1.RackType.CustomFieldsEntryR\fcustomFields\x12&\n" +
-	"\fouter_height\x18\x14 \x01(\x03H\x0eR\vouterHeight\x88\x01\x01\x1a[\n" +
+	"\fouter_height\x18\x14 \x01(\x03H\x0eR\vouterHeight\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\x15 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
@@ -25889,7 +26727,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\f_weight_unitB\x11\n" +
 	"\x0f_mounting_depthB\v\n" +
 	"\t_commentsB\x0f\n" +
-	"\r_outer_height\"\x85\b\n" +
+	"\r_outer_height\"\xc0\b\n" +
 	"\bRearPort\x12(\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12-\n" +
 	"\x06module\x18\x02 \x01(\v2\x10.diode.v1.ModuleH\x00R\x06module\x88\x01\x01\x12\x12\n" +
@@ -25904,7 +26742,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0emark_connected\x18\t \x01(\bH\x05R\rmarkConnected\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\n" +
 	" \x03(\v2\r.diode.v1.TagR\x04tags\x12I\n" +
-	"\rcustom_fields\x18\v \x03(\v2$.diode.v1.RearPort.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\v \x03(\v2$.diode.v1.RearPort.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -25914,7 +26753,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
 	"_positionsB\x0e\n" +
 	"\f_descriptionB\x11\n" +
-	"\x0f_mark_connected\"\x98\x03\n" +
+	"\x0f_mark_connected\"\xd3\x03\n" +
 	"\x06Region\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12-\n" +
@@ -25922,38 +26761,41 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12G\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2\".diode.v1.Region.CustomFieldsEntryR\fcustomFields\x12\x1f\n" +
-	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_parentB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xd4\x02\n" +
+	"\t_comments\"\x8f\x03\n" +
 	"\x04Role\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x1b\n" +
 	"\x06weight\x18\x03 \x01(\x03H\x00R\x06weight\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12E\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2 .diode.v1.Role.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2 .diode.v1.Role.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_weightB\x0e\n" +
-	"\f_description\"\x8e\x03\n" +
+	"\f_description\"\xc9\x03\n" +
 	"\vRouteTarget\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12-\n" +
 	"\x06tenant\x18\x02 \x01(\v2\x10.diode.v1.TenantH\x00R\x06tenant\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x01R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x04 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.RouteTarget.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.RouteTarget.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_tenantB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\x82\a\n" +
+	"\t_comments\"\xbd\a\n" +
 	"\aService\x121\n" +
 	"\x06device\x18\x01 \x01(\v2\x10.diode.v1.DeviceB\x02\x18\x01H\x01R\x06device\x88\x01\x01\x12J\n" +
 	"\x0fvirtual_machine\x18\x02 \x01(\v2\x18.diode.v1.VirtualMachineB\x02\x18\x01H\x02R\x0evirtualMachine\x88\x01\x01\x12\x12\n" +
@@ -25968,7 +26810,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	" \x03(\v2\x13.diode.v1.IPAddressR\vipaddresses\x12D\n" +
 	"\x14parent_object_device\x18\v \x01(\v2\x10.diode.v1.DeviceH\x00R\x12parentObjectDevice\x12N\n" +
 	"\x18parent_object_fhrp_group\x18\f \x01(\v2\x13.diode.v1.FHRPGroupH\x00R\x15parentObjectFhrpGroup\x12]\n" +
-	"\x1dparent_object_virtual_machine\x18\r \x01(\v2\x18.diode.v1.VirtualMachineH\x00R\x1aparentObjectVirtualMachine\x1a[\n" +
+	"\x1dparent_object_virtual_machine\x18\r \x01(\v2\x18.diode.v1.VirtualMachineH\x00R\x1aparentObjectVirtualMachine\x129\n" +
+	"\bmetadata\x18\x0e \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0f\n" +
@@ -25977,7 +26820,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x10_virtual_machineB\v\n" +
 	"\t_protocolB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xd5\a\n" +
+	"\t_comments\"\x90\b\n" +
 	"\x04Site\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12V\n" +
@@ -25997,7 +26840,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x0e \x01(\tH\vR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0f \x03(\v2\r.diode.v1.TagR\x04tags\x12E\n" +
 	"\rcustom_fields\x18\x10 \x03(\v2 .diode.v1.Site.CustomFieldsEntryR\fcustomFields\x12!\n" +
-	"\x04asns\x18\x11 \x03(\v2\r.diode.v1.ASNR\x04asns\x1a[\n" +
+	"\x04asns\x18\x11 \x03(\v2\r.diode.v1.ASNR\x04asns\x129\n" +
+	"\bmetadata\x18\x12 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -26014,7 +26858,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\t_latitudeB\f\n" +
 	"\n" +
 	"_longitudeB\v\n" +
-	"\t_comments\"\xa1\x03\n" +
+	"\t_comments\"\xdc\x03\n" +
 	"\tSiteGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x120\n" +
@@ -26022,13 +26866,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2%.diode.v1.SiteGroup.CustomFieldsEntryR\fcustomFields\x12\x1f\n" +
-	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_parentB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xd6\x0e\n" +
+	"\t_comments\"\x91\x0f\n" +
 	"\x03Tag\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x19\n" +
@@ -26037,10 +26882,11 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x06weight\x18\x05 \x01(\x03H\x02R\x06weight\x88\x01\x01\x12\xa2\r\n" +
 	"\fobject_types\x18\x06 \x03(\tB\xfe\f\xfaB\xfa\f\x92\x01\xf6\f\"\xf3\fr\xf0\fR\x10circuits.circuitR\x15circuits.circuitgroupR\x1fcircuits.circuitgroupassignmentR\x1bcircuits.circuitterminationR\x14circuits.circuittypeR\x11circuits.providerR\x18circuits.provideraccountR\x18circuits.providernetworkR\x17circuits.virtualcircuitR\"circuits.virtualcircuitterminationR\x1bcircuits.virtualcircuittypeR\n" +
 	"dcim.cableR\x10dcim.consoleportR\x16dcim.consoleserverportR\vdcim.deviceR\x0edcim.devicebayR\x0fdcim.deviceroleR\x0fdcim.devicetypeR\x0edcim.frontportR\x0edcim.interfaceR\x12dcim.inventoryitemR\x16dcim.inventoryitemroleR\rdcim.locationR\x0fdcim.macaddressR\x11dcim.manufacturerR\vdcim.moduleR\x0edcim.modulebayR\x0fdcim.moduletypeR\x16dcim.moduletypeprofileR\rdcim.platformR\x0edcim.powerfeedR\x10dcim.poweroutletR\x0fdcim.powerpanelR\x0edcim.powerportR\tdcim.rackR\x14dcim.rackreservationR\rdcim.rackroleR\rdcim.racktypeR\rdcim.rearportR\vdcim.regionR\tdcim.siteR\x0edcim.sitegroupR\x13dcim.virtualchassisR\x19dcim.virtualdevicecontextR\x13extras.journalentryR\x0eipam.aggregateR\bipam.asnR\ripam.asnrangeR\x0eipam.fhrpgroupR\x0eipam.ipaddressR\fipam.iprangeR\vipam.prefixR\bipam.rirR\tipam.roleR\x10ipam.routetargetR\fipam.serviceR\tipam.vlanR\x0eipam.vlangroupR\x1aipam.vlantranslationpolicyR\x18ipam.vlantranslationruleR\bipam.vrfR\x0ftenancy.contactR\x19tenancy.contactassignmentR\x14tenancy.contactgroupR\x13tenancy.contactroleR\x0etenancy.tenantR\x13tenancy.tenantgroupR\x16virtualization.clusterR\x1bvirtualization.clustergroupR\x1avirtualization.clustertypeR\x1avirtualization.virtualdiskR\x1dvirtualization.virtualmachineR\x1avirtualization.vminterfaceR\rvpn.ikepolicyR\x0fvpn.ikeproposalR\x0fvpn.ipsecpolicyR\x10vpn.ipsecprofileR\x11vpn.ipsecproposalR\tvpn.l2vpnR\x14vpn.l2vpnterminationR\n" +
-	"vpn.tunnelR\x0fvpn.tunnelgroupR\x15vpn.tunnelterminationR\x14wireless.wirelesslanR\x19wireless.wirelesslangroupR\x15wireless.wirelesslinkR\vobjectTypesB\b\n" +
+	"vpn.tunnelR\x0fvpn.tunnelgroupR\x15vpn.tunnelterminationR\x14wireless.wirelesslanR\x19wireless.wirelesslangroupR\x15wireless.wirelesslinkR\vobjectTypes\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\b\n" +
 	"\x06_colorB\x0e\n" +
 	"\f_descriptionB\t\n" +
-	"\a_weight\"\x9a\x03\n" +
+	"\a_weight\"\xd5\x03\n" +
 	"\x06Tenant\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x120\n" +
@@ -26048,13 +26894,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x05 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12G\n" +
-	"\rcustom_fields\x18\a \x03(\v2\".diode.v1.Tenant.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2\".diode.v1.Tenant.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
 	"\x06_groupB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xa7\x03\n" +
+	"\t_comments\"\xe2\x03\n" +
 	"\vTenantGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x122\n" +
@@ -26062,13 +26909,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.TenantGroup.CustomFieldsEntryR\fcustomFields\x12\x1f\n" +
-	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_parentB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xf6\x05\n" +
+	"\t_comments\"\xb1\x06\n" +
 	"\x06Tunnel\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x128\n" +
 	"\x06status\x18\x02 \x01(\tB \xfaB\x1dr\x1bR\x06activeR\bdisabledR\aplannedR\x06status\x120\n" +
@@ -26081,7 +26929,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\t \x01(\tH\x05R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\n" +
 	" \x03(\v2\r.diode.v1.TagR\x04tags\x12G\n" +
-	"\rcustom_fields\x18\v \x03(\v2\".diode.v1.Tunnel.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\v \x03(\v2\".diode.v1.Tunnel.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
@@ -26091,17 +26940,18 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
 	"_tunnel_idB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xba\x02\n" +
+	"\t_comments\"\xf5\x02\n" +
 	"\vTunnelGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x04 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
-	"\rcustom_fields\x18\x05 \x03(\v2'.diode.v1.TunnelGroup.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x05 \x03(\v2'.diode.v1.TunnelGroup.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x06 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
-	"\f_description\"\x85?\n" +
+	"\f_description\"\xc0?\n" +
 	"\x11TunnelTermination\x12(\n" +
 	"\x06tunnel\x18\x01 \x01(\v2\x10.diode.v1.TunnelR\x06tunnel\x12+\n" +
 	"\x04role\x18\x02 \x01(\tB\x17\xfaB\x14r\x12R\x03hubR\x04peerR\x05spokeR\x04role\x128\n" +
@@ -26202,12 +27052,13 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
 	"outside_ip\x18[ \x01(\v2\x13.diode.v1.IPAddressH\x01R\toutsideIp\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\\ \x03(\v2\r.diode.v1.TagR\x04tags\x12R\n" +
-	"\rcustom_fields\x18] \x03(\v2-.diode.v1.TunnelTermination.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18] \x03(\v2-.diode.v1.TunnelTermination.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18c \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\r\n" +
 	"\vterminationB\r\n" +
-	"\v_outside_ip\"\x85\x06\n" +
+	"\v_outside_ip\"\xc0\x06\n" +
 	"\x04VLAN\x12'\n" +
 	"\x04site\x18\x01 \x01(\v2\x0e.diode.v1.SiteH\x00R\x04site\x88\x01\x01\x12.\n" +
 	"\x05group\x18\x02 \x01(\v2\x13.diode.v1.VLANGroupH\x01R\x05group\x88\x01\x01\x12\x10\n" +
@@ -26224,7 +27075,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	" \x01(\v2\x0e.diode.v1.VLANH\aR\tqinqSvlan\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\v \x01(\tH\bR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\f \x03(\v2\r.diode.v1.TagR\x04tags\x12E\n" +
-	"\rcustom_fields\x18\r \x03(\v2 .diode.v1.VLAN.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\r \x03(\v2 .diode.v1.VLAN.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x0e \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -26237,7 +27089,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\n" +
 	"_qinq_roleB\r\n" +
 	"\v_qinq_svlanB\v\n" +
-	"\t_comments\"\xb3\x06\n" +
+	"\t_comments\"\xee\x06\n" +
 	"\tVLANGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x128\n" +
@@ -26256,24 +27108,27 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\v \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\f \x03(\v2\r.diode.v1.TagR\x04tags\x12J\n" +
 	"\rcustom_fields\x18\r \x03(\v2%.diode.v1.VLANGroup.CustomFieldsEntryR\fcustomFields\x12-\n" +
-	"\x06tenant\x18\x0e \x01(\v2\x10.diode.v1.TenantH\x02R\x06tenant\x88\x01\x01\x1a[\n" +
+	"\x06tenant\x18\x0e \x01(\v2\x10.diode.v1.TenantH\x02R\x06tenant\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\x0f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
 	"\x05scopeB\x0e\n" +
 	"\f_descriptionB\t\n" +
-	"\a_tenant\"b\n" +
+	"\a_tenant\"\x9d\x01\n" +
 	"\x15VLANTranslationPolicy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
-	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01B\x0e\n" +
-	"\f_description\"\xc1\x01\n" +
+	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\x03 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\x0e\n" +
+	"\f_description\"\xfc\x01\n" +
 	"\x13VLANTranslationRule\x127\n" +
 	"\x06policy\x18\x01 \x01(\v2\x1f.diode.v1.VLANTranslationPolicyR\x06policy\x12\x1b\n" +
 	"\tlocal_vid\x18\x02 \x01(\x03R\blocalVid\x12\x1d\n" +
 	"\n" +
 	"remote_vid\x18\x03 \x01(\x03R\tremoteVid\x12%\n" +
-	"\vdescription\x18\x04 \x01(\tH\x00R\vdescription\x88\x01\x01B\x0e\n" +
-	"\f_description\"\xcb\b\n" +
+	"\vdescription\x18\x04 \x01(\tH\x00R\vdescription\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\x05 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\x0e\n" +
+	"\f_description\"\x86\t\n" +
 	"\vVMInterface\x12A\n" +
 	"\x0fvirtual_machine\x18\x01 \x01(\v2\x18.diode.v1.VirtualMachineR\x0evirtualMachine\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1d\n" +
@@ -26294,7 +27149,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"R\x03vrf\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0e \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
 	"\rcustom_fields\x18\x0f \x03(\v2'.diode.v1.VMInterface.CustomFieldsEntryR\fcustomFields\x121\n" +
-	"\ftagged_vlans\x18\x10 \x03(\v2\x0e.diode.v1.VLANR\vtaggedVlans\x1a[\n" +
+	"\ftagged_vlans\x18\x10 \x03(\v2\x0e.diode.v1.VLANR\vtaggedVlans\x129\n" +
+	"\bmetadata\x18\x11 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\n" +
@@ -26309,7 +27165,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x0e_untagged_vlanB\r\n" +
 	"\v_qinq_svlanB\x1a\n" +
 	"\x18_vlan_translation_policyB\x06\n" +
-	"\x04_vrf\"\xd5\x04\n" +
+	"\x04_vrf\"\x90\x05\n" +
 	"\x03VRF\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x13\n" +
 	"\x02rd\x18\x02 \x01(\tH\x00R\x02rd\x88\x01\x01\x12-\n" +
@@ -26321,7 +27177,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\rcustom_fields\x18\b \x03(\v2\x1f.diode.v1.VRF.CustomFieldsEntryR\fcustomFields\x12<\n" +
 	"\x0eimport_targets\x18\t \x03(\v2\x15.diode.v1.RouteTargetR\rimportTargets\x12<\n" +
 	"\x0eexport_targets\x18\n" +
-	" \x03(\v2\x15.diode.v1.RouteTargetR\rexportTargets\x1a[\n" +
+	" \x03(\v2\x15.diode.v1.RouteTargetR\rexportTargets\x129\n" +
+	"\bmetadata\x18\v \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x05\n" +
@@ -26329,7 +27186,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\a_tenantB\x11\n" +
 	"\x0f_enforce_uniqueB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xbc\x03\n" +
+	"\t_comments\"\xf7\x03\n" +
 	"\x0eVirtualChassis\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\x06domain\x18\x02 \x01(\tH\x00R\x06domain\x88\x01\x01\x12-\n" +
@@ -26337,14 +27194,15 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x02R\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x05 \x01(\tH\x03R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x06 \x03(\v2\r.diode.v1.TagR\x04tags\x12O\n" +
-	"\rcustom_fields\x18\a \x03(\v2*.diode.v1.VirtualChassis.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\a \x03(\v2*.diode.v1.VirtualChassis.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_domainB\t\n" +
 	"\a_masterB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xe1\x05\n" +
+	"\t_comments\"\x9c\x06\n" +
 	"\x0eVirtualCircuit\x12\x10\n" +
 	"\x03cid\x18\x01 \x01(\tR\x03cid\x12D\n" +
 	"\x10provider_network\x18\x02 \x01(\v2\x19.diode.v1.ProviderNetworkR\x0fproviderNetwork\x12I\n" +
@@ -26356,7 +27214,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\b \x01(\tH\x04R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\t \x03(\v2\r.diode.v1.TagR\x04tags\x12O\n" +
 	"\rcustom_fields\x18\n" +
-	" \x03(\v2*.diode.v1.VirtualCircuit.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	" \x03(\v2*.diode.v1.VirtualCircuit.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\v \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x13\n" +
@@ -26364,31 +27223,33 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\a_statusB\t\n" +
 	"\a_tenantB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xdf\x03\n" +
+	"\t_comments\"\x9a\x04\n" +
 	"\x19VirtualCircuitTermination\x12A\n" +
 	"\x0fvirtual_circuit\x18\x01 \x01(\v2\x18.diode.v1.VirtualCircuitR\x0evirtualCircuit\x120\n" +
 	"\x04role\x18\x02 \x01(\tB\x17\xfaB\x14r\x12R\x03hubR\x04peerR\x05spokeH\x00R\x04role\x88\x01\x01\x121\n" +
 	"\tinterface\x18\x03 \x01(\v2\x13.diode.v1.InterfaceR\tinterface\x12%\n" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12Z\n" +
-	"\rcustom_fields\x18\x06 \x03(\v25.diode.v1.VirtualCircuitTermination.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v25.diode.v1.VirtualCircuitTermination.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
 	"\x05_roleB\x0e\n" +
-	"\f_description\"\xed\x02\n" +
+	"\f_description\"\xa8\x03\n" +
 	"\x12VirtualCircuitType\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x19\n" +
 	"\x05color\x18\x03 \x01(\tH\x00R\x05color\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12S\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2..diode.v1.VirtualCircuitType.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2..diode.v1.VirtualCircuitType.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\b\n" +
 	"\x06_colorB\x0e\n" +
-	"\f_description\"\xcd\x05\n" +
+	"\f_description\"\x88\x06\n" +
 	"\x14VirtualDeviceContext\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12(\n" +
 	"\x06device\x18\x02 \x01(\v2\x10.diode.v1.DeviceR\x06device\x12#\n" +
@@ -26405,7 +27266,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\t \x01(\tH\x05R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\n" +
 	" \x03(\v2\r.diode.v1.TagR\x04tags\x12U\n" +
-	"\rcustom_fields\x18\v \x03(\v20.diode.v1.VirtualDeviceContext.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\v \x03(\v20.diode.v1.VirtualDeviceContext.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\r\n" +
@@ -26414,18 +27276,19 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\f_primary_ip4B\x0e\n" +
 	"\f_primary_ip6B\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xfd\x02\n" +
+	"\t_comments\"\xb8\x03\n" +
 	"\vVirtualDisk\x12A\n" +
 	"\x0fvirtual_machine\x18\x01 \x01(\v2\x18.diode.v1.VirtualMachineR\x0evirtualMachine\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12\x12\n" +
 	"\x04size\x18\x04 \x01(\x03R\x04size\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.VirtualDisk.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2'.diode.v1.VirtualDisk.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
-	"\f_description\"\xd7\b\n" +
+	"\f_description\"\x92\t\n" +
 	"\x0eVirtualMachine\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12e\n" +
 	"\x06status\x18\x02 \x01(\tBH\xfaBErCR\x06activeR\x0fdecommissioningR\x06failedR\aofflineR\x06pausedR\aplannedR\x06stagedH\x00R\x06status\x88\x01\x01\x12'\n" +
@@ -26448,7 +27311,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x0f \x01(\tH\rR\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x10 \x01(\tH\x0eR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x11 \x03(\v2\r.diode.v1.TagR\x04tags\x12O\n" +
-	"\rcustom_fields\x18\x12 \x03(\v2*.diode.v1.VirtualMachine.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x12 \x03(\v2*.diode.v1.VirtualMachine.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x13 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
@@ -26467,7 +27331,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\a_memoryB\a\n" +
 	"\x05_diskB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xa2\b\n" +
+	"\t_comments\"\xdd\b\n" +
 	"\vWirelessLAN\x12\x12\n" +
 	"\x04ssid\x18\x01 \x01(\tR\x04ssid\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x01R\vdescription\x88\x01\x01\x125\n" +
@@ -26488,7 +27352,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bauth_psk\x18\r \x01(\tH\bR\aauthPsk\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x0e \x01(\tH\tR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x0f \x03(\v2\r.diode.v1.TagR\x04tags\x12L\n" +
-	"\rcustom_fields\x18\x10 \x03(\v2'.diode.v1.WirelessLAN.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x10 \x03(\v2'.diode.v1.WirelessLAN.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x11 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -26502,7 +27367,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"_auth_typeB\x0e\n" +
 	"\f_auth_cipherB\v\n" +
 	"\t_auth_pskB\v\n" +
-	"\t_comments\"\xb6\x03\n" +
+	"\t_comments\"\xf1\x03\n" +
 	"\x10WirelessLANGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x127\n" +
@@ -26510,13 +27375,14 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\x04 \x01(\tH\x01R\vdescription\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12Q\n" +
 	"\rcustom_fields\x18\x06 \x03(\v2,.diode.v1.WirelessLANGroup.CustomFieldsEntryR\fcustomFields\x12\x1f\n" +
-	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x1a[\n" +
+	"\bcomments\x18\a \x01(\tH\x02R\bcomments\x88\x01\x01\x129\n" +
+	"\bmetadata\x18\b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\t\n" +
 	"\a_parentB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xb9\a\n" +
+	"\t_comments\"\xf4\a\n" +
 	"\fWirelessLink\x124\n" +
 	"\vinterface_a\x18\x01 \x01(\v2\x13.diode.v1.InterfaceR\n" +
 	"interfaceA\x124\n" +
@@ -26535,7 +27401,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\vdescription\x18\v \x01(\tH\bR\vdescription\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\f \x01(\tH\tR\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\r \x03(\v2\r.diode.v1.TagR\x04tags\x12M\n" +
-	"\rcustom_fields\x18\x0e \x03(\v2(.diode.v1.WirelessLink.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x0e \x03(\v2(.diode.v1.WirelessLink.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\x0f \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\a\n" +
@@ -26549,7 +27416,7 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\t_distanceB\x10\n" +
 	"\x0e_distance_unitB\x0e\n" +
 	"\f_descriptionB\v\n" +
-	"\t_comments\"\xff%\n" +
+	"\t_comments\"\xba&\n" +
 	"\vCustomField\x12\x89\x01\n" +
 	"\x04type\x18\x01 \x01(\tBu\xfaBrrpR\abooleanR\x04dateR\bdatetimeR\adecimalR\aintegerR\x04jsonR\blongtextR\vmultiobjectR\vmultiselectR\x06objectR\x06selectR\x04textR\x03urlR\x04type\x12\xbe\x0e\n" +
 	"\x13related_object_type\x18\x02 \x01(\tB\x88\x0e\xfaB\x84\x0er\x81\x0eR\x10circuits.circuitR\x15circuits.circuitgroupR\x1fcircuits.circuitgroupassignmentR\x1bcircuits.circuitterminationR\x14circuits.circuittypeR\x11circuits.providerR\x18circuits.provideraccountR\x18circuits.providernetworkR\x17circuits.virtualcircuitR\"circuits.virtualcircuitterminationR\x1bcircuits.virtualcircuittypeR\n" +
@@ -26583,7 +27450,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\bcomments\x18\x15 \x01(\tH\x12R\bcomments\x88\x01\x01\x12\xa2\r\n" +
 	"\fobject_types\x18\x16 \x03(\tB\xfe\f\xfaB\xfa\f\x92\x01\xf6\f\"\xf3\fr\xf0\fR\x10circuits.circuitR\x15circuits.circuitgroupR\x1fcircuits.circuitgroupassignmentR\x1bcircuits.circuitterminationR\x14circuits.circuittypeR\x11circuits.providerR\x18circuits.provideraccountR\x18circuits.providernetworkR\x17circuits.virtualcircuitR\"circuits.virtualcircuitterminationR\x1bcircuits.virtualcircuittypeR\n" +
 	"dcim.cableR\x10dcim.consoleportR\x16dcim.consoleserverportR\vdcim.deviceR\x0edcim.devicebayR\x0fdcim.deviceroleR\x0fdcim.devicetypeR\x0edcim.frontportR\x0edcim.interfaceR\x12dcim.inventoryitemR\x16dcim.inventoryitemroleR\rdcim.locationR\x0fdcim.macaddressR\x11dcim.manufacturerR\vdcim.moduleR\x0edcim.modulebayR\x0fdcim.moduletypeR\x16dcim.moduletypeprofileR\rdcim.platformR\x0edcim.powerfeedR\x10dcim.poweroutletR\x0fdcim.powerpanelR\x0edcim.powerportR\tdcim.rackR\x14dcim.rackreservationR\rdcim.rackroleR\rdcim.racktypeR\rdcim.rearportR\vdcim.regionR\tdcim.siteR\x0edcim.sitegroupR\x13dcim.virtualchassisR\x19dcim.virtualdevicecontextR\x13extras.journalentryR\x0eipam.aggregateR\bipam.asnR\ripam.asnrangeR\x0eipam.fhrpgroupR\x0eipam.ipaddressR\fipam.iprangeR\vipam.prefixR\bipam.rirR\tipam.roleR\x10ipam.routetargetR\fipam.serviceR\tipam.vlanR\x0eipam.vlangroupR\x1aipam.vlantranslationpolicyR\x18ipam.vlantranslationruleR\bipam.vrfR\x0ftenancy.contactR\x19tenancy.contactassignmentR\x14tenancy.contactgroupR\x13tenancy.contactroleR\x0etenancy.tenantR\x13tenancy.tenantgroupR\x16virtualization.clusterR\x1bvirtualization.clustergroupR\x1avirtualization.clustertypeR\x1avirtualization.virtualdiskR\x1dvirtualization.virtualmachineR\x1avirtualization.vminterfaceR\rvpn.ikepolicyR\x0fvpn.ikeproposalR\x0fvpn.ipsecpolicyR\x10vpn.ipsecprofileR\x11vpn.ipsecproposalR\tvpn.l2vpnR\x14vpn.l2vpnterminationR\n" +
-	"vpn.tunnelR\x0fvpn.tunnelgroupR\x15vpn.tunnelterminationR\x14wireless.wirelesslanR\x19wireless.wirelesslangroupR\x15wireless.wirelesslinkR\vobjectTypesB\x16\n" +
+	"vpn.tunnelR\x0fvpn.tunnelgroupR\x15vpn.tunnelterminationR\x14wireless.wirelesslanR\x19wireless.wirelesslangroupR\x15wireless.wirelesslinkR\vobjectTypes\x129\n" +
+	"\bmetadata\x18\x17 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\x16\n" +
 	"\x14_related_object_typeB\b\n" +
 	"\x06_labelB\r\n" +
 	"\v_group_nameB\x0e\n" +
@@ -26603,16 +27471,17 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x13_validation_maximumB\x13\n" +
 	"\x11_validation_regexB\r\n" +
 	"\v_choice_setB\v\n" +
-	"\t_comments\"\xb2\x02\n" +
+	"\t_comments\"\xed\x02\n" +
 	"\x14CustomFieldChoiceSet\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x12H\n" +
 	"\fbase_choices\x18\x03 \x01(\tB \xfaB\x1dr\x1bR\x04IATAR\bISO_3166R\tUN_LOCODEH\x01R\vbaseChoices\x88\x01\x01\x126\n" +
 	"\x14order_alphabetically\x18\x04 \x01(\bH\x02R\x13orderAlphabetically\x88\x01\x01\x12#\n" +
-	"\rextra_choices\x18\x05 \x03(\tR\fextraChoicesB\x0e\n" +
+	"\rextra_choices\x18\x05 \x03(\tR\fextraChoices\x129\n" +
+	"\bmetadata\x18\x06 \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\x0e\n" +
 	"\f_descriptionB\x0f\n" +
 	"\r_base_choicesB\x17\n" +
-	"\x15_order_alphabetically\"\xd1C\n" +
+	"\x15_order_alphabetically\"\x8cD\n" +
 	"\fJournalEntry\x12?\n" +
 	"\x13assigned_object_asn\x18\x01 \x01(\v2\r.diode.v1.ASNH\x00R\x11assignedObjectAsn\x12O\n" +
 	"\x19assigned_object_asn_range\x18\x02 \x01(\v2\x12.diode.v1.ASNRangeH\x00R\x16assignedObjectAsnRange\x12Q\n" +
@@ -26711,25 +27580,27 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\x04kind\x18] \x01(\tB%\xfaB\"r R\x06dangerR\x04infoR\asuccessR\awarningH\x01R\x04kind\x88\x01\x01\x12\x1a\n" +
 	"\bcomments\x18^ \x01(\tR\bcomments\x12!\n" +
 	"\x04tags\x18_ \x03(\v2\r.diode.v1.TagR\x04tags\x12M\n" +
-	"\rcustom_fields\x18` \x03(\v2(.diode.v1.JournalEntry.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18` \x03(\v2(.diode.v1.JournalEntry.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18b \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x11\n" +
 	"\x0fassigned_objectB\a\n" +
-	"\x05_kind\"\x88\x03\n" +
+	"\x05_kind\"\xc3\x03\n" +
 	"\x11ModuleTypeProfile\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
 	"\vdescription\x18\x02 \x01(\tH\x00R\vdescription\x88\x01\x01\x12\x1b\n" +
 	"\x06schema\x18\x03 \x01(\tH\x01R\x06schema\x88\x01\x01\x12\x1f\n" +
 	"\bcomments\x18\x04 \x01(\tH\x02R\bcomments\x88\x01\x01\x12!\n" +
 	"\x04tags\x18\x05 \x03(\v2\r.diode.v1.TagR\x04tags\x12R\n" +
-	"\rcustom_fields\x18\x06 \x03(\v2-.diode.v1.ModuleTypeProfile.CustomFieldsEntryR\fcustomFields\x1a[\n" +
+	"\rcustom_fields\x18\x06 \x03(\v2-.diode.v1.ModuleTypeProfile.CustomFieldsEntryR\fcustomFields\x129\n" +
+	"\bmetadata\x18\a \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadata\x1a[\n" +
 	"\x11CustomFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.diode.v1.CustomFieldValueR\x05value:\x028\x01B\x0e\n" +
 	"\f_descriptionB\t\n" +
 	"\a_schemaB\v\n" +
-	"\t_comments\"\xa8\x10\n" +
+	"\t_comments\"\xe3\x10\n" +
 	"\n" +
 	"CustomLink\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
@@ -26745,7 +27616,9 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"new_window\x18\b \x01(\bH\x04R\tnewWindow\x88\x01\x01\x12\xe6\f\n" +
 	"\fobject_types\x18\t \x03(\tB\xc2\f\xfaB\xbe\f\x92\x01\xba\f\"\xb7\fr\xb4\fR\x10circuits.circuitR\x15circuits.circuitgroupR\x1bcircuits.circuitterminationR\x14circuits.circuittypeR\x11circuits.providerR\x18circuits.provideraccountR\x18circuits.providernetworkR\x17circuits.virtualcircuitR\"circuits.virtualcircuitterminationR\x1bcircuits.virtualcircuittypeR\n" +
 	"dcim.cableR\x10dcim.consoleportR\x16dcim.consoleserverportR\vdcim.deviceR\x0edcim.devicebayR\x0fdcim.deviceroleR\x0fdcim.devicetypeR\x0edcim.frontportR\x0edcim.interfaceR\x12dcim.inventoryitemR\x16dcim.inventoryitemroleR\rdcim.locationR\x0fdcim.macaddressR\x11dcim.manufacturerR\vdcim.moduleR\x0edcim.modulebayR\x0fdcim.moduletypeR\x16dcim.moduletypeprofileR\rdcim.platformR\x0edcim.powerfeedR\x10dcim.poweroutletR\x0fdcim.powerpanelR\x0edcim.powerportR\tdcim.rackR\x14dcim.rackreservationR\rdcim.rackroleR\rdcim.racktypeR\rdcim.rearportR\vdcim.regionR\tdcim.siteR\x0edcim.sitegroupR\x13dcim.virtualchassisR\x19dcim.virtualdevicecontextR\x13extras.journalentryR\x0eipam.aggregateR\bipam.asnR\ripam.asnrangeR\x0eipam.fhrpgroupR\x0eipam.ipaddressR\fipam.iprangeR\vipam.prefixR\bipam.rirR\tipam.roleR\x10ipam.routetargetR\fipam.serviceR\tipam.vlanR\x0eipam.vlangroupR\x1aipam.vlantranslationpolicyR\x18ipam.vlantranslationruleR\bipam.vrfR\x0ftenancy.contactR\x14tenancy.contactgroupR\x13tenancy.contactroleR\x0etenancy.tenantR\x13tenancy.tenantgroupR\x16virtualization.clusterR\x1bvirtualization.clustergroupR\x1avirtualization.clustertypeR\x1avirtualization.virtualdiskR\x1dvirtualization.virtualmachineR\x1avirtualization.vminterfaceR\rvpn.ikepolicyR\x0fvpn.ikeproposalR\x0fvpn.ipsecpolicyR\x10vpn.ipsecprofileR\x11vpn.ipsecproposalR\tvpn.l2vpnR\x14vpn.l2vpnterminationR\n" +
-	"vpn.tunnelR\x0fvpn.tunnelgroupR\x15vpn.tunnelterminationR\x14wireless.wirelesslanR\x19wireless.wirelesslangroupR\x15wireless.wirelesslinkR\vobjectTypesB\n" +
+	"vpn.tunnelR\x0fvpn.tunnelgroupR\x15vpn.tunnelterminationR\x14wireless.wirelesslanR\x19wireless.wirelesslangroupR\x15wireless.wirelesslinkR\vobjectTypes\x129\n" +
+	"\bmetadata\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructB\x04\x88\xb5\x18\x00R\bmetadataB\n" +
 	"\n" +
 	"\b_enabledB\t\n" +
 	"\a_weightB\r\n" +
@@ -26753,7 +27626,8 @@ const file_diode_v1_ingester_proto_rawDesc = "" +
 	"\r_button_classB\r\n" +
 	"\v_new_window2N\n" +
 	"\x0fIngesterService\x12;\n" +
-	"\x06Ingest\x12\x17.diode.v1.IngestRequest\x1a\x18.diode.v1.IngestResponseB5Z3github.com/netboxlabs/diode-sdk-go/diode/v1/diodepbb\x06proto3"
+	"\x06Ingest\x12\x17.diode.v1.IngestRequest\x1a\x18.diode.v1.IngestResponse:J\n" +
+	"\x10netbox_supported\x12\x1d.google.protobuf.FieldOptions\x18ц\x03 \x01(\bR\x0fnetboxSupportedB5Z3github.com/netboxlabs/diode-sdk-go/diode/v1/diodepbb\x06proto3"
 
 var (
 	file_diode_v1_ingester_proto_rawDescOnce sync.Once
@@ -26952,6 +27826,8 @@ var file_diode_v1_ingester_proto_goTypes = []any{
 	nil,                                // 180: diode.v1.JournalEntry.CustomFieldsEntry
 	nil,                                // 181: diode.v1.ModuleTypeProfile.CustomFieldsEntry
 	(*timestamppb.Timestamp)(nil),      // 182: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),            // 183: google.protobuf.Struct
+	(*descriptorpb.FieldOptions)(nil),  // 184: google.protobuf.FieldOptions
 }
 var file_diode_v1_ingester_proto_depIdxs = []int32{
 	182,  // 0: diode.v1.Entity.timestamp:type_name -> google.protobuf.Timestamp
@@ -27049,1158 +27925,1253 @@ var file_diode_v1_ingester_proto_depIdxs = []int32{
 	97,   // 92: diode.v1.Entity.module_type_profile:type_name -> diode.v1.ModuleTypeProfile
 	98,   // 93: diode.v1.Entity.custom_link:type_name -> diode.v1.CustomLink
 	0,    // 94: diode.v1.IngestRequest.entities:type_name -> diode.v1.Entity
-	60,   // 95: diode.v1.ASN.rir:type_name -> diode.v1.RIR
-	73,   // 96: diode.v1.ASN.tenant:type_name -> diode.v1.Tenant
-	72,   // 97: diode.v1.ASN.tags:type_name -> diode.v1.Tag
-	99,   // 98: diode.v1.ASN.custom_fields:type_name -> diode.v1.ASN.CustomFieldsEntry
-	60,   // 99: diode.v1.ASNRange.rir:type_name -> diode.v1.RIR
-	73,   // 100: diode.v1.ASNRange.tenant:type_name -> diode.v1.Tenant
-	72,   // 101: diode.v1.ASNRange.tags:type_name -> diode.v1.Tag
-	100,  // 102: diode.v1.ASNRange.custom_fields:type_name -> diode.v1.ASNRange.CustomFieldsEntry
-	60,   // 103: diode.v1.Aggregate.rir:type_name -> diode.v1.RIR
-	73,   // 104: diode.v1.Aggregate.tenant:type_name -> diode.v1.Tenant
-	182,  // 105: diode.v1.Aggregate.date_added:type_name -> google.protobuf.Timestamp
-	72,   // 106: diode.v1.Aggregate.tags:type_name -> diode.v1.Tag
-	101,  // 107: diode.v1.Aggregate.custom_fields:type_name -> diode.v1.Aggregate.CustomFieldsEntry
-	32,   // 108: diode.v1.Cable.a_terminations:type_name -> diode.v1.GenericObject
-	32,   // 109: diode.v1.Cable.b_terminations:type_name -> diode.v1.GenericObject
-	73,   // 110: diode.v1.Cable.tenant:type_name -> diode.v1.Tenant
-	72,   // 111: diode.v1.Cable.tags:type_name -> diode.v1.Tag
-	102,  // 112: diode.v1.Cable.custom_fields:type_name -> diode.v1.Cable.CustomFieldsEntry
-	6,    // 113: diode.v1.CableTermination.cable:type_name -> diode.v1.Cable
-	12,   // 114: diode.v1.CableTermination.termination_circuit_termination:type_name -> diode.v1.CircuitTermination
-	17,   // 115: diode.v1.CableTermination.termination_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 116: diode.v1.CableTermination.termination_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	31,   // 117: diode.v1.CableTermination.termination_front_port:type_name -> diode.v1.FrontPort
-	40,   // 118: diode.v1.CableTermination.termination_interface:type_name -> diode.v1.Interface
-	52,   // 119: diode.v1.CableTermination.termination_power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 120: diode.v1.CableTermination.termination_power_outlet:type_name -> diode.v1.PowerOutlet
-	55,   // 121: diode.v1.CableTermination.termination_power_port:type_name -> diode.v1.PowerPort
-	65,   // 122: diode.v1.CableTermination.termination_rear_port:type_name -> diode.v1.RearPort
-	57,   // 123: diode.v1.Circuit.provider:type_name -> diode.v1.Provider
-	58,   // 124: diode.v1.Circuit.provider_account:type_name -> diode.v1.ProviderAccount
-	13,   // 125: diode.v1.Circuit.type:type_name -> diode.v1.CircuitType
-	73,   // 126: diode.v1.Circuit.tenant:type_name -> diode.v1.Tenant
-	182,  // 127: diode.v1.Circuit.install_date:type_name -> google.protobuf.Timestamp
-	182,  // 128: diode.v1.Circuit.termination_date:type_name -> google.protobuf.Timestamp
-	72,   // 129: diode.v1.Circuit.tags:type_name -> diode.v1.Tag
-	11,   // 130: diode.v1.Circuit.assignments:type_name -> diode.v1.CircuitGroupAssignment
-	103,  // 131: diode.v1.Circuit.custom_fields:type_name -> diode.v1.Circuit.CustomFieldsEntry
-	73,   // 132: diode.v1.CircuitGroup.tenant:type_name -> diode.v1.Tenant
-	72,   // 133: diode.v1.CircuitGroup.tags:type_name -> diode.v1.Tag
-	104,  // 134: diode.v1.CircuitGroup.custom_fields:type_name -> diode.v1.CircuitGroup.CustomFieldsEntry
-	10,   // 135: diode.v1.CircuitGroupAssignment.group:type_name -> diode.v1.CircuitGroup
-	9,    // 136: diode.v1.CircuitGroupAssignment.member_circuit:type_name -> diode.v1.Circuit
-	85,   // 137: diode.v1.CircuitGroupAssignment.member_virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	72,   // 138: diode.v1.CircuitGroupAssignment.tags:type_name -> diode.v1.Tag
-	9,    // 139: diode.v1.CircuitTermination.circuit:type_name -> diode.v1.Circuit
-	45,   // 140: diode.v1.CircuitTermination.termination_location:type_name -> diode.v1.Location
-	59,   // 141: diode.v1.CircuitTermination.termination_provider_network:type_name -> diode.v1.ProviderNetwork
-	66,   // 142: diode.v1.CircuitTermination.termination_region:type_name -> diode.v1.Region
-	70,   // 143: diode.v1.CircuitTermination.termination_site:type_name -> diode.v1.Site
-	71,   // 144: diode.v1.CircuitTermination.termination_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 145: diode.v1.CircuitTermination.tags:type_name -> diode.v1.Tag
-	105,  // 146: diode.v1.CircuitTermination.custom_fields:type_name -> diode.v1.CircuitTermination.CustomFieldsEntry
-	72,   // 147: diode.v1.CircuitType.tags:type_name -> diode.v1.Tag
-	106,  // 148: diode.v1.CircuitType.custom_fields:type_name -> diode.v1.CircuitType.CustomFieldsEntry
-	16,   // 149: diode.v1.Cluster.type:type_name -> diode.v1.ClusterType
-	15,   // 150: diode.v1.Cluster.group:type_name -> diode.v1.ClusterGroup
-	73,   // 151: diode.v1.Cluster.tenant:type_name -> diode.v1.Tenant
-	45,   // 152: diode.v1.Cluster.scope_location:type_name -> diode.v1.Location
-	66,   // 153: diode.v1.Cluster.scope_region:type_name -> diode.v1.Region
-	70,   // 154: diode.v1.Cluster.scope_site:type_name -> diode.v1.Site
-	71,   // 155: diode.v1.Cluster.scope_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 156: diode.v1.Cluster.tags:type_name -> diode.v1.Tag
-	107,  // 157: diode.v1.Cluster.custom_fields:type_name -> diode.v1.Cluster.CustomFieldsEntry
-	72,   // 158: diode.v1.ClusterGroup.tags:type_name -> diode.v1.Tag
-	108,  // 159: diode.v1.ClusterGroup.custom_fields:type_name -> diode.v1.ClusterGroup.CustomFieldsEntry
-	72,   // 160: diode.v1.ClusterType.tags:type_name -> diode.v1.Tag
-	109,  // 161: diode.v1.ClusterType.custom_fields:type_name -> diode.v1.ClusterType.CustomFieldsEntry
-	25,   // 162: diode.v1.ConsolePort.device:type_name -> diode.v1.Device
-	48,   // 163: diode.v1.ConsolePort.module:type_name -> diode.v1.Module
-	72,   // 164: diode.v1.ConsolePort.tags:type_name -> diode.v1.Tag
-	110,  // 165: diode.v1.ConsolePort.custom_fields:type_name -> diode.v1.ConsolePort.CustomFieldsEntry
-	25,   // 166: diode.v1.ConsoleServerPort.device:type_name -> diode.v1.Device
-	48,   // 167: diode.v1.ConsoleServerPort.module:type_name -> diode.v1.Module
-	72,   // 168: diode.v1.ConsoleServerPort.tags:type_name -> diode.v1.Tag
-	111,  // 169: diode.v1.ConsoleServerPort.custom_fields:type_name -> diode.v1.ConsoleServerPort.CustomFieldsEntry
-	21,   // 170: diode.v1.Contact.group:type_name -> diode.v1.ContactGroup
-	72,   // 171: diode.v1.Contact.tags:type_name -> diode.v1.Tag
-	112,  // 172: diode.v1.Contact.custom_fields:type_name -> diode.v1.Contact.CustomFieldsEntry
-	21,   // 173: diode.v1.Contact.groups:type_name -> diode.v1.ContactGroup
-	3,    // 174: diode.v1.ContactAssignment.object_asn:type_name -> diode.v1.ASN
-	4,    // 175: diode.v1.ContactAssignment.object_asn_range:type_name -> diode.v1.ASNRange
-	5,    // 176: diode.v1.ContactAssignment.object_aggregate:type_name -> diode.v1.Aggregate
-	6,    // 177: diode.v1.ContactAssignment.object_cable:type_name -> diode.v1.Cable
-	7,    // 178: diode.v1.ContactAssignment.object_cable_path:type_name -> diode.v1.CablePath
-	8,    // 179: diode.v1.ContactAssignment.object_cable_termination:type_name -> diode.v1.CableTermination
-	9,    // 180: diode.v1.ContactAssignment.object_circuit:type_name -> diode.v1.Circuit
-	10,   // 181: diode.v1.ContactAssignment.object_circuit_group:type_name -> diode.v1.CircuitGroup
-	11,   // 182: diode.v1.ContactAssignment.object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
-	12,   // 183: diode.v1.ContactAssignment.object_circuit_termination:type_name -> diode.v1.CircuitTermination
-	13,   // 184: diode.v1.ContactAssignment.object_circuit_type:type_name -> diode.v1.CircuitType
-	14,   // 185: diode.v1.ContactAssignment.object_cluster:type_name -> diode.v1.Cluster
-	15,   // 186: diode.v1.ContactAssignment.object_cluster_group:type_name -> diode.v1.ClusterGroup
-	16,   // 187: diode.v1.ContactAssignment.object_cluster_type:type_name -> diode.v1.ClusterType
-	17,   // 188: diode.v1.ContactAssignment.object_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 189: diode.v1.ContactAssignment.object_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	19,   // 190: diode.v1.ContactAssignment.object_contact:type_name -> diode.v1.Contact
-	20,   // 191: diode.v1.ContactAssignment.object_contact_assignment:type_name -> diode.v1.ContactAssignment
-	21,   // 192: diode.v1.ContactAssignment.object_contact_group:type_name -> diode.v1.ContactGroup
-	22,   // 193: diode.v1.ContactAssignment.object_contact_role:type_name -> diode.v1.ContactRole
-	25,   // 194: diode.v1.ContactAssignment.object_device:type_name -> diode.v1.Device
-	26,   // 195: diode.v1.ContactAssignment.object_device_bay:type_name -> diode.v1.DeviceBay
-	27,   // 196: diode.v1.ContactAssignment.object_device_role:type_name -> diode.v1.DeviceRole
-	28,   // 197: diode.v1.ContactAssignment.object_device_type:type_name -> diode.v1.DeviceType
-	29,   // 198: diode.v1.ContactAssignment.object_fhrp_group:type_name -> diode.v1.FHRPGroup
-	30,   // 199: diode.v1.ContactAssignment.object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
-	31,   // 200: diode.v1.ContactAssignment.object_front_port:type_name -> diode.v1.FrontPort
-	33,   // 201: diode.v1.ContactAssignment.object_ike_policy:type_name -> diode.v1.IKEPolicy
-	34,   // 202: diode.v1.ContactAssignment.object_ike_proposal:type_name -> diode.v1.IKEProposal
-	35,   // 203: diode.v1.ContactAssignment.object_ip_address:type_name -> diode.v1.IPAddress
-	36,   // 204: diode.v1.ContactAssignment.object_ip_range:type_name -> diode.v1.IPRange
-	37,   // 205: diode.v1.ContactAssignment.object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
-	38,   // 206: diode.v1.ContactAssignment.object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
-	39,   // 207: diode.v1.ContactAssignment.object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
-	40,   // 208: diode.v1.ContactAssignment.object_interface:type_name -> diode.v1.Interface
-	41,   // 209: diode.v1.ContactAssignment.object_inventory_item:type_name -> diode.v1.InventoryItem
-	42,   // 210: diode.v1.ContactAssignment.object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
-	43,   // 211: diode.v1.ContactAssignment.object_l2vpn:type_name -> diode.v1.L2VPN
-	44,   // 212: diode.v1.ContactAssignment.object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
-	45,   // 213: diode.v1.ContactAssignment.object_location:type_name -> diode.v1.Location
-	46,   // 214: diode.v1.ContactAssignment.object_mac_address:type_name -> diode.v1.MACAddress
-	47,   // 215: diode.v1.ContactAssignment.object_manufacturer:type_name -> diode.v1.Manufacturer
-	48,   // 216: diode.v1.ContactAssignment.object_module:type_name -> diode.v1.Module
-	49,   // 217: diode.v1.ContactAssignment.object_module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 218: diode.v1.ContactAssignment.object_module_type:type_name -> diode.v1.ModuleType
-	51,   // 219: diode.v1.ContactAssignment.object_platform:type_name -> diode.v1.Platform
-	52,   // 220: diode.v1.ContactAssignment.object_power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 221: diode.v1.ContactAssignment.object_power_outlet:type_name -> diode.v1.PowerOutlet
-	54,   // 222: diode.v1.ContactAssignment.object_power_panel:type_name -> diode.v1.PowerPanel
-	55,   // 223: diode.v1.ContactAssignment.object_power_port:type_name -> diode.v1.PowerPort
-	56,   // 224: diode.v1.ContactAssignment.object_prefix:type_name -> diode.v1.Prefix
-	57,   // 225: diode.v1.ContactAssignment.object_provider:type_name -> diode.v1.Provider
-	58,   // 226: diode.v1.ContactAssignment.object_provider_account:type_name -> diode.v1.ProviderAccount
-	59,   // 227: diode.v1.ContactAssignment.object_provider_network:type_name -> diode.v1.ProviderNetwork
-	60,   // 228: diode.v1.ContactAssignment.object_rir:type_name -> diode.v1.RIR
-	61,   // 229: diode.v1.ContactAssignment.object_rack:type_name -> diode.v1.Rack
-	62,   // 230: diode.v1.ContactAssignment.object_rack_reservation:type_name -> diode.v1.RackReservation
-	63,   // 231: diode.v1.ContactAssignment.object_rack_role:type_name -> diode.v1.RackRole
-	64,   // 232: diode.v1.ContactAssignment.object_rack_type:type_name -> diode.v1.RackType
-	65,   // 233: diode.v1.ContactAssignment.object_rear_port:type_name -> diode.v1.RearPort
-	66,   // 234: diode.v1.ContactAssignment.object_region:type_name -> diode.v1.Region
-	67,   // 235: diode.v1.ContactAssignment.object_role:type_name -> diode.v1.Role
-	68,   // 236: diode.v1.ContactAssignment.object_route_target:type_name -> diode.v1.RouteTarget
-	69,   // 237: diode.v1.ContactAssignment.object_service:type_name -> diode.v1.Service
-	70,   // 238: diode.v1.ContactAssignment.object_site:type_name -> diode.v1.Site
-	71,   // 239: diode.v1.ContactAssignment.object_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 240: diode.v1.ContactAssignment.object_tag:type_name -> diode.v1.Tag
-	73,   // 241: diode.v1.ContactAssignment.object_tenant:type_name -> diode.v1.Tenant
-	74,   // 242: diode.v1.ContactAssignment.object_tenant_group:type_name -> diode.v1.TenantGroup
-	75,   // 243: diode.v1.ContactAssignment.object_tunnel:type_name -> diode.v1.Tunnel
-	76,   // 244: diode.v1.ContactAssignment.object_tunnel_group:type_name -> diode.v1.TunnelGroup
-	77,   // 245: diode.v1.ContactAssignment.object_tunnel_termination:type_name -> diode.v1.TunnelTermination
-	78,   // 246: diode.v1.ContactAssignment.object_vlan:type_name -> diode.v1.VLAN
-	79,   // 247: diode.v1.ContactAssignment.object_vlan_group:type_name -> diode.v1.VLANGroup
-	80,   // 248: diode.v1.ContactAssignment.object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	81,   // 249: diode.v1.ContactAssignment.object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
-	82,   // 250: diode.v1.ContactAssignment.object_vm_interface:type_name -> diode.v1.VMInterface
-	83,   // 251: diode.v1.ContactAssignment.object_vrf:type_name -> diode.v1.VRF
-	84,   // 252: diode.v1.ContactAssignment.object_virtual_chassis:type_name -> diode.v1.VirtualChassis
-	85,   // 253: diode.v1.ContactAssignment.object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	86,   // 254: diode.v1.ContactAssignment.object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
-	87,   // 255: diode.v1.ContactAssignment.object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
-	88,   // 256: diode.v1.ContactAssignment.object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
-	89,   // 257: diode.v1.ContactAssignment.object_virtual_disk:type_name -> diode.v1.VirtualDisk
-	90,   // 258: diode.v1.ContactAssignment.object_virtual_machine:type_name -> diode.v1.VirtualMachine
-	91,   // 259: diode.v1.ContactAssignment.object_wireless_lan:type_name -> diode.v1.WirelessLAN
-	92,   // 260: diode.v1.ContactAssignment.object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
-	93,   // 261: diode.v1.ContactAssignment.object_wireless_link:type_name -> diode.v1.WirelessLink
-	94,   // 262: diode.v1.ContactAssignment.object_custom_field:type_name -> diode.v1.CustomField
-	95,   // 263: diode.v1.ContactAssignment.object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	96,   // 264: diode.v1.ContactAssignment.object_journal_entry:type_name -> diode.v1.JournalEntry
-	97,   // 265: diode.v1.ContactAssignment.object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
-	98,   // 266: diode.v1.ContactAssignment.object_custom_link:type_name -> diode.v1.CustomLink
-	19,   // 267: diode.v1.ContactAssignment.contact:type_name -> diode.v1.Contact
-	22,   // 268: diode.v1.ContactAssignment.role:type_name -> diode.v1.ContactRole
-	72,   // 269: diode.v1.ContactAssignment.tags:type_name -> diode.v1.Tag
-	113,  // 270: diode.v1.ContactAssignment.custom_fields:type_name -> diode.v1.ContactAssignment.CustomFieldsEntry
-	21,   // 271: diode.v1.ContactGroup.parent:type_name -> diode.v1.ContactGroup
-	72,   // 272: diode.v1.ContactGroup.tags:type_name -> diode.v1.Tag
-	114,  // 273: diode.v1.ContactGroup.custom_fields:type_name -> diode.v1.ContactGroup.CustomFieldsEntry
-	72,   // 274: diode.v1.ContactRole.tags:type_name -> diode.v1.Tag
-	115,  // 275: diode.v1.ContactRole.custom_fields:type_name -> diode.v1.ContactRole.CustomFieldsEntry
-	3,    // 276: diode.v1.CustomFieldObjectReference.asn:type_name -> diode.v1.ASN
-	4,    // 277: diode.v1.CustomFieldObjectReference.asn_range:type_name -> diode.v1.ASNRange
-	5,    // 278: diode.v1.CustomFieldObjectReference.aggregate:type_name -> diode.v1.Aggregate
-	6,    // 279: diode.v1.CustomFieldObjectReference.cable:type_name -> diode.v1.Cable
-	7,    // 280: diode.v1.CustomFieldObjectReference.cable_path:type_name -> diode.v1.CablePath
-	8,    // 281: diode.v1.CustomFieldObjectReference.cable_termination:type_name -> diode.v1.CableTermination
-	9,    // 282: diode.v1.CustomFieldObjectReference.circuit:type_name -> diode.v1.Circuit
-	10,   // 283: diode.v1.CustomFieldObjectReference.circuit_group:type_name -> diode.v1.CircuitGroup
-	11,   // 284: diode.v1.CustomFieldObjectReference.circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
-	12,   // 285: diode.v1.CustomFieldObjectReference.circuit_termination:type_name -> diode.v1.CircuitTermination
-	13,   // 286: diode.v1.CustomFieldObjectReference.circuit_type:type_name -> diode.v1.CircuitType
-	14,   // 287: diode.v1.CustomFieldObjectReference.cluster:type_name -> diode.v1.Cluster
-	15,   // 288: diode.v1.CustomFieldObjectReference.cluster_group:type_name -> diode.v1.ClusterGroup
-	16,   // 289: diode.v1.CustomFieldObjectReference.cluster_type:type_name -> diode.v1.ClusterType
-	17,   // 290: diode.v1.CustomFieldObjectReference.console_port:type_name -> diode.v1.ConsolePort
-	18,   // 291: diode.v1.CustomFieldObjectReference.console_server_port:type_name -> diode.v1.ConsoleServerPort
-	19,   // 292: diode.v1.CustomFieldObjectReference.contact:type_name -> diode.v1.Contact
-	20,   // 293: diode.v1.CustomFieldObjectReference.contact_assignment:type_name -> diode.v1.ContactAssignment
-	21,   // 294: diode.v1.CustomFieldObjectReference.contact_group:type_name -> diode.v1.ContactGroup
-	22,   // 295: diode.v1.CustomFieldObjectReference.contact_role:type_name -> diode.v1.ContactRole
-	25,   // 296: diode.v1.CustomFieldObjectReference.device:type_name -> diode.v1.Device
-	26,   // 297: diode.v1.CustomFieldObjectReference.device_bay:type_name -> diode.v1.DeviceBay
-	27,   // 298: diode.v1.CustomFieldObjectReference.device_role:type_name -> diode.v1.DeviceRole
-	28,   // 299: diode.v1.CustomFieldObjectReference.device_type:type_name -> diode.v1.DeviceType
-	29,   // 300: diode.v1.CustomFieldObjectReference.fhrp_group:type_name -> diode.v1.FHRPGroup
-	30,   // 301: diode.v1.CustomFieldObjectReference.fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
-	31,   // 302: diode.v1.CustomFieldObjectReference.front_port:type_name -> diode.v1.FrontPort
-	33,   // 303: diode.v1.CustomFieldObjectReference.ike_policy:type_name -> diode.v1.IKEPolicy
-	34,   // 304: diode.v1.CustomFieldObjectReference.ike_proposal:type_name -> diode.v1.IKEProposal
-	35,   // 305: diode.v1.CustomFieldObjectReference.ip_address:type_name -> diode.v1.IPAddress
-	36,   // 306: diode.v1.CustomFieldObjectReference.ip_range:type_name -> diode.v1.IPRange
-	37,   // 307: diode.v1.CustomFieldObjectReference.ip_sec_policy:type_name -> diode.v1.IPSecPolicy
-	38,   // 308: diode.v1.CustomFieldObjectReference.ip_sec_profile:type_name -> diode.v1.IPSecProfile
-	39,   // 309: diode.v1.CustomFieldObjectReference.ip_sec_proposal:type_name -> diode.v1.IPSecProposal
-	40,   // 310: diode.v1.CustomFieldObjectReference.interface:type_name -> diode.v1.Interface
-	41,   // 311: diode.v1.CustomFieldObjectReference.inventory_item:type_name -> diode.v1.InventoryItem
-	42,   // 312: diode.v1.CustomFieldObjectReference.inventory_item_role:type_name -> diode.v1.InventoryItemRole
-	43,   // 313: diode.v1.CustomFieldObjectReference.l2vpn:type_name -> diode.v1.L2VPN
-	44,   // 314: diode.v1.CustomFieldObjectReference.l2vpn_termination:type_name -> diode.v1.L2VPNTermination
-	45,   // 315: diode.v1.CustomFieldObjectReference.location:type_name -> diode.v1.Location
-	46,   // 316: diode.v1.CustomFieldObjectReference.mac_address:type_name -> diode.v1.MACAddress
-	47,   // 317: diode.v1.CustomFieldObjectReference.manufacturer:type_name -> diode.v1.Manufacturer
-	48,   // 318: diode.v1.CustomFieldObjectReference.module:type_name -> diode.v1.Module
-	49,   // 319: diode.v1.CustomFieldObjectReference.module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 320: diode.v1.CustomFieldObjectReference.module_type:type_name -> diode.v1.ModuleType
-	51,   // 321: diode.v1.CustomFieldObjectReference.platform:type_name -> diode.v1.Platform
-	52,   // 322: diode.v1.CustomFieldObjectReference.power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 323: diode.v1.CustomFieldObjectReference.power_outlet:type_name -> diode.v1.PowerOutlet
-	54,   // 324: diode.v1.CustomFieldObjectReference.power_panel:type_name -> diode.v1.PowerPanel
-	55,   // 325: diode.v1.CustomFieldObjectReference.power_port:type_name -> diode.v1.PowerPort
-	56,   // 326: diode.v1.CustomFieldObjectReference.prefix:type_name -> diode.v1.Prefix
-	57,   // 327: diode.v1.CustomFieldObjectReference.provider:type_name -> diode.v1.Provider
-	58,   // 328: diode.v1.CustomFieldObjectReference.provider_account:type_name -> diode.v1.ProviderAccount
-	59,   // 329: diode.v1.CustomFieldObjectReference.provider_network:type_name -> diode.v1.ProviderNetwork
-	60,   // 330: diode.v1.CustomFieldObjectReference.rir:type_name -> diode.v1.RIR
-	61,   // 331: diode.v1.CustomFieldObjectReference.rack:type_name -> diode.v1.Rack
-	62,   // 332: diode.v1.CustomFieldObjectReference.rack_reservation:type_name -> diode.v1.RackReservation
-	63,   // 333: diode.v1.CustomFieldObjectReference.rack_role:type_name -> diode.v1.RackRole
-	64,   // 334: diode.v1.CustomFieldObjectReference.rack_type:type_name -> diode.v1.RackType
-	65,   // 335: diode.v1.CustomFieldObjectReference.rear_port:type_name -> diode.v1.RearPort
-	66,   // 336: diode.v1.CustomFieldObjectReference.region:type_name -> diode.v1.Region
-	67,   // 337: diode.v1.CustomFieldObjectReference.role:type_name -> diode.v1.Role
-	68,   // 338: diode.v1.CustomFieldObjectReference.route_target:type_name -> diode.v1.RouteTarget
-	69,   // 339: diode.v1.CustomFieldObjectReference.service:type_name -> diode.v1.Service
-	70,   // 340: diode.v1.CustomFieldObjectReference.site:type_name -> diode.v1.Site
-	71,   // 341: diode.v1.CustomFieldObjectReference.site_group:type_name -> diode.v1.SiteGroup
-	72,   // 342: diode.v1.CustomFieldObjectReference.tag:type_name -> diode.v1.Tag
-	73,   // 343: diode.v1.CustomFieldObjectReference.tenant:type_name -> diode.v1.Tenant
-	74,   // 344: diode.v1.CustomFieldObjectReference.tenant_group:type_name -> diode.v1.TenantGroup
-	75,   // 345: diode.v1.CustomFieldObjectReference.tunnel:type_name -> diode.v1.Tunnel
-	76,   // 346: diode.v1.CustomFieldObjectReference.tunnel_group:type_name -> diode.v1.TunnelGroup
-	77,   // 347: diode.v1.CustomFieldObjectReference.tunnel_termination:type_name -> diode.v1.TunnelTermination
-	78,   // 348: diode.v1.CustomFieldObjectReference.vlan:type_name -> diode.v1.VLAN
-	79,   // 349: diode.v1.CustomFieldObjectReference.vlan_group:type_name -> diode.v1.VLANGroup
-	80,   // 350: diode.v1.CustomFieldObjectReference.vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	81,   // 351: diode.v1.CustomFieldObjectReference.vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
-	82,   // 352: diode.v1.CustomFieldObjectReference.vm_interface:type_name -> diode.v1.VMInterface
-	83,   // 353: diode.v1.CustomFieldObjectReference.vrf:type_name -> diode.v1.VRF
-	84,   // 354: diode.v1.CustomFieldObjectReference.virtual_chassis:type_name -> diode.v1.VirtualChassis
-	85,   // 355: diode.v1.CustomFieldObjectReference.virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	86,   // 356: diode.v1.CustomFieldObjectReference.virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
-	87,   // 357: diode.v1.CustomFieldObjectReference.virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
-	88,   // 358: diode.v1.CustomFieldObjectReference.virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
-	89,   // 359: diode.v1.CustomFieldObjectReference.virtual_disk:type_name -> diode.v1.VirtualDisk
-	90,   // 360: diode.v1.CustomFieldObjectReference.virtual_machine:type_name -> diode.v1.VirtualMachine
-	91,   // 361: diode.v1.CustomFieldObjectReference.wireless_lan:type_name -> diode.v1.WirelessLAN
-	92,   // 362: diode.v1.CustomFieldObjectReference.wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
-	93,   // 363: diode.v1.CustomFieldObjectReference.wireless_link:type_name -> diode.v1.WirelessLink
-	94,   // 364: diode.v1.CustomFieldObjectReference.custom_field:type_name -> diode.v1.CustomField
-	95,   // 365: diode.v1.CustomFieldObjectReference.custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	96,   // 366: diode.v1.CustomFieldObjectReference.journal_entry:type_name -> diode.v1.JournalEntry
-	97,   // 367: diode.v1.CustomFieldObjectReference.module_type_profile:type_name -> diode.v1.ModuleTypeProfile
-	98,   // 368: diode.v1.CustomFieldObjectReference.custom_link:type_name -> diode.v1.CustomLink
-	23,   // 369: diode.v1.CustomFieldValue.multiple_objects:type_name -> diode.v1.CustomFieldObjectReference
-	182,  // 370: diode.v1.CustomFieldValue.date:type_name -> google.protobuf.Timestamp
-	182,  // 371: diode.v1.CustomFieldValue.datetime:type_name -> google.protobuf.Timestamp
-	23,   // 372: diode.v1.CustomFieldValue.object:type_name -> diode.v1.CustomFieldObjectReference
-	28,   // 373: diode.v1.Device.device_type:type_name -> diode.v1.DeviceType
-	27,   // 374: diode.v1.Device.role:type_name -> diode.v1.DeviceRole
-	73,   // 375: diode.v1.Device.tenant:type_name -> diode.v1.Tenant
-	51,   // 376: diode.v1.Device.platform:type_name -> diode.v1.Platform
-	70,   // 377: diode.v1.Device.site:type_name -> diode.v1.Site
-	45,   // 378: diode.v1.Device.location:type_name -> diode.v1.Location
-	61,   // 379: diode.v1.Device.rack:type_name -> diode.v1.Rack
-	35,   // 380: diode.v1.Device.primary_ip4:type_name -> diode.v1.IPAddress
-	35,   // 381: diode.v1.Device.primary_ip6:type_name -> diode.v1.IPAddress
-	35,   // 382: diode.v1.Device.oob_ip:type_name -> diode.v1.IPAddress
-	14,   // 383: diode.v1.Device.cluster:type_name -> diode.v1.Cluster
-	84,   // 384: diode.v1.Device.virtual_chassis:type_name -> diode.v1.VirtualChassis
-	72,   // 385: diode.v1.Device.tags:type_name -> diode.v1.Tag
-	116,  // 386: diode.v1.Device.custom_fields:type_name -> diode.v1.Device.CustomFieldsEntry
-	25,   // 387: diode.v1.DeviceBay.device:type_name -> diode.v1.Device
-	25,   // 388: diode.v1.DeviceBay.installed_device:type_name -> diode.v1.Device
-	72,   // 389: diode.v1.DeviceBay.tags:type_name -> diode.v1.Tag
-	117,  // 390: diode.v1.DeviceBay.custom_fields:type_name -> diode.v1.DeviceBay.CustomFieldsEntry
-	72,   // 391: diode.v1.DeviceRole.tags:type_name -> diode.v1.Tag
-	118,  // 392: diode.v1.DeviceRole.custom_fields:type_name -> diode.v1.DeviceRole.CustomFieldsEntry
-	27,   // 393: diode.v1.DeviceRole.parent:type_name -> diode.v1.DeviceRole
-	47,   // 394: diode.v1.DeviceType.manufacturer:type_name -> diode.v1.Manufacturer
-	51,   // 395: diode.v1.DeviceType.default_platform:type_name -> diode.v1.Platform
-	72,   // 396: diode.v1.DeviceType.tags:type_name -> diode.v1.Tag
-	119,  // 397: diode.v1.DeviceType.custom_fields:type_name -> diode.v1.DeviceType.CustomFieldsEntry
-	72,   // 398: diode.v1.FHRPGroup.tags:type_name -> diode.v1.Tag
-	120,  // 399: diode.v1.FHRPGroup.custom_fields:type_name -> diode.v1.FHRPGroup.CustomFieldsEntry
-	29,   // 400: diode.v1.FHRPGroupAssignment.group:type_name -> diode.v1.FHRPGroup
-	3,    // 401: diode.v1.FHRPGroupAssignment.interface_asn:type_name -> diode.v1.ASN
-	4,    // 402: diode.v1.FHRPGroupAssignment.interface_asn_range:type_name -> diode.v1.ASNRange
-	5,    // 403: diode.v1.FHRPGroupAssignment.interface_aggregate:type_name -> diode.v1.Aggregate
-	6,    // 404: diode.v1.FHRPGroupAssignment.interface_cable:type_name -> diode.v1.Cable
-	7,    // 405: diode.v1.FHRPGroupAssignment.interface_cable_path:type_name -> diode.v1.CablePath
-	8,    // 406: diode.v1.FHRPGroupAssignment.interface_cable_termination:type_name -> diode.v1.CableTermination
-	9,    // 407: diode.v1.FHRPGroupAssignment.interface_circuit:type_name -> diode.v1.Circuit
-	10,   // 408: diode.v1.FHRPGroupAssignment.interface_circuit_group:type_name -> diode.v1.CircuitGroup
-	11,   // 409: diode.v1.FHRPGroupAssignment.interface_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
-	12,   // 410: diode.v1.FHRPGroupAssignment.interface_circuit_termination:type_name -> diode.v1.CircuitTermination
-	13,   // 411: diode.v1.FHRPGroupAssignment.interface_circuit_type:type_name -> diode.v1.CircuitType
-	14,   // 412: diode.v1.FHRPGroupAssignment.interface_cluster:type_name -> diode.v1.Cluster
-	15,   // 413: diode.v1.FHRPGroupAssignment.interface_cluster_group:type_name -> diode.v1.ClusterGroup
-	16,   // 414: diode.v1.FHRPGroupAssignment.interface_cluster_type:type_name -> diode.v1.ClusterType
-	17,   // 415: diode.v1.FHRPGroupAssignment.interface_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 416: diode.v1.FHRPGroupAssignment.interface_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	19,   // 417: diode.v1.FHRPGroupAssignment.interface_contact:type_name -> diode.v1.Contact
-	20,   // 418: diode.v1.FHRPGroupAssignment.interface_contact_assignment:type_name -> diode.v1.ContactAssignment
-	21,   // 419: diode.v1.FHRPGroupAssignment.interface_contact_group:type_name -> diode.v1.ContactGroup
-	22,   // 420: diode.v1.FHRPGroupAssignment.interface_contact_role:type_name -> diode.v1.ContactRole
-	25,   // 421: diode.v1.FHRPGroupAssignment.interface_device:type_name -> diode.v1.Device
-	26,   // 422: diode.v1.FHRPGroupAssignment.interface_device_bay:type_name -> diode.v1.DeviceBay
-	27,   // 423: diode.v1.FHRPGroupAssignment.interface_device_role:type_name -> diode.v1.DeviceRole
-	28,   // 424: diode.v1.FHRPGroupAssignment.interface_device_type:type_name -> diode.v1.DeviceType
-	29,   // 425: diode.v1.FHRPGroupAssignment.interface_fhrp_group:type_name -> diode.v1.FHRPGroup
-	30,   // 426: diode.v1.FHRPGroupAssignment.interface_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
-	31,   // 427: diode.v1.FHRPGroupAssignment.interface_front_port:type_name -> diode.v1.FrontPort
-	33,   // 428: diode.v1.FHRPGroupAssignment.interface_ike_policy:type_name -> diode.v1.IKEPolicy
-	34,   // 429: diode.v1.FHRPGroupAssignment.interface_ike_proposal:type_name -> diode.v1.IKEProposal
-	35,   // 430: diode.v1.FHRPGroupAssignment.interface_ip_address:type_name -> diode.v1.IPAddress
-	36,   // 431: diode.v1.FHRPGroupAssignment.interface_ip_range:type_name -> diode.v1.IPRange
-	37,   // 432: diode.v1.FHRPGroupAssignment.interface_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
-	38,   // 433: diode.v1.FHRPGroupAssignment.interface_ip_sec_profile:type_name -> diode.v1.IPSecProfile
-	39,   // 434: diode.v1.FHRPGroupAssignment.interface_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
-	40,   // 435: diode.v1.FHRPGroupAssignment.interface_interface:type_name -> diode.v1.Interface
-	41,   // 436: diode.v1.FHRPGroupAssignment.interface_inventory_item:type_name -> diode.v1.InventoryItem
-	42,   // 437: diode.v1.FHRPGroupAssignment.interface_inventory_item_role:type_name -> diode.v1.InventoryItemRole
-	43,   // 438: diode.v1.FHRPGroupAssignment.interface_l2vpn:type_name -> diode.v1.L2VPN
-	44,   // 439: diode.v1.FHRPGroupAssignment.interface_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
-	45,   // 440: diode.v1.FHRPGroupAssignment.interface_location:type_name -> diode.v1.Location
-	46,   // 441: diode.v1.FHRPGroupAssignment.interface_mac_address:type_name -> diode.v1.MACAddress
-	47,   // 442: diode.v1.FHRPGroupAssignment.interface_manufacturer:type_name -> diode.v1.Manufacturer
-	48,   // 443: diode.v1.FHRPGroupAssignment.interface_module:type_name -> diode.v1.Module
-	49,   // 444: diode.v1.FHRPGroupAssignment.interface_module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 445: diode.v1.FHRPGroupAssignment.interface_module_type:type_name -> diode.v1.ModuleType
-	51,   // 446: diode.v1.FHRPGroupAssignment.interface_platform:type_name -> diode.v1.Platform
-	52,   // 447: diode.v1.FHRPGroupAssignment.interface_power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 448: diode.v1.FHRPGroupAssignment.interface_power_outlet:type_name -> diode.v1.PowerOutlet
-	54,   // 449: diode.v1.FHRPGroupAssignment.interface_power_panel:type_name -> diode.v1.PowerPanel
-	55,   // 450: diode.v1.FHRPGroupAssignment.interface_power_port:type_name -> diode.v1.PowerPort
-	56,   // 451: diode.v1.FHRPGroupAssignment.interface_prefix:type_name -> diode.v1.Prefix
-	57,   // 452: diode.v1.FHRPGroupAssignment.interface_provider:type_name -> diode.v1.Provider
-	58,   // 453: diode.v1.FHRPGroupAssignment.interface_provider_account:type_name -> diode.v1.ProviderAccount
-	59,   // 454: diode.v1.FHRPGroupAssignment.interface_provider_network:type_name -> diode.v1.ProviderNetwork
-	60,   // 455: diode.v1.FHRPGroupAssignment.interface_rir:type_name -> diode.v1.RIR
-	61,   // 456: diode.v1.FHRPGroupAssignment.interface_rack:type_name -> diode.v1.Rack
-	62,   // 457: diode.v1.FHRPGroupAssignment.interface_rack_reservation:type_name -> diode.v1.RackReservation
-	63,   // 458: diode.v1.FHRPGroupAssignment.interface_rack_role:type_name -> diode.v1.RackRole
-	64,   // 459: diode.v1.FHRPGroupAssignment.interface_rack_type:type_name -> diode.v1.RackType
-	65,   // 460: diode.v1.FHRPGroupAssignment.interface_rear_port:type_name -> diode.v1.RearPort
-	66,   // 461: diode.v1.FHRPGroupAssignment.interface_region:type_name -> diode.v1.Region
-	67,   // 462: diode.v1.FHRPGroupAssignment.interface_role:type_name -> diode.v1.Role
-	68,   // 463: diode.v1.FHRPGroupAssignment.interface_route_target:type_name -> diode.v1.RouteTarget
-	69,   // 464: diode.v1.FHRPGroupAssignment.interface_service:type_name -> diode.v1.Service
-	70,   // 465: diode.v1.FHRPGroupAssignment.interface_site:type_name -> diode.v1.Site
-	71,   // 466: diode.v1.FHRPGroupAssignment.interface_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 467: diode.v1.FHRPGroupAssignment.interface_tag:type_name -> diode.v1.Tag
-	73,   // 468: diode.v1.FHRPGroupAssignment.interface_tenant:type_name -> diode.v1.Tenant
-	74,   // 469: diode.v1.FHRPGroupAssignment.interface_tenant_group:type_name -> diode.v1.TenantGroup
-	75,   // 470: diode.v1.FHRPGroupAssignment.interface_tunnel:type_name -> diode.v1.Tunnel
-	76,   // 471: diode.v1.FHRPGroupAssignment.interface_tunnel_group:type_name -> diode.v1.TunnelGroup
-	77,   // 472: diode.v1.FHRPGroupAssignment.interface_tunnel_termination:type_name -> diode.v1.TunnelTermination
-	78,   // 473: diode.v1.FHRPGroupAssignment.interface_vlan:type_name -> diode.v1.VLAN
-	79,   // 474: diode.v1.FHRPGroupAssignment.interface_vlan_group:type_name -> diode.v1.VLANGroup
-	80,   // 475: diode.v1.FHRPGroupAssignment.interface_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	81,   // 476: diode.v1.FHRPGroupAssignment.interface_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
-	82,   // 477: diode.v1.FHRPGroupAssignment.interface_vm_interface:type_name -> diode.v1.VMInterface
-	83,   // 478: diode.v1.FHRPGroupAssignment.interface_vrf:type_name -> diode.v1.VRF
-	84,   // 479: diode.v1.FHRPGroupAssignment.interface_virtual_chassis:type_name -> diode.v1.VirtualChassis
-	85,   // 480: diode.v1.FHRPGroupAssignment.interface_virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	86,   // 481: diode.v1.FHRPGroupAssignment.interface_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
-	87,   // 482: diode.v1.FHRPGroupAssignment.interface_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
-	88,   // 483: diode.v1.FHRPGroupAssignment.interface_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
-	89,   // 484: diode.v1.FHRPGroupAssignment.interface_virtual_disk:type_name -> diode.v1.VirtualDisk
-	90,   // 485: diode.v1.FHRPGroupAssignment.interface_virtual_machine:type_name -> diode.v1.VirtualMachine
-	91,   // 486: diode.v1.FHRPGroupAssignment.interface_wireless_lan:type_name -> diode.v1.WirelessLAN
-	92,   // 487: diode.v1.FHRPGroupAssignment.interface_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
-	93,   // 488: diode.v1.FHRPGroupAssignment.interface_wireless_link:type_name -> diode.v1.WirelessLink
-	94,   // 489: diode.v1.FHRPGroupAssignment.interface_custom_field:type_name -> diode.v1.CustomField
-	95,   // 490: diode.v1.FHRPGroupAssignment.interface_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	96,   // 491: diode.v1.FHRPGroupAssignment.interface_journal_entry:type_name -> diode.v1.JournalEntry
-	97,   // 492: diode.v1.FHRPGroupAssignment.interface_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
-	98,   // 493: diode.v1.FHRPGroupAssignment.interface_custom_link:type_name -> diode.v1.CustomLink
-	25,   // 494: diode.v1.FrontPort.device:type_name -> diode.v1.Device
-	48,   // 495: diode.v1.FrontPort.module:type_name -> diode.v1.Module
-	65,   // 496: diode.v1.FrontPort.rear_port:type_name -> diode.v1.RearPort
-	72,   // 497: diode.v1.FrontPort.tags:type_name -> diode.v1.Tag
-	121,  // 498: diode.v1.FrontPort.custom_fields:type_name -> diode.v1.FrontPort.CustomFieldsEntry
-	3,    // 499: diode.v1.GenericObject.object_asn:type_name -> diode.v1.ASN
-	4,    // 500: diode.v1.GenericObject.object_asn_range:type_name -> diode.v1.ASNRange
-	5,    // 501: diode.v1.GenericObject.object_aggregate:type_name -> diode.v1.Aggregate
-	6,    // 502: diode.v1.GenericObject.object_cable:type_name -> diode.v1.Cable
-	7,    // 503: diode.v1.GenericObject.object_cable_path:type_name -> diode.v1.CablePath
-	8,    // 504: diode.v1.GenericObject.object_cable_termination:type_name -> diode.v1.CableTermination
-	9,    // 505: diode.v1.GenericObject.object_circuit:type_name -> diode.v1.Circuit
-	10,   // 506: diode.v1.GenericObject.object_circuit_group:type_name -> diode.v1.CircuitGroup
-	11,   // 507: diode.v1.GenericObject.object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
-	12,   // 508: diode.v1.GenericObject.object_circuit_termination:type_name -> diode.v1.CircuitTermination
-	13,   // 509: diode.v1.GenericObject.object_circuit_type:type_name -> diode.v1.CircuitType
-	14,   // 510: diode.v1.GenericObject.object_cluster:type_name -> diode.v1.Cluster
-	15,   // 511: diode.v1.GenericObject.object_cluster_group:type_name -> diode.v1.ClusterGroup
-	16,   // 512: diode.v1.GenericObject.object_cluster_type:type_name -> diode.v1.ClusterType
-	17,   // 513: diode.v1.GenericObject.object_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 514: diode.v1.GenericObject.object_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	19,   // 515: diode.v1.GenericObject.object_contact:type_name -> diode.v1.Contact
-	20,   // 516: diode.v1.GenericObject.object_contact_assignment:type_name -> diode.v1.ContactAssignment
-	21,   // 517: diode.v1.GenericObject.object_contact_group:type_name -> diode.v1.ContactGroup
-	22,   // 518: diode.v1.GenericObject.object_contact_role:type_name -> diode.v1.ContactRole
-	25,   // 519: diode.v1.GenericObject.object_device:type_name -> diode.v1.Device
-	26,   // 520: diode.v1.GenericObject.object_device_bay:type_name -> diode.v1.DeviceBay
-	27,   // 521: diode.v1.GenericObject.object_device_role:type_name -> diode.v1.DeviceRole
-	28,   // 522: diode.v1.GenericObject.object_device_type:type_name -> diode.v1.DeviceType
-	29,   // 523: diode.v1.GenericObject.object_fhrp_group:type_name -> diode.v1.FHRPGroup
-	30,   // 524: diode.v1.GenericObject.object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
-	31,   // 525: diode.v1.GenericObject.object_front_port:type_name -> diode.v1.FrontPort
-	33,   // 526: diode.v1.GenericObject.object_ike_policy:type_name -> diode.v1.IKEPolicy
-	34,   // 527: diode.v1.GenericObject.object_ike_proposal:type_name -> diode.v1.IKEProposal
-	35,   // 528: diode.v1.GenericObject.object_ip_address:type_name -> diode.v1.IPAddress
-	36,   // 529: diode.v1.GenericObject.object_ip_range:type_name -> diode.v1.IPRange
-	37,   // 530: diode.v1.GenericObject.object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
-	38,   // 531: diode.v1.GenericObject.object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
-	39,   // 532: diode.v1.GenericObject.object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
-	40,   // 533: diode.v1.GenericObject.object_interface:type_name -> diode.v1.Interface
-	41,   // 534: diode.v1.GenericObject.object_inventory_item:type_name -> diode.v1.InventoryItem
-	42,   // 535: diode.v1.GenericObject.object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
-	43,   // 536: diode.v1.GenericObject.object_l2vpn:type_name -> diode.v1.L2VPN
-	44,   // 537: diode.v1.GenericObject.object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
-	45,   // 538: diode.v1.GenericObject.object_location:type_name -> diode.v1.Location
-	46,   // 539: diode.v1.GenericObject.object_mac_address:type_name -> diode.v1.MACAddress
-	47,   // 540: diode.v1.GenericObject.object_manufacturer:type_name -> diode.v1.Manufacturer
-	48,   // 541: diode.v1.GenericObject.object_module:type_name -> diode.v1.Module
-	49,   // 542: diode.v1.GenericObject.object_module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 543: diode.v1.GenericObject.object_module_type:type_name -> diode.v1.ModuleType
-	51,   // 544: diode.v1.GenericObject.object_platform:type_name -> diode.v1.Platform
-	52,   // 545: diode.v1.GenericObject.object_power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 546: diode.v1.GenericObject.object_power_outlet:type_name -> diode.v1.PowerOutlet
-	54,   // 547: diode.v1.GenericObject.object_power_panel:type_name -> diode.v1.PowerPanel
-	55,   // 548: diode.v1.GenericObject.object_power_port:type_name -> diode.v1.PowerPort
-	56,   // 549: diode.v1.GenericObject.object_prefix:type_name -> diode.v1.Prefix
-	57,   // 550: diode.v1.GenericObject.object_provider:type_name -> diode.v1.Provider
-	58,   // 551: diode.v1.GenericObject.object_provider_account:type_name -> diode.v1.ProviderAccount
-	59,   // 552: diode.v1.GenericObject.object_provider_network:type_name -> diode.v1.ProviderNetwork
-	60,   // 553: diode.v1.GenericObject.object_rir:type_name -> diode.v1.RIR
-	61,   // 554: diode.v1.GenericObject.object_rack:type_name -> diode.v1.Rack
-	62,   // 555: diode.v1.GenericObject.object_rack_reservation:type_name -> diode.v1.RackReservation
-	63,   // 556: diode.v1.GenericObject.object_rack_role:type_name -> diode.v1.RackRole
-	64,   // 557: diode.v1.GenericObject.object_rack_type:type_name -> diode.v1.RackType
-	65,   // 558: diode.v1.GenericObject.object_rear_port:type_name -> diode.v1.RearPort
-	66,   // 559: diode.v1.GenericObject.object_region:type_name -> diode.v1.Region
-	67,   // 560: diode.v1.GenericObject.object_role:type_name -> diode.v1.Role
-	68,   // 561: diode.v1.GenericObject.object_route_target:type_name -> diode.v1.RouteTarget
-	69,   // 562: diode.v1.GenericObject.object_service:type_name -> diode.v1.Service
-	70,   // 563: diode.v1.GenericObject.object_site:type_name -> diode.v1.Site
-	71,   // 564: diode.v1.GenericObject.object_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 565: diode.v1.GenericObject.object_tag:type_name -> diode.v1.Tag
-	73,   // 566: diode.v1.GenericObject.object_tenant:type_name -> diode.v1.Tenant
-	74,   // 567: diode.v1.GenericObject.object_tenant_group:type_name -> diode.v1.TenantGroup
-	75,   // 568: diode.v1.GenericObject.object_tunnel:type_name -> diode.v1.Tunnel
-	76,   // 569: diode.v1.GenericObject.object_tunnel_group:type_name -> diode.v1.TunnelGroup
-	77,   // 570: diode.v1.GenericObject.object_tunnel_termination:type_name -> diode.v1.TunnelTermination
-	78,   // 571: diode.v1.GenericObject.object_vlan:type_name -> diode.v1.VLAN
-	79,   // 572: diode.v1.GenericObject.object_vlan_group:type_name -> diode.v1.VLANGroup
-	80,   // 573: diode.v1.GenericObject.object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	81,   // 574: diode.v1.GenericObject.object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
-	82,   // 575: diode.v1.GenericObject.object_vm_interface:type_name -> diode.v1.VMInterface
-	83,   // 576: diode.v1.GenericObject.object_vrf:type_name -> diode.v1.VRF
-	84,   // 577: diode.v1.GenericObject.object_virtual_chassis:type_name -> diode.v1.VirtualChassis
-	85,   // 578: diode.v1.GenericObject.object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	86,   // 579: diode.v1.GenericObject.object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
-	87,   // 580: diode.v1.GenericObject.object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
-	88,   // 581: diode.v1.GenericObject.object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
-	89,   // 582: diode.v1.GenericObject.object_virtual_disk:type_name -> diode.v1.VirtualDisk
-	90,   // 583: diode.v1.GenericObject.object_virtual_machine:type_name -> diode.v1.VirtualMachine
-	91,   // 584: diode.v1.GenericObject.object_wireless_lan:type_name -> diode.v1.WirelessLAN
-	92,   // 585: diode.v1.GenericObject.object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
-	93,   // 586: diode.v1.GenericObject.object_wireless_link:type_name -> diode.v1.WirelessLink
-	94,   // 587: diode.v1.GenericObject.object_custom_field:type_name -> diode.v1.CustomField
-	95,   // 588: diode.v1.GenericObject.object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	96,   // 589: diode.v1.GenericObject.object_journal_entry:type_name -> diode.v1.JournalEntry
-	97,   // 590: diode.v1.GenericObject.object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
-	98,   // 591: diode.v1.GenericObject.object_custom_link:type_name -> diode.v1.CustomLink
-	72,   // 592: diode.v1.IKEPolicy.tags:type_name -> diode.v1.Tag
-	122,  // 593: diode.v1.IKEPolicy.custom_fields:type_name -> diode.v1.IKEPolicy.CustomFieldsEntry
-	34,   // 594: diode.v1.IKEPolicy.proposals:type_name -> diode.v1.IKEProposal
-	72,   // 595: diode.v1.IKEProposal.tags:type_name -> diode.v1.Tag
-	123,  // 596: diode.v1.IKEProposal.custom_fields:type_name -> diode.v1.IKEProposal.CustomFieldsEntry
-	83,   // 597: diode.v1.IPAddress.vrf:type_name -> diode.v1.VRF
-	73,   // 598: diode.v1.IPAddress.tenant:type_name -> diode.v1.Tenant
-	29,   // 599: diode.v1.IPAddress.assigned_object_fhrp_group:type_name -> diode.v1.FHRPGroup
-	40,   // 600: diode.v1.IPAddress.assigned_object_interface:type_name -> diode.v1.Interface
-	82,   // 601: diode.v1.IPAddress.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
-	35,   // 602: diode.v1.IPAddress.nat_inside:type_name -> diode.v1.IPAddress
-	72,   // 603: diode.v1.IPAddress.tags:type_name -> diode.v1.Tag
-	124,  // 604: diode.v1.IPAddress.custom_fields:type_name -> diode.v1.IPAddress.CustomFieldsEntry
-	83,   // 605: diode.v1.IPRange.vrf:type_name -> diode.v1.VRF
-	73,   // 606: diode.v1.IPRange.tenant:type_name -> diode.v1.Tenant
-	67,   // 607: diode.v1.IPRange.role:type_name -> diode.v1.Role
-	72,   // 608: diode.v1.IPRange.tags:type_name -> diode.v1.Tag
-	125,  // 609: diode.v1.IPRange.custom_fields:type_name -> diode.v1.IPRange.CustomFieldsEntry
-	72,   // 610: diode.v1.IPSecPolicy.tags:type_name -> diode.v1.Tag
-	126,  // 611: diode.v1.IPSecPolicy.custom_fields:type_name -> diode.v1.IPSecPolicy.CustomFieldsEntry
-	39,   // 612: diode.v1.IPSecPolicy.proposals:type_name -> diode.v1.IPSecProposal
-	33,   // 613: diode.v1.IPSecProfile.ike_policy:type_name -> diode.v1.IKEPolicy
-	37,   // 614: diode.v1.IPSecProfile.ipsec_policy:type_name -> diode.v1.IPSecPolicy
-	72,   // 615: diode.v1.IPSecProfile.tags:type_name -> diode.v1.Tag
-	127,  // 616: diode.v1.IPSecProfile.custom_fields:type_name -> diode.v1.IPSecProfile.CustomFieldsEntry
-	72,   // 617: diode.v1.IPSecProposal.tags:type_name -> diode.v1.Tag
-	128,  // 618: diode.v1.IPSecProposal.custom_fields:type_name -> diode.v1.IPSecProposal.CustomFieldsEntry
-	25,   // 619: diode.v1.Interface.device:type_name -> diode.v1.Device
-	48,   // 620: diode.v1.Interface.module:type_name -> diode.v1.Module
-	40,   // 621: diode.v1.Interface.parent:type_name -> diode.v1.Interface
-	40,   // 622: diode.v1.Interface.bridge:type_name -> diode.v1.Interface
-	40,   // 623: diode.v1.Interface.lag:type_name -> diode.v1.Interface
-	46,   // 624: diode.v1.Interface.primary_mac_address:type_name -> diode.v1.MACAddress
-	78,   // 625: diode.v1.Interface.untagged_vlan:type_name -> diode.v1.VLAN
-	78,   // 626: diode.v1.Interface.qinq_svlan:type_name -> diode.v1.VLAN
-	80,   // 627: diode.v1.Interface.vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	83,   // 628: diode.v1.Interface.vrf:type_name -> diode.v1.VRF
-	72,   // 629: diode.v1.Interface.tags:type_name -> diode.v1.Tag
-	129,  // 630: diode.v1.Interface.custom_fields:type_name -> diode.v1.Interface.CustomFieldsEntry
-	88,   // 631: diode.v1.Interface.vdcs:type_name -> diode.v1.VirtualDeviceContext
-	78,   // 632: diode.v1.Interface.tagged_vlans:type_name -> diode.v1.VLAN
-	91,   // 633: diode.v1.Interface.wireless_lans:type_name -> diode.v1.WirelessLAN
-	25,   // 634: diode.v1.InventoryItem.device:type_name -> diode.v1.Device
-	41,   // 635: diode.v1.InventoryItem.parent:type_name -> diode.v1.InventoryItem
-	42,   // 636: diode.v1.InventoryItem.role:type_name -> diode.v1.InventoryItemRole
-	47,   // 637: diode.v1.InventoryItem.manufacturer:type_name -> diode.v1.Manufacturer
-	17,   // 638: diode.v1.InventoryItem.component_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 639: diode.v1.InventoryItem.component_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	31,   // 640: diode.v1.InventoryItem.component_front_port:type_name -> diode.v1.FrontPort
-	40,   // 641: diode.v1.InventoryItem.component_interface:type_name -> diode.v1.Interface
-	53,   // 642: diode.v1.InventoryItem.component_power_outlet:type_name -> diode.v1.PowerOutlet
-	55,   // 643: diode.v1.InventoryItem.component_power_port:type_name -> diode.v1.PowerPort
-	65,   // 644: diode.v1.InventoryItem.component_rear_port:type_name -> diode.v1.RearPort
-	72,   // 645: diode.v1.InventoryItem.tags:type_name -> diode.v1.Tag
-	130,  // 646: diode.v1.InventoryItem.custom_fields:type_name -> diode.v1.InventoryItem.CustomFieldsEntry
-	72,   // 647: diode.v1.InventoryItemRole.tags:type_name -> diode.v1.Tag
-	131,  // 648: diode.v1.InventoryItemRole.custom_fields:type_name -> diode.v1.InventoryItemRole.CustomFieldsEntry
-	73,   // 649: diode.v1.L2VPN.tenant:type_name -> diode.v1.Tenant
-	72,   // 650: diode.v1.L2VPN.tags:type_name -> diode.v1.Tag
-	132,  // 651: diode.v1.L2VPN.custom_fields:type_name -> diode.v1.L2VPN.CustomFieldsEntry
-	68,   // 652: diode.v1.L2VPN.import_targets:type_name -> diode.v1.RouteTarget
-	68,   // 653: diode.v1.L2VPN.export_targets:type_name -> diode.v1.RouteTarget
-	43,   // 654: diode.v1.L2VPNTermination.l2vpn:type_name -> diode.v1.L2VPN
-	40,   // 655: diode.v1.L2VPNTermination.assigned_object_interface:type_name -> diode.v1.Interface
-	78,   // 656: diode.v1.L2VPNTermination.assigned_object_vlan:type_name -> diode.v1.VLAN
-	82,   // 657: diode.v1.L2VPNTermination.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
-	3,    // 658: diode.v1.L2VPNTermination.assigned_object_asn:type_name -> diode.v1.ASN
-	4,    // 659: diode.v1.L2VPNTermination.assigned_object_asn_range:type_name -> diode.v1.ASNRange
-	5,    // 660: diode.v1.L2VPNTermination.assigned_object_aggregate:type_name -> diode.v1.Aggregate
-	6,    // 661: diode.v1.L2VPNTermination.assigned_object_cable:type_name -> diode.v1.Cable
-	7,    // 662: diode.v1.L2VPNTermination.assigned_object_cable_path:type_name -> diode.v1.CablePath
-	8,    // 663: diode.v1.L2VPNTermination.assigned_object_cable_termination:type_name -> diode.v1.CableTermination
-	9,    // 664: diode.v1.L2VPNTermination.assigned_object_circuit:type_name -> diode.v1.Circuit
-	10,   // 665: diode.v1.L2VPNTermination.assigned_object_circuit_group:type_name -> diode.v1.CircuitGroup
-	11,   // 666: diode.v1.L2VPNTermination.assigned_object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
-	12,   // 667: diode.v1.L2VPNTermination.assigned_object_circuit_termination:type_name -> diode.v1.CircuitTermination
-	13,   // 668: diode.v1.L2VPNTermination.assigned_object_circuit_type:type_name -> diode.v1.CircuitType
-	14,   // 669: diode.v1.L2VPNTermination.assigned_object_cluster:type_name -> diode.v1.Cluster
-	15,   // 670: diode.v1.L2VPNTermination.assigned_object_cluster_group:type_name -> diode.v1.ClusterGroup
-	16,   // 671: diode.v1.L2VPNTermination.assigned_object_cluster_type:type_name -> diode.v1.ClusterType
-	17,   // 672: diode.v1.L2VPNTermination.assigned_object_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 673: diode.v1.L2VPNTermination.assigned_object_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	19,   // 674: diode.v1.L2VPNTermination.assigned_object_contact:type_name -> diode.v1.Contact
-	20,   // 675: diode.v1.L2VPNTermination.assigned_object_contact_assignment:type_name -> diode.v1.ContactAssignment
-	21,   // 676: diode.v1.L2VPNTermination.assigned_object_contact_group:type_name -> diode.v1.ContactGroup
-	22,   // 677: diode.v1.L2VPNTermination.assigned_object_contact_role:type_name -> diode.v1.ContactRole
-	94,   // 678: diode.v1.L2VPNTermination.assigned_object_custom_field:type_name -> diode.v1.CustomField
-	95,   // 679: diode.v1.L2VPNTermination.assigned_object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	25,   // 680: diode.v1.L2VPNTermination.assigned_object_device:type_name -> diode.v1.Device
-	26,   // 681: diode.v1.L2VPNTermination.assigned_object_device_bay:type_name -> diode.v1.DeviceBay
-	27,   // 682: diode.v1.L2VPNTermination.assigned_object_device_role:type_name -> diode.v1.DeviceRole
-	28,   // 683: diode.v1.L2VPNTermination.assigned_object_device_type:type_name -> diode.v1.DeviceType
-	29,   // 684: diode.v1.L2VPNTermination.assigned_object_fhrp_group:type_name -> diode.v1.FHRPGroup
-	30,   // 685: diode.v1.L2VPNTermination.assigned_object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
-	31,   // 686: diode.v1.L2VPNTermination.assigned_object_front_port:type_name -> diode.v1.FrontPort
-	33,   // 687: diode.v1.L2VPNTermination.assigned_object_ike_policy:type_name -> diode.v1.IKEPolicy
-	34,   // 688: diode.v1.L2VPNTermination.assigned_object_ike_proposal:type_name -> diode.v1.IKEProposal
-	35,   // 689: diode.v1.L2VPNTermination.assigned_object_ip_address:type_name -> diode.v1.IPAddress
-	36,   // 690: diode.v1.L2VPNTermination.assigned_object_ip_range:type_name -> diode.v1.IPRange
-	37,   // 691: diode.v1.L2VPNTermination.assigned_object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
-	38,   // 692: diode.v1.L2VPNTermination.assigned_object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
-	39,   // 693: diode.v1.L2VPNTermination.assigned_object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
-	41,   // 694: diode.v1.L2VPNTermination.assigned_object_inventory_item:type_name -> diode.v1.InventoryItem
-	42,   // 695: diode.v1.L2VPNTermination.assigned_object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
-	96,   // 696: diode.v1.L2VPNTermination.assigned_object_journal_entry:type_name -> diode.v1.JournalEntry
-	43,   // 697: diode.v1.L2VPNTermination.assigned_object_l2vpn:type_name -> diode.v1.L2VPN
-	44,   // 698: diode.v1.L2VPNTermination.assigned_object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
-	45,   // 699: diode.v1.L2VPNTermination.assigned_object_location:type_name -> diode.v1.Location
-	46,   // 700: diode.v1.L2VPNTermination.assigned_object_mac_address:type_name -> diode.v1.MACAddress
-	47,   // 701: diode.v1.L2VPNTermination.assigned_object_manufacturer:type_name -> diode.v1.Manufacturer
-	48,   // 702: diode.v1.L2VPNTermination.assigned_object_module:type_name -> diode.v1.Module
-	49,   // 703: diode.v1.L2VPNTermination.assigned_object_module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 704: diode.v1.L2VPNTermination.assigned_object_module_type:type_name -> diode.v1.ModuleType
-	97,   // 705: diode.v1.L2VPNTermination.assigned_object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
-	51,   // 706: diode.v1.L2VPNTermination.assigned_object_platform:type_name -> diode.v1.Platform
-	52,   // 707: diode.v1.L2VPNTermination.assigned_object_power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 708: diode.v1.L2VPNTermination.assigned_object_power_outlet:type_name -> diode.v1.PowerOutlet
-	54,   // 709: diode.v1.L2VPNTermination.assigned_object_power_panel:type_name -> diode.v1.PowerPanel
-	55,   // 710: diode.v1.L2VPNTermination.assigned_object_power_port:type_name -> diode.v1.PowerPort
-	56,   // 711: diode.v1.L2VPNTermination.assigned_object_prefix:type_name -> diode.v1.Prefix
-	57,   // 712: diode.v1.L2VPNTermination.assigned_object_provider:type_name -> diode.v1.Provider
-	58,   // 713: diode.v1.L2VPNTermination.assigned_object_provider_account:type_name -> diode.v1.ProviderAccount
-	59,   // 714: diode.v1.L2VPNTermination.assigned_object_provider_network:type_name -> diode.v1.ProviderNetwork
-	60,   // 715: diode.v1.L2VPNTermination.assigned_object_rir:type_name -> diode.v1.RIR
-	61,   // 716: diode.v1.L2VPNTermination.assigned_object_rack:type_name -> diode.v1.Rack
-	62,   // 717: diode.v1.L2VPNTermination.assigned_object_rack_reservation:type_name -> diode.v1.RackReservation
-	63,   // 718: diode.v1.L2VPNTermination.assigned_object_rack_role:type_name -> diode.v1.RackRole
-	64,   // 719: diode.v1.L2VPNTermination.assigned_object_rack_type:type_name -> diode.v1.RackType
-	65,   // 720: diode.v1.L2VPNTermination.assigned_object_rear_port:type_name -> diode.v1.RearPort
-	66,   // 721: diode.v1.L2VPNTermination.assigned_object_region:type_name -> diode.v1.Region
-	67,   // 722: diode.v1.L2VPNTermination.assigned_object_role:type_name -> diode.v1.Role
-	68,   // 723: diode.v1.L2VPNTermination.assigned_object_route_target:type_name -> diode.v1.RouteTarget
-	69,   // 724: diode.v1.L2VPNTermination.assigned_object_service:type_name -> diode.v1.Service
-	70,   // 725: diode.v1.L2VPNTermination.assigned_object_site:type_name -> diode.v1.Site
-	71,   // 726: diode.v1.L2VPNTermination.assigned_object_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 727: diode.v1.L2VPNTermination.assigned_object_tag:type_name -> diode.v1.Tag
-	73,   // 728: diode.v1.L2VPNTermination.assigned_object_tenant:type_name -> diode.v1.Tenant
-	74,   // 729: diode.v1.L2VPNTermination.assigned_object_tenant_group:type_name -> diode.v1.TenantGroup
-	75,   // 730: diode.v1.L2VPNTermination.assigned_object_tunnel:type_name -> diode.v1.Tunnel
-	76,   // 731: diode.v1.L2VPNTermination.assigned_object_tunnel_group:type_name -> diode.v1.TunnelGroup
-	77,   // 732: diode.v1.L2VPNTermination.assigned_object_tunnel_termination:type_name -> diode.v1.TunnelTermination
-	79,   // 733: diode.v1.L2VPNTermination.assigned_object_vlan_group:type_name -> diode.v1.VLANGroup
-	80,   // 734: diode.v1.L2VPNTermination.assigned_object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	81,   // 735: diode.v1.L2VPNTermination.assigned_object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
-	83,   // 736: diode.v1.L2VPNTermination.assigned_object_vrf:type_name -> diode.v1.VRF
-	84,   // 737: diode.v1.L2VPNTermination.assigned_object_virtual_chassis:type_name -> diode.v1.VirtualChassis
-	85,   // 738: diode.v1.L2VPNTermination.assigned_object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	86,   // 739: diode.v1.L2VPNTermination.assigned_object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
-	87,   // 740: diode.v1.L2VPNTermination.assigned_object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
-	88,   // 741: diode.v1.L2VPNTermination.assigned_object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
-	89,   // 742: diode.v1.L2VPNTermination.assigned_object_virtual_disk:type_name -> diode.v1.VirtualDisk
-	90,   // 743: diode.v1.L2VPNTermination.assigned_object_virtual_machine:type_name -> diode.v1.VirtualMachine
-	91,   // 744: diode.v1.L2VPNTermination.assigned_object_wireless_lan:type_name -> diode.v1.WirelessLAN
-	92,   // 745: diode.v1.L2VPNTermination.assigned_object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
-	93,   // 746: diode.v1.L2VPNTermination.assigned_object_wireless_link:type_name -> diode.v1.WirelessLink
-	98,   // 747: diode.v1.L2VPNTermination.assigned_object_custom_link:type_name -> diode.v1.CustomLink
-	72,   // 748: diode.v1.L2VPNTermination.tags:type_name -> diode.v1.Tag
-	133,  // 749: diode.v1.L2VPNTermination.custom_fields:type_name -> diode.v1.L2VPNTermination.CustomFieldsEntry
-	70,   // 750: diode.v1.Location.site:type_name -> diode.v1.Site
-	45,   // 751: diode.v1.Location.parent:type_name -> diode.v1.Location
-	73,   // 752: diode.v1.Location.tenant:type_name -> diode.v1.Tenant
-	72,   // 753: diode.v1.Location.tags:type_name -> diode.v1.Tag
-	134,  // 754: diode.v1.Location.custom_fields:type_name -> diode.v1.Location.CustomFieldsEntry
-	40,   // 755: diode.v1.MACAddress.assigned_object_interface:type_name -> diode.v1.Interface
-	82,   // 756: diode.v1.MACAddress.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
-	72,   // 757: diode.v1.MACAddress.tags:type_name -> diode.v1.Tag
-	135,  // 758: diode.v1.MACAddress.custom_fields:type_name -> diode.v1.MACAddress.CustomFieldsEntry
-	72,   // 759: diode.v1.Manufacturer.tags:type_name -> diode.v1.Tag
-	136,  // 760: diode.v1.Manufacturer.custom_fields:type_name -> diode.v1.Manufacturer.CustomFieldsEntry
-	25,   // 761: diode.v1.Module.device:type_name -> diode.v1.Device
-	49,   // 762: diode.v1.Module.module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 763: diode.v1.Module.module_type:type_name -> diode.v1.ModuleType
-	72,   // 764: diode.v1.Module.tags:type_name -> diode.v1.Tag
-	137,  // 765: diode.v1.Module.custom_fields:type_name -> diode.v1.Module.CustomFieldsEntry
-	25,   // 766: diode.v1.ModuleBay.device:type_name -> diode.v1.Device
-	48,   // 767: diode.v1.ModuleBay.module:type_name -> diode.v1.Module
-	48,   // 768: diode.v1.ModuleBay.installed_module:type_name -> diode.v1.Module
-	72,   // 769: diode.v1.ModuleBay.tags:type_name -> diode.v1.Tag
-	138,  // 770: diode.v1.ModuleBay.custom_fields:type_name -> diode.v1.ModuleBay.CustomFieldsEntry
-	47,   // 771: diode.v1.ModuleType.manufacturer:type_name -> diode.v1.Manufacturer
-	72,   // 772: diode.v1.ModuleType.tags:type_name -> diode.v1.Tag
-	139,  // 773: diode.v1.ModuleType.custom_fields:type_name -> diode.v1.ModuleType.CustomFieldsEntry
-	97,   // 774: diode.v1.ModuleType.profile:type_name -> diode.v1.ModuleTypeProfile
-	47,   // 775: diode.v1.Platform.manufacturer:type_name -> diode.v1.Manufacturer
-	72,   // 776: diode.v1.Platform.tags:type_name -> diode.v1.Tag
-	140,  // 777: diode.v1.Platform.custom_fields:type_name -> diode.v1.Platform.CustomFieldsEntry
-	51,   // 778: diode.v1.Platform.parent:type_name -> diode.v1.Platform
-	54,   // 779: diode.v1.PowerFeed.power_panel:type_name -> diode.v1.PowerPanel
-	61,   // 780: diode.v1.PowerFeed.rack:type_name -> diode.v1.Rack
-	73,   // 781: diode.v1.PowerFeed.tenant:type_name -> diode.v1.Tenant
-	72,   // 782: diode.v1.PowerFeed.tags:type_name -> diode.v1.Tag
-	141,  // 783: diode.v1.PowerFeed.custom_fields:type_name -> diode.v1.PowerFeed.CustomFieldsEntry
-	25,   // 784: diode.v1.PowerOutlet.device:type_name -> diode.v1.Device
-	48,   // 785: diode.v1.PowerOutlet.module:type_name -> diode.v1.Module
-	55,   // 786: diode.v1.PowerOutlet.power_port:type_name -> diode.v1.PowerPort
-	72,   // 787: diode.v1.PowerOutlet.tags:type_name -> diode.v1.Tag
-	142,  // 788: diode.v1.PowerOutlet.custom_fields:type_name -> diode.v1.PowerOutlet.CustomFieldsEntry
-	70,   // 789: diode.v1.PowerPanel.site:type_name -> diode.v1.Site
-	45,   // 790: diode.v1.PowerPanel.location:type_name -> diode.v1.Location
-	72,   // 791: diode.v1.PowerPanel.tags:type_name -> diode.v1.Tag
-	143,  // 792: diode.v1.PowerPanel.custom_fields:type_name -> diode.v1.PowerPanel.CustomFieldsEntry
-	25,   // 793: diode.v1.PowerPort.device:type_name -> diode.v1.Device
-	48,   // 794: diode.v1.PowerPort.module:type_name -> diode.v1.Module
-	72,   // 795: diode.v1.PowerPort.tags:type_name -> diode.v1.Tag
-	144,  // 796: diode.v1.PowerPort.custom_fields:type_name -> diode.v1.PowerPort.CustomFieldsEntry
-	83,   // 797: diode.v1.Prefix.vrf:type_name -> diode.v1.VRF
-	45,   // 798: diode.v1.Prefix.scope_location:type_name -> diode.v1.Location
-	66,   // 799: diode.v1.Prefix.scope_region:type_name -> diode.v1.Region
-	70,   // 800: diode.v1.Prefix.scope_site:type_name -> diode.v1.Site
-	71,   // 801: diode.v1.Prefix.scope_site_group:type_name -> diode.v1.SiteGroup
-	73,   // 802: diode.v1.Prefix.tenant:type_name -> diode.v1.Tenant
-	78,   // 803: diode.v1.Prefix.vlan:type_name -> diode.v1.VLAN
-	67,   // 804: diode.v1.Prefix.role:type_name -> diode.v1.Role
-	72,   // 805: diode.v1.Prefix.tags:type_name -> diode.v1.Tag
-	145,  // 806: diode.v1.Prefix.custom_fields:type_name -> diode.v1.Prefix.CustomFieldsEntry
-	72,   // 807: diode.v1.Provider.tags:type_name -> diode.v1.Tag
-	146,  // 808: diode.v1.Provider.custom_fields:type_name -> diode.v1.Provider.CustomFieldsEntry
-	58,   // 809: diode.v1.Provider.accounts:type_name -> diode.v1.ProviderAccount
-	3,    // 810: diode.v1.Provider.asns:type_name -> diode.v1.ASN
-	57,   // 811: diode.v1.ProviderAccount.provider:type_name -> diode.v1.Provider
-	72,   // 812: diode.v1.ProviderAccount.tags:type_name -> diode.v1.Tag
-	147,  // 813: diode.v1.ProviderAccount.custom_fields:type_name -> diode.v1.ProviderAccount.CustomFieldsEntry
-	57,   // 814: diode.v1.ProviderNetwork.provider:type_name -> diode.v1.Provider
-	72,   // 815: diode.v1.ProviderNetwork.tags:type_name -> diode.v1.Tag
-	148,  // 816: diode.v1.ProviderNetwork.custom_fields:type_name -> diode.v1.ProviderNetwork.CustomFieldsEntry
-	72,   // 817: diode.v1.RIR.tags:type_name -> diode.v1.Tag
-	149,  // 818: diode.v1.RIR.custom_fields:type_name -> diode.v1.RIR.CustomFieldsEntry
-	70,   // 819: diode.v1.Rack.site:type_name -> diode.v1.Site
-	45,   // 820: diode.v1.Rack.location:type_name -> diode.v1.Location
-	73,   // 821: diode.v1.Rack.tenant:type_name -> diode.v1.Tenant
-	63,   // 822: diode.v1.Rack.role:type_name -> diode.v1.RackRole
-	64,   // 823: diode.v1.Rack.rack_type:type_name -> diode.v1.RackType
-	72,   // 824: diode.v1.Rack.tags:type_name -> diode.v1.Tag
-	150,  // 825: diode.v1.Rack.custom_fields:type_name -> diode.v1.Rack.CustomFieldsEntry
-	61,   // 826: diode.v1.RackReservation.rack:type_name -> diode.v1.Rack
-	73,   // 827: diode.v1.RackReservation.tenant:type_name -> diode.v1.Tenant
-	72,   // 828: diode.v1.RackReservation.tags:type_name -> diode.v1.Tag
-	151,  // 829: diode.v1.RackReservation.custom_fields:type_name -> diode.v1.RackReservation.CustomFieldsEntry
-	72,   // 830: diode.v1.RackRole.tags:type_name -> diode.v1.Tag
-	152,  // 831: diode.v1.RackRole.custom_fields:type_name -> diode.v1.RackRole.CustomFieldsEntry
-	47,   // 832: diode.v1.RackType.manufacturer:type_name -> diode.v1.Manufacturer
-	72,   // 833: diode.v1.RackType.tags:type_name -> diode.v1.Tag
-	153,  // 834: diode.v1.RackType.custom_fields:type_name -> diode.v1.RackType.CustomFieldsEntry
-	25,   // 835: diode.v1.RearPort.device:type_name -> diode.v1.Device
-	48,   // 836: diode.v1.RearPort.module:type_name -> diode.v1.Module
-	72,   // 837: diode.v1.RearPort.tags:type_name -> diode.v1.Tag
-	154,  // 838: diode.v1.RearPort.custom_fields:type_name -> diode.v1.RearPort.CustomFieldsEntry
-	66,   // 839: diode.v1.Region.parent:type_name -> diode.v1.Region
-	72,   // 840: diode.v1.Region.tags:type_name -> diode.v1.Tag
-	155,  // 841: diode.v1.Region.custom_fields:type_name -> diode.v1.Region.CustomFieldsEntry
-	72,   // 842: diode.v1.Role.tags:type_name -> diode.v1.Tag
-	156,  // 843: diode.v1.Role.custom_fields:type_name -> diode.v1.Role.CustomFieldsEntry
-	73,   // 844: diode.v1.RouteTarget.tenant:type_name -> diode.v1.Tenant
-	72,   // 845: diode.v1.RouteTarget.tags:type_name -> diode.v1.Tag
-	157,  // 846: diode.v1.RouteTarget.custom_fields:type_name -> diode.v1.RouteTarget.CustomFieldsEntry
-	25,   // 847: diode.v1.Service.device:type_name -> diode.v1.Device
-	90,   // 848: diode.v1.Service.virtual_machine:type_name -> diode.v1.VirtualMachine
-	72,   // 849: diode.v1.Service.tags:type_name -> diode.v1.Tag
-	158,  // 850: diode.v1.Service.custom_fields:type_name -> diode.v1.Service.CustomFieldsEntry
-	35,   // 851: diode.v1.Service.ipaddresses:type_name -> diode.v1.IPAddress
-	25,   // 852: diode.v1.Service.parent_object_device:type_name -> diode.v1.Device
-	29,   // 853: diode.v1.Service.parent_object_fhrp_group:type_name -> diode.v1.FHRPGroup
-	90,   // 854: diode.v1.Service.parent_object_virtual_machine:type_name -> diode.v1.VirtualMachine
-	66,   // 855: diode.v1.Site.region:type_name -> diode.v1.Region
-	71,   // 856: diode.v1.Site.group:type_name -> diode.v1.SiteGroup
-	73,   // 857: diode.v1.Site.tenant:type_name -> diode.v1.Tenant
-	72,   // 858: diode.v1.Site.tags:type_name -> diode.v1.Tag
-	159,  // 859: diode.v1.Site.custom_fields:type_name -> diode.v1.Site.CustomFieldsEntry
-	3,    // 860: diode.v1.Site.asns:type_name -> diode.v1.ASN
-	71,   // 861: diode.v1.SiteGroup.parent:type_name -> diode.v1.SiteGroup
-	72,   // 862: diode.v1.SiteGroup.tags:type_name -> diode.v1.Tag
-	160,  // 863: diode.v1.SiteGroup.custom_fields:type_name -> diode.v1.SiteGroup.CustomFieldsEntry
-	74,   // 864: diode.v1.Tenant.group:type_name -> diode.v1.TenantGroup
-	72,   // 865: diode.v1.Tenant.tags:type_name -> diode.v1.Tag
-	161,  // 866: diode.v1.Tenant.custom_fields:type_name -> diode.v1.Tenant.CustomFieldsEntry
-	74,   // 867: diode.v1.TenantGroup.parent:type_name -> diode.v1.TenantGroup
-	72,   // 868: diode.v1.TenantGroup.tags:type_name -> diode.v1.Tag
-	162,  // 869: diode.v1.TenantGroup.custom_fields:type_name -> diode.v1.TenantGroup.CustomFieldsEntry
-	76,   // 870: diode.v1.Tunnel.group:type_name -> diode.v1.TunnelGroup
-	38,   // 871: diode.v1.Tunnel.ipsec_profile:type_name -> diode.v1.IPSecProfile
-	73,   // 872: diode.v1.Tunnel.tenant:type_name -> diode.v1.Tenant
-	72,   // 873: diode.v1.Tunnel.tags:type_name -> diode.v1.Tag
-	163,  // 874: diode.v1.Tunnel.custom_fields:type_name -> diode.v1.Tunnel.CustomFieldsEntry
-	72,   // 875: diode.v1.TunnelGroup.tags:type_name -> diode.v1.Tag
-	164,  // 876: diode.v1.TunnelGroup.custom_fields:type_name -> diode.v1.TunnelGroup.CustomFieldsEntry
-	75,   // 877: diode.v1.TunnelTermination.tunnel:type_name -> diode.v1.Tunnel
-	3,    // 878: diode.v1.TunnelTermination.termination_asn:type_name -> diode.v1.ASN
-	4,    // 879: diode.v1.TunnelTermination.termination_asn_range:type_name -> diode.v1.ASNRange
-	5,    // 880: diode.v1.TunnelTermination.termination_aggregate:type_name -> diode.v1.Aggregate
-	6,    // 881: diode.v1.TunnelTermination.termination_cable:type_name -> diode.v1.Cable
-	7,    // 882: diode.v1.TunnelTermination.termination_cable_path:type_name -> diode.v1.CablePath
-	8,    // 883: diode.v1.TunnelTermination.termination_cable_termination:type_name -> diode.v1.CableTermination
-	9,    // 884: diode.v1.TunnelTermination.termination_circuit:type_name -> diode.v1.Circuit
-	10,   // 885: diode.v1.TunnelTermination.termination_circuit_group:type_name -> diode.v1.CircuitGroup
-	11,   // 886: diode.v1.TunnelTermination.termination_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
-	12,   // 887: diode.v1.TunnelTermination.termination_circuit_termination:type_name -> diode.v1.CircuitTermination
-	13,   // 888: diode.v1.TunnelTermination.termination_circuit_type:type_name -> diode.v1.CircuitType
-	14,   // 889: diode.v1.TunnelTermination.termination_cluster:type_name -> diode.v1.Cluster
-	15,   // 890: diode.v1.TunnelTermination.termination_cluster_group:type_name -> diode.v1.ClusterGroup
-	16,   // 891: diode.v1.TunnelTermination.termination_cluster_type:type_name -> diode.v1.ClusterType
-	17,   // 892: diode.v1.TunnelTermination.termination_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 893: diode.v1.TunnelTermination.termination_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	19,   // 894: diode.v1.TunnelTermination.termination_contact:type_name -> diode.v1.Contact
-	20,   // 895: diode.v1.TunnelTermination.termination_contact_assignment:type_name -> diode.v1.ContactAssignment
-	21,   // 896: diode.v1.TunnelTermination.termination_contact_group:type_name -> diode.v1.ContactGroup
-	22,   // 897: diode.v1.TunnelTermination.termination_contact_role:type_name -> diode.v1.ContactRole
-	25,   // 898: diode.v1.TunnelTermination.termination_device:type_name -> diode.v1.Device
-	26,   // 899: diode.v1.TunnelTermination.termination_device_bay:type_name -> diode.v1.DeviceBay
-	27,   // 900: diode.v1.TunnelTermination.termination_device_role:type_name -> diode.v1.DeviceRole
-	28,   // 901: diode.v1.TunnelTermination.termination_device_type:type_name -> diode.v1.DeviceType
-	29,   // 902: diode.v1.TunnelTermination.termination_fhrp_group:type_name -> diode.v1.FHRPGroup
-	30,   // 903: diode.v1.TunnelTermination.termination_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
-	31,   // 904: diode.v1.TunnelTermination.termination_front_port:type_name -> diode.v1.FrontPort
-	33,   // 905: diode.v1.TunnelTermination.termination_ike_policy:type_name -> diode.v1.IKEPolicy
-	34,   // 906: diode.v1.TunnelTermination.termination_ike_proposal:type_name -> diode.v1.IKEProposal
-	35,   // 907: diode.v1.TunnelTermination.termination_ip_address:type_name -> diode.v1.IPAddress
-	36,   // 908: diode.v1.TunnelTermination.termination_ip_range:type_name -> diode.v1.IPRange
-	37,   // 909: diode.v1.TunnelTermination.termination_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
-	38,   // 910: diode.v1.TunnelTermination.termination_ip_sec_profile:type_name -> diode.v1.IPSecProfile
-	39,   // 911: diode.v1.TunnelTermination.termination_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
-	40,   // 912: diode.v1.TunnelTermination.termination_interface:type_name -> diode.v1.Interface
-	41,   // 913: diode.v1.TunnelTermination.termination_inventory_item:type_name -> diode.v1.InventoryItem
-	42,   // 914: diode.v1.TunnelTermination.termination_inventory_item_role:type_name -> diode.v1.InventoryItemRole
-	43,   // 915: diode.v1.TunnelTermination.termination_l2vpn:type_name -> diode.v1.L2VPN
-	44,   // 916: diode.v1.TunnelTermination.termination_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
-	45,   // 917: diode.v1.TunnelTermination.termination_location:type_name -> diode.v1.Location
-	46,   // 918: diode.v1.TunnelTermination.termination_mac_address:type_name -> diode.v1.MACAddress
-	47,   // 919: diode.v1.TunnelTermination.termination_manufacturer:type_name -> diode.v1.Manufacturer
-	48,   // 920: diode.v1.TunnelTermination.termination_module:type_name -> diode.v1.Module
-	49,   // 921: diode.v1.TunnelTermination.termination_module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 922: diode.v1.TunnelTermination.termination_module_type:type_name -> diode.v1.ModuleType
-	51,   // 923: diode.v1.TunnelTermination.termination_platform:type_name -> diode.v1.Platform
-	52,   // 924: diode.v1.TunnelTermination.termination_power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 925: diode.v1.TunnelTermination.termination_power_outlet:type_name -> diode.v1.PowerOutlet
-	54,   // 926: diode.v1.TunnelTermination.termination_power_panel:type_name -> diode.v1.PowerPanel
-	55,   // 927: diode.v1.TunnelTermination.termination_power_port:type_name -> diode.v1.PowerPort
-	56,   // 928: diode.v1.TunnelTermination.termination_prefix:type_name -> diode.v1.Prefix
-	57,   // 929: diode.v1.TunnelTermination.termination_provider:type_name -> diode.v1.Provider
-	58,   // 930: diode.v1.TunnelTermination.termination_provider_account:type_name -> diode.v1.ProviderAccount
-	59,   // 931: diode.v1.TunnelTermination.termination_provider_network:type_name -> diode.v1.ProviderNetwork
-	60,   // 932: diode.v1.TunnelTermination.termination_rir:type_name -> diode.v1.RIR
-	61,   // 933: diode.v1.TunnelTermination.termination_rack:type_name -> diode.v1.Rack
-	62,   // 934: diode.v1.TunnelTermination.termination_rack_reservation:type_name -> diode.v1.RackReservation
-	63,   // 935: diode.v1.TunnelTermination.termination_rack_role:type_name -> diode.v1.RackRole
-	64,   // 936: diode.v1.TunnelTermination.termination_rack_type:type_name -> diode.v1.RackType
-	65,   // 937: diode.v1.TunnelTermination.termination_rear_port:type_name -> diode.v1.RearPort
-	66,   // 938: diode.v1.TunnelTermination.termination_region:type_name -> diode.v1.Region
-	67,   // 939: diode.v1.TunnelTermination.termination_role:type_name -> diode.v1.Role
-	68,   // 940: diode.v1.TunnelTermination.termination_route_target:type_name -> diode.v1.RouteTarget
-	69,   // 941: diode.v1.TunnelTermination.termination_service:type_name -> diode.v1.Service
-	70,   // 942: diode.v1.TunnelTermination.termination_site:type_name -> diode.v1.Site
-	71,   // 943: diode.v1.TunnelTermination.termination_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 944: diode.v1.TunnelTermination.termination_tag:type_name -> diode.v1.Tag
-	73,   // 945: diode.v1.TunnelTermination.termination_tenant:type_name -> diode.v1.Tenant
-	74,   // 946: diode.v1.TunnelTermination.termination_tenant_group:type_name -> diode.v1.TenantGroup
-	75,   // 947: diode.v1.TunnelTermination.termination_tunnel:type_name -> diode.v1.Tunnel
-	76,   // 948: diode.v1.TunnelTermination.termination_tunnel_group:type_name -> diode.v1.TunnelGroup
-	77,   // 949: diode.v1.TunnelTermination.termination_tunnel_termination:type_name -> diode.v1.TunnelTermination
-	78,   // 950: diode.v1.TunnelTermination.termination_vlan:type_name -> diode.v1.VLAN
-	79,   // 951: diode.v1.TunnelTermination.termination_vlan_group:type_name -> diode.v1.VLANGroup
-	80,   // 952: diode.v1.TunnelTermination.termination_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	81,   // 953: diode.v1.TunnelTermination.termination_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
-	82,   // 954: diode.v1.TunnelTermination.termination_vm_interface:type_name -> diode.v1.VMInterface
-	83,   // 955: diode.v1.TunnelTermination.termination_vrf:type_name -> diode.v1.VRF
-	84,   // 956: diode.v1.TunnelTermination.termination_virtual_chassis:type_name -> diode.v1.VirtualChassis
-	85,   // 957: diode.v1.TunnelTermination.termination_virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	86,   // 958: diode.v1.TunnelTermination.termination_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
-	87,   // 959: diode.v1.TunnelTermination.termination_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
-	88,   // 960: diode.v1.TunnelTermination.termination_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
-	89,   // 961: diode.v1.TunnelTermination.termination_virtual_disk:type_name -> diode.v1.VirtualDisk
-	90,   // 962: diode.v1.TunnelTermination.termination_virtual_machine:type_name -> diode.v1.VirtualMachine
-	91,   // 963: diode.v1.TunnelTermination.termination_wireless_lan:type_name -> diode.v1.WirelessLAN
-	92,   // 964: diode.v1.TunnelTermination.termination_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
-	93,   // 965: diode.v1.TunnelTermination.termination_wireless_link:type_name -> diode.v1.WirelessLink
-	94,   // 966: diode.v1.TunnelTermination.termination_custom_field:type_name -> diode.v1.CustomField
-	95,   // 967: diode.v1.TunnelTermination.termination_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	96,   // 968: diode.v1.TunnelTermination.termination_journal_entry:type_name -> diode.v1.JournalEntry
-	97,   // 969: diode.v1.TunnelTermination.termination_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
-	98,   // 970: diode.v1.TunnelTermination.termination_custom_link:type_name -> diode.v1.CustomLink
-	35,   // 971: diode.v1.TunnelTermination.outside_ip:type_name -> diode.v1.IPAddress
-	72,   // 972: diode.v1.TunnelTermination.tags:type_name -> diode.v1.Tag
-	165,  // 973: diode.v1.TunnelTermination.custom_fields:type_name -> diode.v1.TunnelTermination.CustomFieldsEntry
-	70,   // 974: diode.v1.VLAN.site:type_name -> diode.v1.Site
-	79,   // 975: diode.v1.VLAN.group:type_name -> diode.v1.VLANGroup
-	73,   // 976: diode.v1.VLAN.tenant:type_name -> diode.v1.Tenant
-	67,   // 977: diode.v1.VLAN.role:type_name -> diode.v1.Role
-	78,   // 978: diode.v1.VLAN.qinq_svlan:type_name -> diode.v1.VLAN
-	72,   // 979: diode.v1.VLAN.tags:type_name -> diode.v1.Tag
-	166,  // 980: diode.v1.VLAN.custom_fields:type_name -> diode.v1.VLAN.CustomFieldsEntry
-	14,   // 981: diode.v1.VLANGroup.scope_cluster:type_name -> diode.v1.Cluster
-	15,   // 982: diode.v1.VLANGroup.scope_cluster_group:type_name -> diode.v1.ClusterGroup
-	45,   // 983: diode.v1.VLANGroup.scope_location:type_name -> diode.v1.Location
-	61,   // 984: diode.v1.VLANGroup.scope_rack:type_name -> diode.v1.Rack
-	66,   // 985: diode.v1.VLANGroup.scope_region:type_name -> diode.v1.Region
-	70,   // 986: diode.v1.VLANGroup.scope_site:type_name -> diode.v1.Site
-	71,   // 987: diode.v1.VLANGroup.scope_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 988: diode.v1.VLANGroup.tags:type_name -> diode.v1.Tag
-	167,  // 989: diode.v1.VLANGroup.custom_fields:type_name -> diode.v1.VLANGroup.CustomFieldsEntry
-	73,   // 990: diode.v1.VLANGroup.tenant:type_name -> diode.v1.Tenant
-	80,   // 991: diode.v1.VLANTranslationRule.policy:type_name -> diode.v1.VLANTranslationPolicy
-	90,   // 992: diode.v1.VMInterface.virtual_machine:type_name -> diode.v1.VirtualMachine
-	82,   // 993: diode.v1.VMInterface.parent:type_name -> diode.v1.VMInterface
-	82,   // 994: diode.v1.VMInterface.bridge:type_name -> diode.v1.VMInterface
-	46,   // 995: diode.v1.VMInterface.primary_mac_address:type_name -> diode.v1.MACAddress
-	78,   // 996: diode.v1.VMInterface.untagged_vlan:type_name -> diode.v1.VLAN
-	78,   // 997: diode.v1.VMInterface.qinq_svlan:type_name -> diode.v1.VLAN
-	80,   // 998: diode.v1.VMInterface.vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	83,   // 999: diode.v1.VMInterface.vrf:type_name -> diode.v1.VRF
-	72,   // 1000: diode.v1.VMInterface.tags:type_name -> diode.v1.Tag
-	168,  // 1001: diode.v1.VMInterface.custom_fields:type_name -> diode.v1.VMInterface.CustomFieldsEntry
-	78,   // 1002: diode.v1.VMInterface.tagged_vlans:type_name -> diode.v1.VLAN
-	73,   // 1003: diode.v1.VRF.tenant:type_name -> diode.v1.Tenant
-	72,   // 1004: diode.v1.VRF.tags:type_name -> diode.v1.Tag
-	169,  // 1005: diode.v1.VRF.custom_fields:type_name -> diode.v1.VRF.CustomFieldsEntry
-	68,   // 1006: diode.v1.VRF.import_targets:type_name -> diode.v1.RouteTarget
-	68,   // 1007: diode.v1.VRF.export_targets:type_name -> diode.v1.RouteTarget
-	25,   // 1008: diode.v1.VirtualChassis.master:type_name -> diode.v1.Device
-	72,   // 1009: diode.v1.VirtualChassis.tags:type_name -> diode.v1.Tag
-	170,  // 1010: diode.v1.VirtualChassis.custom_fields:type_name -> diode.v1.VirtualChassis.CustomFieldsEntry
-	59,   // 1011: diode.v1.VirtualCircuit.provider_network:type_name -> diode.v1.ProviderNetwork
-	58,   // 1012: diode.v1.VirtualCircuit.provider_account:type_name -> diode.v1.ProviderAccount
-	87,   // 1013: diode.v1.VirtualCircuit.type:type_name -> diode.v1.VirtualCircuitType
-	73,   // 1014: diode.v1.VirtualCircuit.tenant:type_name -> diode.v1.Tenant
-	72,   // 1015: diode.v1.VirtualCircuit.tags:type_name -> diode.v1.Tag
-	171,  // 1016: diode.v1.VirtualCircuit.custom_fields:type_name -> diode.v1.VirtualCircuit.CustomFieldsEntry
-	85,   // 1017: diode.v1.VirtualCircuitTermination.virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	40,   // 1018: diode.v1.VirtualCircuitTermination.interface:type_name -> diode.v1.Interface
-	72,   // 1019: diode.v1.VirtualCircuitTermination.tags:type_name -> diode.v1.Tag
-	172,  // 1020: diode.v1.VirtualCircuitTermination.custom_fields:type_name -> diode.v1.VirtualCircuitTermination.CustomFieldsEntry
-	72,   // 1021: diode.v1.VirtualCircuitType.tags:type_name -> diode.v1.Tag
-	173,  // 1022: diode.v1.VirtualCircuitType.custom_fields:type_name -> diode.v1.VirtualCircuitType.CustomFieldsEntry
-	25,   // 1023: diode.v1.VirtualDeviceContext.device:type_name -> diode.v1.Device
-	73,   // 1024: diode.v1.VirtualDeviceContext.tenant:type_name -> diode.v1.Tenant
-	35,   // 1025: diode.v1.VirtualDeviceContext.primary_ip4:type_name -> diode.v1.IPAddress
-	35,   // 1026: diode.v1.VirtualDeviceContext.primary_ip6:type_name -> diode.v1.IPAddress
-	72,   // 1027: diode.v1.VirtualDeviceContext.tags:type_name -> diode.v1.Tag
-	174,  // 1028: diode.v1.VirtualDeviceContext.custom_fields:type_name -> diode.v1.VirtualDeviceContext.CustomFieldsEntry
-	90,   // 1029: diode.v1.VirtualDisk.virtual_machine:type_name -> diode.v1.VirtualMachine
-	72,   // 1030: diode.v1.VirtualDisk.tags:type_name -> diode.v1.Tag
-	175,  // 1031: diode.v1.VirtualDisk.custom_fields:type_name -> diode.v1.VirtualDisk.CustomFieldsEntry
-	70,   // 1032: diode.v1.VirtualMachine.site:type_name -> diode.v1.Site
-	14,   // 1033: diode.v1.VirtualMachine.cluster:type_name -> diode.v1.Cluster
-	25,   // 1034: diode.v1.VirtualMachine.device:type_name -> diode.v1.Device
-	27,   // 1035: diode.v1.VirtualMachine.role:type_name -> diode.v1.DeviceRole
-	73,   // 1036: diode.v1.VirtualMachine.tenant:type_name -> diode.v1.Tenant
-	51,   // 1037: diode.v1.VirtualMachine.platform:type_name -> diode.v1.Platform
-	35,   // 1038: diode.v1.VirtualMachine.primary_ip4:type_name -> diode.v1.IPAddress
-	35,   // 1039: diode.v1.VirtualMachine.primary_ip6:type_name -> diode.v1.IPAddress
-	72,   // 1040: diode.v1.VirtualMachine.tags:type_name -> diode.v1.Tag
-	176,  // 1041: diode.v1.VirtualMachine.custom_fields:type_name -> diode.v1.VirtualMachine.CustomFieldsEntry
-	92,   // 1042: diode.v1.WirelessLAN.group:type_name -> diode.v1.WirelessLANGroup
-	78,   // 1043: diode.v1.WirelessLAN.vlan:type_name -> diode.v1.VLAN
-	45,   // 1044: diode.v1.WirelessLAN.scope_location:type_name -> diode.v1.Location
-	66,   // 1045: diode.v1.WirelessLAN.scope_region:type_name -> diode.v1.Region
-	70,   // 1046: diode.v1.WirelessLAN.scope_site:type_name -> diode.v1.Site
-	71,   // 1047: diode.v1.WirelessLAN.scope_site_group:type_name -> diode.v1.SiteGroup
-	73,   // 1048: diode.v1.WirelessLAN.tenant:type_name -> diode.v1.Tenant
-	72,   // 1049: diode.v1.WirelessLAN.tags:type_name -> diode.v1.Tag
-	177,  // 1050: diode.v1.WirelessLAN.custom_fields:type_name -> diode.v1.WirelessLAN.CustomFieldsEntry
-	92,   // 1051: diode.v1.WirelessLANGroup.parent:type_name -> diode.v1.WirelessLANGroup
-	72,   // 1052: diode.v1.WirelessLANGroup.tags:type_name -> diode.v1.Tag
-	178,  // 1053: diode.v1.WirelessLANGroup.custom_fields:type_name -> diode.v1.WirelessLANGroup.CustomFieldsEntry
-	40,   // 1054: diode.v1.WirelessLink.interface_a:type_name -> diode.v1.Interface
-	40,   // 1055: diode.v1.WirelessLink.interface_b:type_name -> diode.v1.Interface
-	73,   // 1056: diode.v1.WirelessLink.tenant:type_name -> diode.v1.Tenant
-	72,   // 1057: diode.v1.WirelessLink.tags:type_name -> diode.v1.Tag
-	179,  // 1058: diode.v1.WirelessLink.custom_fields:type_name -> diode.v1.WirelessLink.CustomFieldsEntry
-	95,   // 1059: diode.v1.CustomField.choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	3,    // 1060: diode.v1.JournalEntry.assigned_object_asn:type_name -> diode.v1.ASN
-	4,    // 1061: diode.v1.JournalEntry.assigned_object_asn_range:type_name -> diode.v1.ASNRange
-	5,    // 1062: diode.v1.JournalEntry.assigned_object_aggregate:type_name -> diode.v1.Aggregate
-	6,    // 1063: diode.v1.JournalEntry.assigned_object_cable:type_name -> diode.v1.Cable
-	7,    // 1064: diode.v1.JournalEntry.assigned_object_cable_path:type_name -> diode.v1.CablePath
-	8,    // 1065: diode.v1.JournalEntry.assigned_object_cable_termination:type_name -> diode.v1.CableTermination
-	9,    // 1066: diode.v1.JournalEntry.assigned_object_circuit:type_name -> diode.v1.Circuit
-	10,   // 1067: diode.v1.JournalEntry.assigned_object_circuit_group:type_name -> diode.v1.CircuitGroup
-	11,   // 1068: diode.v1.JournalEntry.assigned_object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
-	12,   // 1069: diode.v1.JournalEntry.assigned_object_circuit_termination:type_name -> diode.v1.CircuitTermination
-	13,   // 1070: diode.v1.JournalEntry.assigned_object_circuit_type:type_name -> diode.v1.CircuitType
-	14,   // 1071: diode.v1.JournalEntry.assigned_object_cluster:type_name -> diode.v1.Cluster
-	15,   // 1072: diode.v1.JournalEntry.assigned_object_cluster_group:type_name -> diode.v1.ClusterGroup
-	16,   // 1073: diode.v1.JournalEntry.assigned_object_cluster_type:type_name -> diode.v1.ClusterType
-	17,   // 1074: diode.v1.JournalEntry.assigned_object_console_port:type_name -> diode.v1.ConsolePort
-	18,   // 1075: diode.v1.JournalEntry.assigned_object_console_server_port:type_name -> diode.v1.ConsoleServerPort
-	19,   // 1076: diode.v1.JournalEntry.assigned_object_contact:type_name -> diode.v1.Contact
-	20,   // 1077: diode.v1.JournalEntry.assigned_object_contact_assignment:type_name -> diode.v1.ContactAssignment
-	21,   // 1078: diode.v1.JournalEntry.assigned_object_contact_group:type_name -> diode.v1.ContactGroup
-	22,   // 1079: diode.v1.JournalEntry.assigned_object_contact_role:type_name -> diode.v1.ContactRole
-	94,   // 1080: diode.v1.JournalEntry.assigned_object_custom_field:type_name -> diode.v1.CustomField
-	95,   // 1081: diode.v1.JournalEntry.assigned_object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
-	25,   // 1082: diode.v1.JournalEntry.assigned_object_device:type_name -> diode.v1.Device
-	26,   // 1083: diode.v1.JournalEntry.assigned_object_device_bay:type_name -> diode.v1.DeviceBay
-	27,   // 1084: diode.v1.JournalEntry.assigned_object_device_role:type_name -> diode.v1.DeviceRole
-	28,   // 1085: diode.v1.JournalEntry.assigned_object_device_type:type_name -> diode.v1.DeviceType
-	29,   // 1086: diode.v1.JournalEntry.assigned_object_fhrp_group:type_name -> diode.v1.FHRPGroup
-	30,   // 1087: diode.v1.JournalEntry.assigned_object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
-	31,   // 1088: diode.v1.JournalEntry.assigned_object_front_port:type_name -> diode.v1.FrontPort
-	33,   // 1089: diode.v1.JournalEntry.assigned_object_ike_policy:type_name -> diode.v1.IKEPolicy
-	34,   // 1090: diode.v1.JournalEntry.assigned_object_ike_proposal:type_name -> diode.v1.IKEProposal
-	35,   // 1091: diode.v1.JournalEntry.assigned_object_ip_address:type_name -> diode.v1.IPAddress
-	36,   // 1092: diode.v1.JournalEntry.assigned_object_ip_range:type_name -> diode.v1.IPRange
-	37,   // 1093: diode.v1.JournalEntry.assigned_object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
-	38,   // 1094: diode.v1.JournalEntry.assigned_object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
-	39,   // 1095: diode.v1.JournalEntry.assigned_object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
-	40,   // 1096: diode.v1.JournalEntry.assigned_object_interface:type_name -> diode.v1.Interface
-	41,   // 1097: diode.v1.JournalEntry.assigned_object_inventory_item:type_name -> diode.v1.InventoryItem
-	42,   // 1098: diode.v1.JournalEntry.assigned_object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
-	96,   // 1099: diode.v1.JournalEntry.assigned_object_journal_entry:type_name -> diode.v1.JournalEntry
-	43,   // 1100: diode.v1.JournalEntry.assigned_object_l2vpn:type_name -> diode.v1.L2VPN
-	44,   // 1101: diode.v1.JournalEntry.assigned_object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
-	45,   // 1102: diode.v1.JournalEntry.assigned_object_location:type_name -> diode.v1.Location
-	46,   // 1103: diode.v1.JournalEntry.assigned_object_mac_address:type_name -> diode.v1.MACAddress
-	47,   // 1104: diode.v1.JournalEntry.assigned_object_manufacturer:type_name -> diode.v1.Manufacturer
-	48,   // 1105: diode.v1.JournalEntry.assigned_object_module:type_name -> diode.v1.Module
-	49,   // 1106: diode.v1.JournalEntry.assigned_object_module_bay:type_name -> diode.v1.ModuleBay
-	50,   // 1107: diode.v1.JournalEntry.assigned_object_module_type:type_name -> diode.v1.ModuleType
-	97,   // 1108: diode.v1.JournalEntry.assigned_object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
-	51,   // 1109: diode.v1.JournalEntry.assigned_object_platform:type_name -> diode.v1.Platform
-	52,   // 1110: diode.v1.JournalEntry.assigned_object_power_feed:type_name -> diode.v1.PowerFeed
-	53,   // 1111: diode.v1.JournalEntry.assigned_object_power_outlet:type_name -> diode.v1.PowerOutlet
-	54,   // 1112: diode.v1.JournalEntry.assigned_object_power_panel:type_name -> diode.v1.PowerPanel
-	55,   // 1113: diode.v1.JournalEntry.assigned_object_power_port:type_name -> diode.v1.PowerPort
-	56,   // 1114: diode.v1.JournalEntry.assigned_object_prefix:type_name -> diode.v1.Prefix
-	57,   // 1115: diode.v1.JournalEntry.assigned_object_provider:type_name -> diode.v1.Provider
-	58,   // 1116: diode.v1.JournalEntry.assigned_object_provider_account:type_name -> diode.v1.ProviderAccount
-	59,   // 1117: diode.v1.JournalEntry.assigned_object_provider_network:type_name -> diode.v1.ProviderNetwork
-	60,   // 1118: diode.v1.JournalEntry.assigned_object_rir:type_name -> diode.v1.RIR
-	61,   // 1119: diode.v1.JournalEntry.assigned_object_rack:type_name -> diode.v1.Rack
-	62,   // 1120: diode.v1.JournalEntry.assigned_object_rack_reservation:type_name -> diode.v1.RackReservation
-	63,   // 1121: diode.v1.JournalEntry.assigned_object_rack_role:type_name -> diode.v1.RackRole
-	64,   // 1122: diode.v1.JournalEntry.assigned_object_rack_type:type_name -> diode.v1.RackType
-	65,   // 1123: diode.v1.JournalEntry.assigned_object_rear_port:type_name -> diode.v1.RearPort
-	66,   // 1124: diode.v1.JournalEntry.assigned_object_region:type_name -> diode.v1.Region
-	67,   // 1125: diode.v1.JournalEntry.assigned_object_role:type_name -> diode.v1.Role
-	68,   // 1126: diode.v1.JournalEntry.assigned_object_route_target:type_name -> diode.v1.RouteTarget
-	69,   // 1127: diode.v1.JournalEntry.assigned_object_service:type_name -> diode.v1.Service
-	70,   // 1128: diode.v1.JournalEntry.assigned_object_site:type_name -> diode.v1.Site
-	71,   // 1129: diode.v1.JournalEntry.assigned_object_site_group:type_name -> diode.v1.SiteGroup
-	72,   // 1130: diode.v1.JournalEntry.assigned_object_tag:type_name -> diode.v1.Tag
-	73,   // 1131: diode.v1.JournalEntry.assigned_object_tenant:type_name -> diode.v1.Tenant
-	74,   // 1132: diode.v1.JournalEntry.assigned_object_tenant_group:type_name -> diode.v1.TenantGroup
-	75,   // 1133: diode.v1.JournalEntry.assigned_object_tunnel:type_name -> diode.v1.Tunnel
-	76,   // 1134: diode.v1.JournalEntry.assigned_object_tunnel_group:type_name -> diode.v1.TunnelGroup
-	77,   // 1135: diode.v1.JournalEntry.assigned_object_tunnel_termination:type_name -> diode.v1.TunnelTermination
-	78,   // 1136: diode.v1.JournalEntry.assigned_object_vlan:type_name -> diode.v1.VLAN
-	79,   // 1137: diode.v1.JournalEntry.assigned_object_vlan_group:type_name -> diode.v1.VLANGroup
-	80,   // 1138: diode.v1.JournalEntry.assigned_object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
-	81,   // 1139: diode.v1.JournalEntry.assigned_object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
-	82,   // 1140: diode.v1.JournalEntry.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
-	83,   // 1141: diode.v1.JournalEntry.assigned_object_vrf:type_name -> diode.v1.VRF
-	84,   // 1142: diode.v1.JournalEntry.assigned_object_virtual_chassis:type_name -> diode.v1.VirtualChassis
-	85,   // 1143: diode.v1.JournalEntry.assigned_object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
-	86,   // 1144: diode.v1.JournalEntry.assigned_object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
-	87,   // 1145: diode.v1.JournalEntry.assigned_object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
-	88,   // 1146: diode.v1.JournalEntry.assigned_object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
-	89,   // 1147: diode.v1.JournalEntry.assigned_object_virtual_disk:type_name -> diode.v1.VirtualDisk
-	90,   // 1148: diode.v1.JournalEntry.assigned_object_virtual_machine:type_name -> diode.v1.VirtualMachine
-	91,   // 1149: diode.v1.JournalEntry.assigned_object_wireless_lan:type_name -> diode.v1.WirelessLAN
-	92,   // 1150: diode.v1.JournalEntry.assigned_object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
-	93,   // 1151: diode.v1.JournalEntry.assigned_object_wireless_link:type_name -> diode.v1.WirelessLink
-	98,   // 1152: diode.v1.JournalEntry.assigned_object_custom_link:type_name -> diode.v1.CustomLink
-	72,   // 1153: diode.v1.JournalEntry.tags:type_name -> diode.v1.Tag
-	180,  // 1154: diode.v1.JournalEntry.custom_fields:type_name -> diode.v1.JournalEntry.CustomFieldsEntry
-	72,   // 1155: diode.v1.ModuleTypeProfile.tags:type_name -> diode.v1.Tag
-	181,  // 1156: diode.v1.ModuleTypeProfile.custom_fields:type_name -> diode.v1.ModuleTypeProfile.CustomFieldsEntry
-	24,   // 1157: diode.v1.ASN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1158: diode.v1.ASNRange.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1159: diode.v1.Aggregate.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1160: diode.v1.Cable.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1161: diode.v1.Circuit.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1162: diode.v1.CircuitGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1163: diode.v1.CircuitTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1164: diode.v1.CircuitType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1165: diode.v1.Cluster.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1166: diode.v1.ClusterGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1167: diode.v1.ClusterType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1168: diode.v1.ConsolePort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1169: diode.v1.ConsoleServerPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1170: diode.v1.Contact.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1171: diode.v1.ContactAssignment.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1172: diode.v1.ContactGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1173: diode.v1.ContactRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1174: diode.v1.Device.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1175: diode.v1.DeviceBay.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1176: diode.v1.DeviceRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1177: diode.v1.DeviceType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1178: diode.v1.FHRPGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1179: diode.v1.FrontPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1180: diode.v1.IKEPolicy.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1181: diode.v1.IKEProposal.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1182: diode.v1.IPAddress.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1183: diode.v1.IPRange.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1184: diode.v1.IPSecPolicy.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1185: diode.v1.IPSecProfile.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1186: diode.v1.IPSecProposal.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1187: diode.v1.Interface.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1188: diode.v1.InventoryItem.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1189: diode.v1.InventoryItemRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1190: diode.v1.L2VPN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1191: diode.v1.L2VPNTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1192: diode.v1.Location.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1193: diode.v1.MACAddress.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1194: diode.v1.Manufacturer.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1195: diode.v1.Module.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1196: diode.v1.ModuleBay.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1197: diode.v1.ModuleType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1198: diode.v1.Platform.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1199: diode.v1.PowerFeed.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1200: diode.v1.PowerOutlet.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1201: diode.v1.PowerPanel.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1202: diode.v1.PowerPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1203: diode.v1.Prefix.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1204: diode.v1.Provider.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1205: diode.v1.ProviderAccount.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1206: diode.v1.ProviderNetwork.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1207: diode.v1.RIR.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1208: diode.v1.Rack.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1209: diode.v1.RackReservation.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1210: diode.v1.RackRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1211: diode.v1.RackType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1212: diode.v1.RearPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1213: diode.v1.Region.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1214: diode.v1.Role.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1215: diode.v1.RouteTarget.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1216: diode.v1.Service.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1217: diode.v1.Site.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1218: diode.v1.SiteGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1219: diode.v1.Tenant.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1220: diode.v1.TenantGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1221: diode.v1.Tunnel.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1222: diode.v1.TunnelGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1223: diode.v1.TunnelTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1224: diode.v1.VLAN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1225: diode.v1.VLANGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1226: diode.v1.VMInterface.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1227: diode.v1.VRF.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1228: diode.v1.VirtualChassis.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1229: diode.v1.VirtualCircuit.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1230: diode.v1.VirtualCircuitTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1231: diode.v1.VirtualCircuitType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1232: diode.v1.VirtualDeviceContext.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1233: diode.v1.VirtualDisk.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1234: diode.v1.VirtualMachine.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1235: diode.v1.WirelessLAN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1236: diode.v1.WirelessLANGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1237: diode.v1.WirelessLink.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1238: diode.v1.JournalEntry.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	24,   // 1239: diode.v1.ModuleTypeProfile.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
-	1,    // 1240: diode.v1.IngesterService.Ingest:input_type -> diode.v1.IngestRequest
-	2,    // 1241: diode.v1.IngesterService.Ingest:output_type -> diode.v1.IngestResponse
-	1241, // [1241:1242] is the sub-list for method output_type
-	1240, // [1240:1241] is the sub-list for method input_type
-	1240, // [1240:1240] is the sub-list for extension type_name
-	1240, // [1240:1240] is the sub-list for extension extendee
-	0,    // [0:1240] is the sub-list for field type_name
+	183,  // 95: diode.v1.IngestRequest.metadata:type_name -> google.protobuf.Struct
+	60,   // 96: diode.v1.ASN.rir:type_name -> diode.v1.RIR
+	73,   // 97: diode.v1.ASN.tenant:type_name -> diode.v1.Tenant
+	72,   // 98: diode.v1.ASN.tags:type_name -> diode.v1.Tag
+	99,   // 99: diode.v1.ASN.custom_fields:type_name -> diode.v1.ASN.CustomFieldsEntry
+	183,  // 100: diode.v1.ASN.metadata:type_name -> google.protobuf.Struct
+	60,   // 101: diode.v1.ASNRange.rir:type_name -> diode.v1.RIR
+	73,   // 102: diode.v1.ASNRange.tenant:type_name -> diode.v1.Tenant
+	72,   // 103: diode.v1.ASNRange.tags:type_name -> diode.v1.Tag
+	100,  // 104: diode.v1.ASNRange.custom_fields:type_name -> diode.v1.ASNRange.CustomFieldsEntry
+	183,  // 105: diode.v1.ASNRange.metadata:type_name -> google.protobuf.Struct
+	60,   // 106: diode.v1.Aggregate.rir:type_name -> diode.v1.RIR
+	73,   // 107: diode.v1.Aggregate.tenant:type_name -> diode.v1.Tenant
+	182,  // 108: diode.v1.Aggregate.date_added:type_name -> google.protobuf.Timestamp
+	72,   // 109: diode.v1.Aggregate.tags:type_name -> diode.v1.Tag
+	101,  // 110: diode.v1.Aggregate.custom_fields:type_name -> diode.v1.Aggregate.CustomFieldsEntry
+	183,  // 111: diode.v1.Aggregate.metadata:type_name -> google.protobuf.Struct
+	32,   // 112: diode.v1.Cable.a_terminations:type_name -> diode.v1.GenericObject
+	32,   // 113: diode.v1.Cable.b_terminations:type_name -> diode.v1.GenericObject
+	73,   // 114: diode.v1.Cable.tenant:type_name -> diode.v1.Tenant
+	72,   // 115: diode.v1.Cable.tags:type_name -> diode.v1.Tag
+	102,  // 116: diode.v1.Cable.custom_fields:type_name -> diode.v1.Cable.CustomFieldsEntry
+	183,  // 117: diode.v1.Cable.metadata:type_name -> google.protobuf.Struct
+	183,  // 118: diode.v1.CablePath.metadata:type_name -> google.protobuf.Struct
+	6,    // 119: diode.v1.CableTermination.cable:type_name -> diode.v1.Cable
+	12,   // 120: diode.v1.CableTermination.termination_circuit_termination:type_name -> diode.v1.CircuitTermination
+	17,   // 121: diode.v1.CableTermination.termination_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 122: diode.v1.CableTermination.termination_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	31,   // 123: diode.v1.CableTermination.termination_front_port:type_name -> diode.v1.FrontPort
+	40,   // 124: diode.v1.CableTermination.termination_interface:type_name -> diode.v1.Interface
+	52,   // 125: diode.v1.CableTermination.termination_power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 126: diode.v1.CableTermination.termination_power_outlet:type_name -> diode.v1.PowerOutlet
+	55,   // 127: diode.v1.CableTermination.termination_power_port:type_name -> diode.v1.PowerPort
+	65,   // 128: diode.v1.CableTermination.termination_rear_port:type_name -> diode.v1.RearPort
+	183,  // 129: diode.v1.CableTermination.metadata:type_name -> google.protobuf.Struct
+	57,   // 130: diode.v1.Circuit.provider:type_name -> diode.v1.Provider
+	58,   // 131: diode.v1.Circuit.provider_account:type_name -> diode.v1.ProviderAccount
+	13,   // 132: diode.v1.Circuit.type:type_name -> diode.v1.CircuitType
+	73,   // 133: diode.v1.Circuit.tenant:type_name -> diode.v1.Tenant
+	182,  // 134: diode.v1.Circuit.install_date:type_name -> google.protobuf.Timestamp
+	182,  // 135: diode.v1.Circuit.termination_date:type_name -> google.protobuf.Timestamp
+	72,   // 136: diode.v1.Circuit.tags:type_name -> diode.v1.Tag
+	11,   // 137: diode.v1.Circuit.assignments:type_name -> diode.v1.CircuitGroupAssignment
+	103,  // 138: diode.v1.Circuit.custom_fields:type_name -> diode.v1.Circuit.CustomFieldsEntry
+	183,  // 139: diode.v1.Circuit.metadata:type_name -> google.protobuf.Struct
+	73,   // 140: diode.v1.CircuitGroup.tenant:type_name -> diode.v1.Tenant
+	72,   // 141: diode.v1.CircuitGroup.tags:type_name -> diode.v1.Tag
+	104,  // 142: diode.v1.CircuitGroup.custom_fields:type_name -> diode.v1.CircuitGroup.CustomFieldsEntry
+	183,  // 143: diode.v1.CircuitGroup.metadata:type_name -> google.protobuf.Struct
+	10,   // 144: diode.v1.CircuitGroupAssignment.group:type_name -> diode.v1.CircuitGroup
+	9,    // 145: diode.v1.CircuitGroupAssignment.member_circuit:type_name -> diode.v1.Circuit
+	85,   // 146: diode.v1.CircuitGroupAssignment.member_virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	72,   // 147: diode.v1.CircuitGroupAssignment.tags:type_name -> diode.v1.Tag
+	183,  // 148: diode.v1.CircuitGroupAssignment.metadata:type_name -> google.protobuf.Struct
+	9,    // 149: diode.v1.CircuitTermination.circuit:type_name -> diode.v1.Circuit
+	45,   // 150: diode.v1.CircuitTermination.termination_location:type_name -> diode.v1.Location
+	59,   // 151: diode.v1.CircuitTermination.termination_provider_network:type_name -> diode.v1.ProviderNetwork
+	66,   // 152: diode.v1.CircuitTermination.termination_region:type_name -> diode.v1.Region
+	70,   // 153: diode.v1.CircuitTermination.termination_site:type_name -> diode.v1.Site
+	71,   // 154: diode.v1.CircuitTermination.termination_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 155: diode.v1.CircuitTermination.tags:type_name -> diode.v1.Tag
+	105,  // 156: diode.v1.CircuitTermination.custom_fields:type_name -> diode.v1.CircuitTermination.CustomFieldsEntry
+	183,  // 157: diode.v1.CircuitTermination.metadata:type_name -> google.protobuf.Struct
+	72,   // 158: diode.v1.CircuitType.tags:type_name -> diode.v1.Tag
+	106,  // 159: diode.v1.CircuitType.custom_fields:type_name -> diode.v1.CircuitType.CustomFieldsEntry
+	183,  // 160: diode.v1.CircuitType.metadata:type_name -> google.protobuf.Struct
+	16,   // 161: diode.v1.Cluster.type:type_name -> diode.v1.ClusterType
+	15,   // 162: diode.v1.Cluster.group:type_name -> diode.v1.ClusterGroup
+	73,   // 163: diode.v1.Cluster.tenant:type_name -> diode.v1.Tenant
+	45,   // 164: diode.v1.Cluster.scope_location:type_name -> diode.v1.Location
+	66,   // 165: diode.v1.Cluster.scope_region:type_name -> diode.v1.Region
+	70,   // 166: diode.v1.Cluster.scope_site:type_name -> diode.v1.Site
+	71,   // 167: diode.v1.Cluster.scope_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 168: diode.v1.Cluster.tags:type_name -> diode.v1.Tag
+	107,  // 169: diode.v1.Cluster.custom_fields:type_name -> diode.v1.Cluster.CustomFieldsEntry
+	183,  // 170: diode.v1.Cluster.metadata:type_name -> google.protobuf.Struct
+	72,   // 171: diode.v1.ClusterGroup.tags:type_name -> diode.v1.Tag
+	108,  // 172: diode.v1.ClusterGroup.custom_fields:type_name -> diode.v1.ClusterGroup.CustomFieldsEntry
+	183,  // 173: diode.v1.ClusterGroup.metadata:type_name -> google.protobuf.Struct
+	72,   // 174: diode.v1.ClusterType.tags:type_name -> diode.v1.Tag
+	109,  // 175: diode.v1.ClusterType.custom_fields:type_name -> diode.v1.ClusterType.CustomFieldsEntry
+	183,  // 176: diode.v1.ClusterType.metadata:type_name -> google.protobuf.Struct
+	25,   // 177: diode.v1.ConsolePort.device:type_name -> diode.v1.Device
+	48,   // 178: diode.v1.ConsolePort.module:type_name -> diode.v1.Module
+	72,   // 179: diode.v1.ConsolePort.tags:type_name -> diode.v1.Tag
+	110,  // 180: diode.v1.ConsolePort.custom_fields:type_name -> diode.v1.ConsolePort.CustomFieldsEntry
+	183,  // 181: diode.v1.ConsolePort.metadata:type_name -> google.protobuf.Struct
+	25,   // 182: diode.v1.ConsoleServerPort.device:type_name -> diode.v1.Device
+	48,   // 183: diode.v1.ConsoleServerPort.module:type_name -> diode.v1.Module
+	72,   // 184: diode.v1.ConsoleServerPort.tags:type_name -> diode.v1.Tag
+	111,  // 185: diode.v1.ConsoleServerPort.custom_fields:type_name -> diode.v1.ConsoleServerPort.CustomFieldsEntry
+	183,  // 186: diode.v1.ConsoleServerPort.metadata:type_name -> google.protobuf.Struct
+	21,   // 187: diode.v1.Contact.group:type_name -> diode.v1.ContactGroup
+	72,   // 188: diode.v1.Contact.tags:type_name -> diode.v1.Tag
+	112,  // 189: diode.v1.Contact.custom_fields:type_name -> diode.v1.Contact.CustomFieldsEntry
+	21,   // 190: diode.v1.Contact.groups:type_name -> diode.v1.ContactGroup
+	183,  // 191: diode.v1.Contact.metadata:type_name -> google.protobuf.Struct
+	3,    // 192: diode.v1.ContactAssignment.object_asn:type_name -> diode.v1.ASN
+	4,    // 193: diode.v1.ContactAssignment.object_asn_range:type_name -> diode.v1.ASNRange
+	5,    // 194: diode.v1.ContactAssignment.object_aggregate:type_name -> diode.v1.Aggregate
+	6,    // 195: diode.v1.ContactAssignment.object_cable:type_name -> diode.v1.Cable
+	7,    // 196: diode.v1.ContactAssignment.object_cable_path:type_name -> diode.v1.CablePath
+	8,    // 197: diode.v1.ContactAssignment.object_cable_termination:type_name -> diode.v1.CableTermination
+	9,    // 198: diode.v1.ContactAssignment.object_circuit:type_name -> diode.v1.Circuit
+	10,   // 199: diode.v1.ContactAssignment.object_circuit_group:type_name -> diode.v1.CircuitGroup
+	11,   // 200: diode.v1.ContactAssignment.object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
+	12,   // 201: diode.v1.ContactAssignment.object_circuit_termination:type_name -> diode.v1.CircuitTermination
+	13,   // 202: diode.v1.ContactAssignment.object_circuit_type:type_name -> diode.v1.CircuitType
+	14,   // 203: diode.v1.ContactAssignment.object_cluster:type_name -> diode.v1.Cluster
+	15,   // 204: diode.v1.ContactAssignment.object_cluster_group:type_name -> diode.v1.ClusterGroup
+	16,   // 205: diode.v1.ContactAssignment.object_cluster_type:type_name -> diode.v1.ClusterType
+	17,   // 206: diode.v1.ContactAssignment.object_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 207: diode.v1.ContactAssignment.object_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	19,   // 208: diode.v1.ContactAssignment.object_contact:type_name -> diode.v1.Contact
+	20,   // 209: diode.v1.ContactAssignment.object_contact_assignment:type_name -> diode.v1.ContactAssignment
+	21,   // 210: diode.v1.ContactAssignment.object_contact_group:type_name -> diode.v1.ContactGroup
+	22,   // 211: diode.v1.ContactAssignment.object_contact_role:type_name -> diode.v1.ContactRole
+	25,   // 212: diode.v1.ContactAssignment.object_device:type_name -> diode.v1.Device
+	26,   // 213: diode.v1.ContactAssignment.object_device_bay:type_name -> diode.v1.DeviceBay
+	27,   // 214: diode.v1.ContactAssignment.object_device_role:type_name -> diode.v1.DeviceRole
+	28,   // 215: diode.v1.ContactAssignment.object_device_type:type_name -> diode.v1.DeviceType
+	29,   // 216: diode.v1.ContactAssignment.object_fhrp_group:type_name -> diode.v1.FHRPGroup
+	30,   // 217: diode.v1.ContactAssignment.object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
+	31,   // 218: diode.v1.ContactAssignment.object_front_port:type_name -> diode.v1.FrontPort
+	33,   // 219: diode.v1.ContactAssignment.object_ike_policy:type_name -> diode.v1.IKEPolicy
+	34,   // 220: diode.v1.ContactAssignment.object_ike_proposal:type_name -> diode.v1.IKEProposal
+	35,   // 221: diode.v1.ContactAssignment.object_ip_address:type_name -> diode.v1.IPAddress
+	36,   // 222: diode.v1.ContactAssignment.object_ip_range:type_name -> diode.v1.IPRange
+	37,   // 223: diode.v1.ContactAssignment.object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
+	38,   // 224: diode.v1.ContactAssignment.object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
+	39,   // 225: diode.v1.ContactAssignment.object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
+	40,   // 226: diode.v1.ContactAssignment.object_interface:type_name -> diode.v1.Interface
+	41,   // 227: diode.v1.ContactAssignment.object_inventory_item:type_name -> diode.v1.InventoryItem
+	42,   // 228: diode.v1.ContactAssignment.object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
+	43,   // 229: diode.v1.ContactAssignment.object_l2vpn:type_name -> diode.v1.L2VPN
+	44,   // 230: diode.v1.ContactAssignment.object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
+	45,   // 231: diode.v1.ContactAssignment.object_location:type_name -> diode.v1.Location
+	46,   // 232: diode.v1.ContactAssignment.object_mac_address:type_name -> diode.v1.MACAddress
+	47,   // 233: diode.v1.ContactAssignment.object_manufacturer:type_name -> diode.v1.Manufacturer
+	48,   // 234: diode.v1.ContactAssignment.object_module:type_name -> diode.v1.Module
+	49,   // 235: diode.v1.ContactAssignment.object_module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 236: diode.v1.ContactAssignment.object_module_type:type_name -> diode.v1.ModuleType
+	51,   // 237: diode.v1.ContactAssignment.object_platform:type_name -> diode.v1.Platform
+	52,   // 238: diode.v1.ContactAssignment.object_power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 239: diode.v1.ContactAssignment.object_power_outlet:type_name -> diode.v1.PowerOutlet
+	54,   // 240: diode.v1.ContactAssignment.object_power_panel:type_name -> diode.v1.PowerPanel
+	55,   // 241: diode.v1.ContactAssignment.object_power_port:type_name -> diode.v1.PowerPort
+	56,   // 242: diode.v1.ContactAssignment.object_prefix:type_name -> diode.v1.Prefix
+	57,   // 243: diode.v1.ContactAssignment.object_provider:type_name -> diode.v1.Provider
+	58,   // 244: diode.v1.ContactAssignment.object_provider_account:type_name -> diode.v1.ProviderAccount
+	59,   // 245: diode.v1.ContactAssignment.object_provider_network:type_name -> diode.v1.ProviderNetwork
+	60,   // 246: diode.v1.ContactAssignment.object_rir:type_name -> diode.v1.RIR
+	61,   // 247: diode.v1.ContactAssignment.object_rack:type_name -> diode.v1.Rack
+	62,   // 248: diode.v1.ContactAssignment.object_rack_reservation:type_name -> diode.v1.RackReservation
+	63,   // 249: diode.v1.ContactAssignment.object_rack_role:type_name -> diode.v1.RackRole
+	64,   // 250: diode.v1.ContactAssignment.object_rack_type:type_name -> diode.v1.RackType
+	65,   // 251: diode.v1.ContactAssignment.object_rear_port:type_name -> diode.v1.RearPort
+	66,   // 252: diode.v1.ContactAssignment.object_region:type_name -> diode.v1.Region
+	67,   // 253: diode.v1.ContactAssignment.object_role:type_name -> diode.v1.Role
+	68,   // 254: diode.v1.ContactAssignment.object_route_target:type_name -> diode.v1.RouteTarget
+	69,   // 255: diode.v1.ContactAssignment.object_service:type_name -> diode.v1.Service
+	70,   // 256: diode.v1.ContactAssignment.object_site:type_name -> diode.v1.Site
+	71,   // 257: diode.v1.ContactAssignment.object_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 258: diode.v1.ContactAssignment.object_tag:type_name -> diode.v1.Tag
+	73,   // 259: diode.v1.ContactAssignment.object_tenant:type_name -> diode.v1.Tenant
+	74,   // 260: diode.v1.ContactAssignment.object_tenant_group:type_name -> diode.v1.TenantGroup
+	75,   // 261: diode.v1.ContactAssignment.object_tunnel:type_name -> diode.v1.Tunnel
+	76,   // 262: diode.v1.ContactAssignment.object_tunnel_group:type_name -> diode.v1.TunnelGroup
+	77,   // 263: diode.v1.ContactAssignment.object_tunnel_termination:type_name -> diode.v1.TunnelTermination
+	78,   // 264: diode.v1.ContactAssignment.object_vlan:type_name -> diode.v1.VLAN
+	79,   // 265: diode.v1.ContactAssignment.object_vlan_group:type_name -> diode.v1.VLANGroup
+	80,   // 266: diode.v1.ContactAssignment.object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	81,   // 267: diode.v1.ContactAssignment.object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
+	82,   // 268: diode.v1.ContactAssignment.object_vm_interface:type_name -> diode.v1.VMInterface
+	83,   // 269: diode.v1.ContactAssignment.object_vrf:type_name -> diode.v1.VRF
+	84,   // 270: diode.v1.ContactAssignment.object_virtual_chassis:type_name -> diode.v1.VirtualChassis
+	85,   // 271: diode.v1.ContactAssignment.object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	86,   // 272: diode.v1.ContactAssignment.object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
+	87,   // 273: diode.v1.ContactAssignment.object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
+	88,   // 274: diode.v1.ContactAssignment.object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
+	89,   // 275: diode.v1.ContactAssignment.object_virtual_disk:type_name -> diode.v1.VirtualDisk
+	90,   // 276: diode.v1.ContactAssignment.object_virtual_machine:type_name -> diode.v1.VirtualMachine
+	91,   // 277: diode.v1.ContactAssignment.object_wireless_lan:type_name -> diode.v1.WirelessLAN
+	92,   // 278: diode.v1.ContactAssignment.object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
+	93,   // 279: diode.v1.ContactAssignment.object_wireless_link:type_name -> diode.v1.WirelessLink
+	94,   // 280: diode.v1.ContactAssignment.object_custom_field:type_name -> diode.v1.CustomField
+	95,   // 281: diode.v1.ContactAssignment.object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	96,   // 282: diode.v1.ContactAssignment.object_journal_entry:type_name -> diode.v1.JournalEntry
+	97,   // 283: diode.v1.ContactAssignment.object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
+	98,   // 284: diode.v1.ContactAssignment.object_custom_link:type_name -> diode.v1.CustomLink
+	19,   // 285: diode.v1.ContactAssignment.contact:type_name -> diode.v1.Contact
+	22,   // 286: diode.v1.ContactAssignment.role:type_name -> diode.v1.ContactRole
+	72,   // 287: diode.v1.ContactAssignment.tags:type_name -> diode.v1.Tag
+	113,  // 288: diode.v1.ContactAssignment.custom_fields:type_name -> diode.v1.ContactAssignment.CustomFieldsEntry
+	183,  // 289: diode.v1.ContactAssignment.metadata:type_name -> google.protobuf.Struct
+	21,   // 290: diode.v1.ContactGroup.parent:type_name -> diode.v1.ContactGroup
+	72,   // 291: diode.v1.ContactGroup.tags:type_name -> diode.v1.Tag
+	114,  // 292: diode.v1.ContactGroup.custom_fields:type_name -> diode.v1.ContactGroup.CustomFieldsEntry
+	183,  // 293: diode.v1.ContactGroup.metadata:type_name -> google.protobuf.Struct
+	72,   // 294: diode.v1.ContactRole.tags:type_name -> diode.v1.Tag
+	115,  // 295: diode.v1.ContactRole.custom_fields:type_name -> diode.v1.ContactRole.CustomFieldsEntry
+	183,  // 296: diode.v1.ContactRole.metadata:type_name -> google.protobuf.Struct
+	3,    // 297: diode.v1.CustomFieldObjectReference.asn:type_name -> diode.v1.ASN
+	4,    // 298: diode.v1.CustomFieldObjectReference.asn_range:type_name -> diode.v1.ASNRange
+	5,    // 299: diode.v1.CustomFieldObjectReference.aggregate:type_name -> diode.v1.Aggregate
+	6,    // 300: diode.v1.CustomFieldObjectReference.cable:type_name -> diode.v1.Cable
+	7,    // 301: diode.v1.CustomFieldObjectReference.cable_path:type_name -> diode.v1.CablePath
+	8,    // 302: diode.v1.CustomFieldObjectReference.cable_termination:type_name -> diode.v1.CableTermination
+	9,    // 303: diode.v1.CustomFieldObjectReference.circuit:type_name -> diode.v1.Circuit
+	10,   // 304: diode.v1.CustomFieldObjectReference.circuit_group:type_name -> diode.v1.CircuitGroup
+	11,   // 305: diode.v1.CustomFieldObjectReference.circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
+	12,   // 306: diode.v1.CustomFieldObjectReference.circuit_termination:type_name -> diode.v1.CircuitTermination
+	13,   // 307: diode.v1.CustomFieldObjectReference.circuit_type:type_name -> diode.v1.CircuitType
+	14,   // 308: diode.v1.CustomFieldObjectReference.cluster:type_name -> diode.v1.Cluster
+	15,   // 309: diode.v1.CustomFieldObjectReference.cluster_group:type_name -> diode.v1.ClusterGroup
+	16,   // 310: diode.v1.CustomFieldObjectReference.cluster_type:type_name -> diode.v1.ClusterType
+	17,   // 311: diode.v1.CustomFieldObjectReference.console_port:type_name -> diode.v1.ConsolePort
+	18,   // 312: diode.v1.CustomFieldObjectReference.console_server_port:type_name -> diode.v1.ConsoleServerPort
+	19,   // 313: diode.v1.CustomFieldObjectReference.contact:type_name -> diode.v1.Contact
+	20,   // 314: diode.v1.CustomFieldObjectReference.contact_assignment:type_name -> diode.v1.ContactAssignment
+	21,   // 315: diode.v1.CustomFieldObjectReference.contact_group:type_name -> diode.v1.ContactGroup
+	22,   // 316: diode.v1.CustomFieldObjectReference.contact_role:type_name -> diode.v1.ContactRole
+	25,   // 317: diode.v1.CustomFieldObjectReference.device:type_name -> diode.v1.Device
+	26,   // 318: diode.v1.CustomFieldObjectReference.device_bay:type_name -> diode.v1.DeviceBay
+	27,   // 319: diode.v1.CustomFieldObjectReference.device_role:type_name -> diode.v1.DeviceRole
+	28,   // 320: diode.v1.CustomFieldObjectReference.device_type:type_name -> diode.v1.DeviceType
+	29,   // 321: diode.v1.CustomFieldObjectReference.fhrp_group:type_name -> diode.v1.FHRPGroup
+	30,   // 322: diode.v1.CustomFieldObjectReference.fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
+	31,   // 323: diode.v1.CustomFieldObjectReference.front_port:type_name -> diode.v1.FrontPort
+	33,   // 324: diode.v1.CustomFieldObjectReference.ike_policy:type_name -> diode.v1.IKEPolicy
+	34,   // 325: diode.v1.CustomFieldObjectReference.ike_proposal:type_name -> diode.v1.IKEProposal
+	35,   // 326: diode.v1.CustomFieldObjectReference.ip_address:type_name -> diode.v1.IPAddress
+	36,   // 327: diode.v1.CustomFieldObjectReference.ip_range:type_name -> diode.v1.IPRange
+	37,   // 328: diode.v1.CustomFieldObjectReference.ip_sec_policy:type_name -> diode.v1.IPSecPolicy
+	38,   // 329: diode.v1.CustomFieldObjectReference.ip_sec_profile:type_name -> diode.v1.IPSecProfile
+	39,   // 330: diode.v1.CustomFieldObjectReference.ip_sec_proposal:type_name -> diode.v1.IPSecProposal
+	40,   // 331: diode.v1.CustomFieldObjectReference.interface:type_name -> diode.v1.Interface
+	41,   // 332: diode.v1.CustomFieldObjectReference.inventory_item:type_name -> diode.v1.InventoryItem
+	42,   // 333: diode.v1.CustomFieldObjectReference.inventory_item_role:type_name -> diode.v1.InventoryItemRole
+	43,   // 334: diode.v1.CustomFieldObjectReference.l2vpn:type_name -> diode.v1.L2VPN
+	44,   // 335: diode.v1.CustomFieldObjectReference.l2vpn_termination:type_name -> diode.v1.L2VPNTermination
+	45,   // 336: diode.v1.CustomFieldObjectReference.location:type_name -> diode.v1.Location
+	46,   // 337: diode.v1.CustomFieldObjectReference.mac_address:type_name -> diode.v1.MACAddress
+	47,   // 338: diode.v1.CustomFieldObjectReference.manufacturer:type_name -> diode.v1.Manufacturer
+	48,   // 339: diode.v1.CustomFieldObjectReference.module:type_name -> diode.v1.Module
+	49,   // 340: diode.v1.CustomFieldObjectReference.module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 341: diode.v1.CustomFieldObjectReference.module_type:type_name -> diode.v1.ModuleType
+	51,   // 342: diode.v1.CustomFieldObjectReference.platform:type_name -> diode.v1.Platform
+	52,   // 343: diode.v1.CustomFieldObjectReference.power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 344: diode.v1.CustomFieldObjectReference.power_outlet:type_name -> diode.v1.PowerOutlet
+	54,   // 345: diode.v1.CustomFieldObjectReference.power_panel:type_name -> diode.v1.PowerPanel
+	55,   // 346: diode.v1.CustomFieldObjectReference.power_port:type_name -> diode.v1.PowerPort
+	56,   // 347: diode.v1.CustomFieldObjectReference.prefix:type_name -> diode.v1.Prefix
+	57,   // 348: diode.v1.CustomFieldObjectReference.provider:type_name -> diode.v1.Provider
+	58,   // 349: diode.v1.CustomFieldObjectReference.provider_account:type_name -> diode.v1.ProviderAccount
+	59,   // 350: diode.v1.CustomFieldObjectReference.provider_network:type_name -> diode.v1.ProviderNetwork
+	60,   // 351: diode.v1.CustomFieldObjectReference.rir:type_name -> diode.v1.RIR
+	61,   // 352: diode.v1.CustomFieldObjectReference.rack:type_name -> diode.v1.Rack
+	62,   // 353: diode.v1.CustomFieldObjectReference.rack_reservation:type_name -> diode.v1.RackReservation
+	63,   // 354: diode.v1.CustomFieldObjectReference.rack_role:type_name -> diode.v1.RackRole
+	64,   // 355: diode.v1.CustomFieldObjectReference.rack_type:type_name -> diode.v1.RackType
+	65,   // 356: diode.v1.CustomFieldObjectReference.rear_port:type_name -> diode.v1.RearPort
+	66,   // 357: diode.v1.CustomFieldObjectReference.region:type_name -> diode.v1.Region
+	67,   // 358: diode.v1.CustomFieldObjectReference.role:type_name -> diode.v1.Role
+	68,   // 359: diode.v1.CustomFieldObjectReference.route_target:type_name -> diode.v1.RouteTarget
+	69,   // 360: diode.v1.CustomFieldObjectReference.service:type_name -> diode.v1.Service
+	70,   // 361: diode.v1.CustomFieldObjectReference.site:type_name -> diode.v1.Site
+	71,   // 362: diode.v1.CustomFieldObjectReference.site_group:type_name -> diode.v1.SiteGroup
+	72,   // 363: diode.v1.CustomFieldObjectReference.tag:type_name -> diode.v1.Tag
+	73,   // 364: diode.v1.CustomFieldObjectReference.tenant:type_name -> diode.v1.Tenant
+	74,   // 365: diode.v1.CustomFieldObjectReference.tenant_group:type_name -> diode.v1.TenantGroup
+	75,   // 366: diode.v1.CustomFieldObjectReference.tunnel:type_name -> diode.v1.Tunnel
+	76,   // 367: diode.v1.CustomFieldObjectReference.tunnel_group:type_name -> diode.v1.TunnelGroup
+	77,   // 368: diode.v1.CustomFieldObjectReference.tunnel_termination:type_name -> diode.v1.TunnelTermination
+	78,   // 369: diode.v1.CustomFieldObjectReference.vlan:type_name -> diode.v1.VLAN
+	79,   // 370: diode.v1.CustomFieldObjectReference.vlan_group:type_name -> diode.v1.VLANGroup
+	80,   // 371: diode.v1.CustomFieldObjectReference.vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	81,   // 372: diode.v1.CustomFieldObjectReference.vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
+	82,   // 373: diode.v1.CustomFieldObjectReference.vm_interface:type_name -> diode.v1.VMInterface
+	83,   // 374: diode.v1.CustomFieldObjectReference.vrf:type_name -> diode.v1.VRF
+	84,   // 375: diode.v1.CustomFieldObjectReference.virtual_chassis:type_name -> diode.v1.VirtualChassis
+	85,   // 376: diode.v1.CustomFieldObjectReference.virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	86,   // 377: diode.v1.CustomFieldObjectReference.virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
+	87,   // 378: diode.v1.CustomFieldObjectReference.virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
+	88,   // 379: diode.v1.CustomFieldObjectReference.virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
+	89,   // 380: diode.v1.CustomFieldObjectReference.virtual_disk:type_name -> diode.v1.VirtualDisk
+	90,   // 381: diode.v1.CustomFieldObjectReference.virtual_machine:type_name -> diode.v1.VirtualMachine
+	91,   // 382: diode.v1.CustomFieldObjectReference.wireless_lan:type_name -> diode.v1.WirelessLAN
+	92,   // 383: diode.v1.CustomFieldObjectReference.wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
+	93,   // 384: diode.v1.CustomFieldObjectReference.wireless_link:type_name -> diode.v1.WirelessLink
+	94,   // 385: diode.v1.CustomFieldObjectReference.custom_field:type_name -> diode.v1.CustomField
+	95,   // 386: diode.v1.CustomFieldObjectReference.custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	96,   // 387: diode.v1.CustomFieldObjectReference.journal_entry:type_name -> diode.v1.JournalEntry
+	97,   // 388: diode.v1.CustomFieldObjectReference.module_type_profile:type_name -> diode.v1.ModuleTypeProfile
+	98,   // 389: diode.v1.CustomFieldObjectReference.custom_link:type_name -> diode.v1.CustomLink
+	23,   // 390: diode.v1.CustomFieldValue.multiple_objects:type_name -> diode.v1.CustomFieldObjectReference
+	182,  // 391: diode.v1.CustomFieldValue.date:type_name -> google.protobuf.Timestamp
+	182,  // 392: diode.v1.CustomFieldValue.datetime:type_name -> google.protobuf.Timestamp
+	23,   // 393: diode.v1.CustomFieldValue.object:type_name -> diode.v1.CustomFieldObjectReference
+	28,   // 394: diode.v1.Device.device_type:type_name -> diode.v1.DeviceType
+	27,   // 395: diode.v1.Device.role:type_name -> diode.v1.DeviceRole
+	73,   // 396: diode.v1.Device.tenant:type_name -> diode.v1.Tenant
+	51,   // 397: diode.v1.Device.platform:type_name -> diode.v1.Platform
+	70,   // 398: diode.v1.Device.site:type_name -> diode.v1.Site
+	45,   // 399: diode.v1.Device.location:type_name -> diode.v1.Location
+	61,   // 400: diode.v1.Device.rack:type_name -> diode.v1.Rack
+	35,   // 401: diode.v1.Device.primary_ip4:type_name -> diode.v1.IPAddress
+	35,   // 402: diode.v1.Device.primary_ip6:type_name -> diode.v1.IPAddress
+	35,   // 403: diode.v1.Device.oob_ip:type_name -> diode.v1.IPAddress
+	14,   // 404: diode.v1.Device.cluster:type_name -> diode.v1.Cluster
+	84,   // 405: diode.v1.Device.virtual_chassis:type_name -> diode.v1.VirtualChassis
+	72,   // 406: diode.v1.Device.tags:type_name -> diode.v1.Tag
+	116,  // 407: diode.v1.Device.custom_fields:type_name -> diode.v1.Device.CustomFieldsEntry
+	183,  // 408: diode.v1.Device.metadata:type_name -> google.protobuf.Struct
+	25,   // 409: diode.v1.DeviceBay.device:type_name -> diode.v1.Device
+	25,   // 410: diode.v1.DeviceBay.installed_device:type_name -> diode.v1.Device
+	72,   // 411: diode.v1.DeviceBay.tags:type_name -> diode.v1.Tag
+	117,  // 412: diode.v1.DeviceBay.custom_fields:type_name -> diode.v1.DeviceBay.CustomFieldsEntry
+	183,  // 413: diode.v1.DeviceBay.metadata:type_name -> google.protobuf.Struct
+	72,   // 414: diode.v1.DeviceRole.tags:type_name -> diode.v1.Tag
+	118,  // 415: diode.v1.DeviceRole.custom_fields:type_name -> diode.v1.DeviceRole.CustomFieldsEntry
+	27,   // 416: diode.v1.DeviceRole.parent:type_name -> diode.v1.DeviceRole
+	183,  // 417: diode.v1.DeviceRole.metadata:type_name -> google.protobuf.Struct
+	47,   // 418: diode.v1.DeviceType.manufacturer:type_name -> diode.v1.Manufacturer
+	51,   // 419: diode.v1.DeviceType.default_platform:type_name -> diode.v1.Platform
+	72,   // 420: diode.v1.DeviceType.tags:type_name -> diode.v1.Tag
+	119,  // 421: diode.v1.DeviceType.custom_fields:type_name -> diode.v1.DeviceType.CustomFieldsEntry
+	183,  // 422: diode.v1.DeviceType.metadata:type_name -> google.protobuf.Struct
+	72,   // 423: diode.v1.FHRPGroup.tags:type_name -> diode.v1.Tag
+	120,  // 424: diode.v1.FHRPGroup.custom_fields:type_name -> diode.v1.FHRPGroup.CustomFieldsEntry
+	183,  // 425: diode.v1.FHRPGroup.metadata:type_name -> google.protobuf.Struct
+	29,   // 426: diode.v1.FHRPGroupAssignment.group:type_name -> diode.v1.FHRPGroup
+	3,    // 427: diode.v1.FHRPGroupAssignment.interface_asn:type_name -> diode.v1.ASN
+	4,    // 428: diode.v1.FHRPGroupAssignment.interface_asn_range:type_name -> diode.v1.ASNRange
+	5,    // 429: diode.v1.FHRPGroupAssignment.interface_aggregate:type_name -> diode.v1.Aggregate
+	6,    // 430: diode.v1.FHRPGroupAssignment.interface_cable:type_name -> diode.v1.Cable
+	7,    // 431: diode.v1.FHRPGroupAssignment.interface_cable_path:type_name -> diode.v1.CablePath
+	8,    // 432: diode.v1.FHRPGroupAssignment.interface_cable_termination:type_name -> diode.v1.CableTermination
+	9,    // 433: diode.v1.FHRPGroupAssignment.interface_circuit:type_name -> diode.v1.Circuit
+	10,   // 434: diode.v1.FHRPGroupAssignment.interface_circuit_group:type_name -> diode.v1.CircuitGroup
+	11,   // 435: diode.v1.FHRPGroupAssignment.interface_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
+	12,   // 436: diode.v1.FHRPGroupAssignment.interface_circuit_termination:type_name -> diode.v1.CircuitTermination
+	13,   // 437: diode.v1.FHRPGroupAssignment.interface_circuit_type:type_name -> diode.v1.CircuitType
+	14,   // 438: diode.v1.FHRPGroupAssignment.interface_cluster:type_name -> diode.v1.Cluster
+	15,   // 439: diode.v1.FHRPGroupAssignment.interface_cluster_group:type_name -> diode.v1.ClusterGroup
+	16,   // 440: diode.v1.FHRPGroupAssignment.interface_cluster_type:type_name -> diode.v1.ClusterType
+	17,   // 441: diode.v1.FHRPGroupAssignment.interface_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 442: diode.v1.FHRPGroupAssignment.interface_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	19,   // 443: diode.v1.FHRPGroupAssignment.interface_contact:type_name -> diode.v1.Contact
+	20,   // 444: diode.v1.FHRPGroupAssignment.interface_contact_assignment:type_name -> diode.v1.ContactAssignment
+	21,   // 445: diode.v1.FHRPGroupAssignment.interface_contact_group:type_name -> diode.v1.ContactGroup
+	22,   // 446: diode.v1.FHRPGroupAssignment.interface_contact_role:type_name -> diode.v1.ContactRole
+	25,   // 447: diode.v1.FHRPGroupAssignment.interface_device:type_name -> diode.v1.Device
+	26,   // 448: diode.v1.FHRPGroupAssignment.interface_device_bay:type_name -> diode.v1.DeviceBay
+	27,   // 449: diode.v1.FHRPGroupAssignment.interface_device_role:type_name -> diode.v1.DeviceRole
+	28,   // 450: diode.v1.FHRPGroupAssignment.interface_device_type:type_name -> diode.v1.DeviceType
+	29,   // 451: diode.v1.FHRPGroupAssignment.interface_fhrp_group:type_name -> diode.v1.FHRPGroup
+	30,   // 452: diode.v1.FHRPGroupAssignment.interface_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
+	31,   // 453: diode.v1.FHRPGroupAssignment.interface_front_port:type_name -> diode.v1.FrontPort
+	33,   // 454: diode.v1.FHRPGroupAssignment.interface_ike_policy:type_name -> diode.v1.IKEPolicy
+	34,   // 455: diode.v1.FHRPGroupAssignment.interface_ike_proposal:type_name -> diode.v1.IKEProposal
+	35,   // 456: diode.v1.FHRPGroupAssignment.interface_ip_address:type_name -> diode.v1.IPAddress
+	36,   // 457: diode.v1.FHRPGroupAssignment.interface_ip_range:type_name -> diode.v1.IPRange
+	37,   // 458: diode.v1.FHRPGroupAssignment.interface_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
+	38,   // 459: diode.v1.FHRPGroupAssignment.interface_ip_sec_profile:type_name -> diode.v1.IPSecProfile
+	39,   // 460: diode.v1.FHRPGroupAssignment.interface_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
+	40,   // 461: diode.v1.FHRPGroupAssignment.interface_interface:type_name -> diode.v1.Interface
+	41,   // 462: diode.v1.FHRPGroupAssignment.interface_inventory_item:type_name -> diode.v1.InventoryItem
+	42,   // 463: diode.v1.FHRPGroupAssignment.interface_inventory_item_role:type_name -> diode.v1.InventoryItemRole
+	43,   // 464: diode.v1.FHRPGroupAssignment.interface_l2vpn:type_name -> diode.v1.L2VPN
+	44,   // 465: diode.v1.FHRPGroupAssignment.interface_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
+	45,   // 466: diode.v1.FHRPGroupAssignment.interface_location:type_name -> diode.v1.Location
+	46,   // 467: diode.v1.FHRPGroupAssignment.interface_mac_address:type_name -> diode.v1.MACAddress
+	47,   // 468: diode.v1.FHRPGroupAssignment.interface_manufacturer:type_name -> diode.v1.Manufacturer
+	48,   // 469: diode.v1.FHRPGroupAssignment.interface_module:type_name -> diode.v1.Module
+	49,   // 470: diode.v1.FHRPGroupAssignment.interface_module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 471: diode.v1.FHRPGroupAssignment.interface_module_type:type_name -> diode.v1.ModuleType
+	51,   // 472: diode.v1.FHRPGroupAssignment.interface_platform:type_name -> diode.v1.Platform
+	52,   // 473: diode.v1.FHRPGroupAssignment.interface_power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 474: diode.v1.FHRPGroupAssignment.interface_power_outlet:type_name -> diode.v1.PowerOutlet
+	54,   // 475: diode.v1.FHRPGroupAssignment.interface_power_panel:type_name -> diode.v1.PowerPanel
+	55,   // 476: diode.v1.FHRPGroupAssignment.interface_power_port:type_name -> diode.v1.PowerPort
+	56,   // 477: diode.v1.FHRPGroupAssignment.interface_prefix:type_name -> diode.v1.Prefix
+	57,   // 478: diode.v1.FHRPGroupAssignment.interface_provider:type_name -> diode.v1.Provider
+	58,   // 479: diode.v1.FHRPGroupAssignment.interface_provider_account:type_name -> diode.v1.ProviderAccount
+	59,   // 480: diode.v1.FHRPGroupAssignment.interface_provider_network:type_name -> diode.v1.ProviderNetwork
+	60,   // 481: diode.v1.FHRPGroupAssignment.interface_rir:type_name -> diode.v1.RIR
+	61,   // 482: diode.v1.FHRPGroupAssignment.interface_rack:type_name -> diode.v1.Rack
+	62,   // 483: diode.v1.FHRPGroupAssignment.interface_rack_reservation:type_name -> diode.v1.RackReservation
+	63,   // 484: diode.v1.FHRPGroupAssignment.interface_rack_role:type_name -> diode.v1.RackRole
+	64,   // 485: diode.v1.FHRPGroupAssignment.interface_rack_type:type_name -> diode.v1.RackType
+	65,   // 486: diode.v1.FHRPGroupAssignment.interface_rear_port:type_name -> diode.v1.RearPort
+	66,   // 487: diode.v1.FHRPGroupAssignment.interface_region:type_name -> diode.v1.Region
+	67,   // 488: diode.v1.FHRPGroupAssignment.interface_role:type_name -> diode.v1.Role
+	68,   // 489: diode.v1.FHRPGroupAssignment.interface_route_target:type_name -> diode.v1.RouteTarget
+	69,   // 490: diode.v1.FHRPGroupAssignment.interface_service:type_name -> diode.v1.Service
+	70,   // 491: diode.v1.FHRPGroupAssignment.interface_site:type_name -> diode.v1.Site
+	71,   // 492: diode.v1.FHRPGroupAssignment.interface_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 493: diode.v1.FHRPGroupAssignment.interface_tag:type_name -> diode.v1.Tag
+	73,   // 494: diode.v1.FHRPGroupAssignment.interface_tenant:type_name -> diode.v1.Tenant
+	74,   // 495: diode.v1.FHRPGroupAssignment.interface_tenant_group:type_name -> diode.v1.TenantGroup
+	75,   // 496: diode.v1.FHRPGroupAssignment.interface_tunnel:type_name -> diode.v1.Tunnel
+	76,   // 497: diode.v1.FHRPGroupAssignment.interface_tunnel_group:type_name -> diode.v1.TunnelGroup
+	77,   // 498: diode.v1.FHRPGroupAssignment.interface_tunnel_termination:type_name -> diode.v1.TunnelTermination
+	78,   // 499: diode.v1.FHRPGroupAssignment.interface_vlan:type_name -> diode.v1.VLAN
+	79,   // 500: diode.v1.FHRPGroupAssignment.interface_vlan_group:type_name -> diode.v1.VLANGroup
+	80,   // 501: diode.v1.FHRPGroupAssignment.interface_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	81,   // 502: diode.v1.FHRPGroupAssignment.interface_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
+	82,   // 503: diode.v1.FHRPGroupAssignment.interface_vm_interface:type_name -> diode.v1.VMInterface
+	83,   // 504: diode.v1.FHRPGroupAssignment.interface_vrf:type_name -> diode.v1.VRF
+	84,   // 505: diode.v1.FHRPGroupAssignment.interface_virtual_chassis:type_name -> diode.v1.VirtualChassis
+	85,   // 506: diode.v1.FHRPGroupAssignment.interface_virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	86,   // 507: diode.v1.FHRPGroupAssignment.interface_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
+	87,   // 508: diode.v1.FHRPGroupAssignment.interface_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
+	88,   // 509: diode.v1.FHRPGroupAssignment.interface_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
+	89,   // 510: diode.v1.FHRPGroupAssignment.interface_virtual_disk:type_name -> diode.v1.VirtualDisk
+	90,   // 511: diode.v1.FHRPGroupAssignment.interface_virtual_machine:type_name -> diode.v1.VirtualMachine
+	91,   // 512: diode.v1.FHRPGroupAssignment.interface_wireless_lan:type_name -> diode.v1.WirelessLAN
+	92,   // 513: diode.v1.FHRPGroupAssignment.interface_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
+	93,   // 514: diode.v1.FHRPGroupAssignment.interface_wireless_link:type_name -> diode.v1.WirelessLink
+	94,   // 515: diode.v1.FHRPGroupAssignment.interface_custom_field:type_name -> diode.v1.CustomField
+	95,   // 516: diode.v1.FHRPGroupAssignment.interface_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	96,   // 517: diode.v1.FHRPGroupAssignment.interface_journal_entry:type_name -> diode.v1.JournalEntry
+	97,   // 518: diode.v1.FHRPGroupAssignment.interface_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
+	98,   // 519: diode.v1.FHRPGroupAssignment.interface_custom_link:type_name -> diode.v1.CustomLink
+	183,  // 520: diode.v1.FHRPGroupAssignment.metadata:type_name -> google.protobuf.Struct
+	25,   // 521: diode.v1.FrontPort.device:type_name -> diode.v1.Device
+	48,   // 522: diode.v1.FrontPort.module:type_name -> diode.v1.Module
+	65,   // 523: diode.v1.FrontPort.rear_port:type_name -> diode.v1.RearPort
+	72,   // 524: diode.v1.FrontPort.tags:type_name -> diode.v1.Tag
+	121,  // 525: diode.v1.FrontPort.custom_fields:type_name -> diode.v1.FrontPort.CustomFieldsEntry
+	183,  // 526: diode.v1.FrontPort.metadata:type_name -> google.protobuf.Struct
+	3,    // 527: diode.v1.GenericObject.object_asn:type_name -> diode.v1.ASN
+	4,    // 528: diode.v1.GenericObject.object_asn_range:type_name -> diode.v1.ASNRange
+	5,    // 529: diode.v1.GenericObject.object_aggregate:type_name -> diode.v1.Aggregate
+	6,    // 530: diode.v1.GenericObject.object_cable:type_name -> diode.v1.Cable
+	7,    // 531: diode.v1.GenericObject.object_cable_path:type_name -> diode.v1.CablePath
+	8,    // 532: diode.v1.GenericObject.object_cable_termination:type_name -> diode.v1.CableTermination
+	9,    // 533: diode.v1.GenericObject.object_circuit:type_name -> diode.v1.Circuit
+	10,   // 534: diode.v1.GenericObject.object_circuit_group:type_name -> diode.v1.CircuitGroup
+	11,   // 535: diode.v1.GenericObject.object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
+	12,   // 536: diode.v1.GenericObject.object_circuit_termination:type_name -> diode.v1.CircuitTermination
+	13,   // 537: diode.v1.GenericObject.object_circuit_type:type_name -> diode.v1.CircuitType
+	14,   // 538: diode.v1.GenericObject.object_cluster:type_name -> diode.v1.Cluster
+	15,   // 539: diode.v1.GenericObject.object_cluster_group:type_name -> diode.v1.ClusterGroup
+	16,   // 540: diode.v1.GenericObject.object_cluster_type:type_name -> diode.v1.ClusterType
+	17,   // 541: diode.v1.GenericObject.object_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 542: diode.v1.GenericObject.object_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	19,   // 543: diode.v1.GenericObject.object_contact:type_name -> diode.v1.Contact
+	20,   // 544: diode.v1.GenericObject.object_contact_assignment:type_name -> diode.v1.ContactAssignment
+	21,   // 545: diode.v1.GenericObject.object_contact_group:type_name -> diode.v1.ContactGroup
+	22,   // 546: diode.v1.GenericObject.object_contact_role:type_name -> diode.v1.ContactRole
+	25,   // 547: diode.v1.GenericObject.object_device:type_name -> diode.v1.Device
+	26,   // 548: diode.v1.GenericObject.object_device_bay:type_name -> diode.v1.DeviceBay
+	27,   // 549: diode.v1.GenericObject.object_device_role:type_name -> diode.v1.DeviceRole
+	28,   // 550: diode.v1.GenericObject.object_device_type:type_name -> diode.v1.DeviceType
+	29,   // 551: diode.v1.GenericObject.object_fhrp_group:type_name -> diode.v1.FHRPGroup
+	30,   // 552: diode.v1.GenericObject.object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
+	31,   // 553: diode.v1.GenericObject.object_front_port:type_name -> diode.v1.FrontPort
+	33,   // 554: diode.v1.GenericObject.object_ike_policy:type_name -> diode.v1.IKEPolicy
+	34,   // 555: diode.v1.GenericObject.object_ike_proposal:type_name -> diode.v1.IKEProposal
+	35,   // 556: diode.v1.GenericObject.object_ip_address:type_name -> diode.v1.IPAddress
+	36,   // 557: diode.v1.GenericObject.object_ip_range:type_name -> diode.v1.IPRange
+	37,   // 558: diode.v1.GenericObject.object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
+	38,   // 559: diode.v1.GenericObject.object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
+	39,   // 560: diode.v1.GenericObject.object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
+	40,   // 561: diode.v1.GenericObject.object_interface:type_name -> diode.v1.Interface
+	41,   // 562: diode.v1.GenericObject.object_inventory_item:type_name -> diode.v1.InventoryItem
+	42,   // 563: diode.v1.GenericObject.object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
+	43,   // 564: diode.v1.GenericObject.object_l2vpn:type_name -> diode.v1.L2VPN
+	44,   // 565: diode.v1.GenericObject.object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
+	45,   // 566: diode.v1.GenericObject.object_location:type_name -> diode.v1.Location
+	46,   // 567: diode.v1.GenericObject.object_mac_address:type_name -> diode.v1.MACAddress
+	47,   // 568: diode.v1.GenericObject.object_manufacturer:type_name -> diode.v1.Manufacturer
+	48,   // 569: diode.v1.GenericObject.object_module:type_name -> diode.v1.Module
+	49,   // 570: diode.v1.GenericObject.object_module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 571: diode.v1.GenericObject.object_module_type:type_name -> diode.v1.ModuleType
+	51,   // 572: diode.v1.GenericObject.object_platform:type_name -> diode.v1.Platform
+	52,   // 573: diode.v1.GenericObject.object_power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 574: diode.v1.GenericObject.object_power_outlet:type_name -> diode.v1.PowerOutlet
+	54,   // 575: diode.v1.GenericObject.object_power_panel:type_name -> diode.v1.PowerPanel
+	55,   // 576: diode.v1.GenericObject.object_power_port:type_name -> diode.v1.PowerPort
+	56,   // 577: diode.v1.GenericObject.object_prefix:type_name -> diode.v1.Prefix
+	57,   // 578: diode.v1.GenericObject.object_provider:type_name -> diode.v1.Provider
+	58,   // 579: diode.v1.GenericObject.object_provider_account:type_name -> diode.v1.ProviderAccount
+	59,   // 580: diode.v1.GenericObject.object_provider_network:type_name -> diode.v1.ProviderNetwork
+	60,   // 581: diode.v1.GenericObject.object_rir:type_name -> diode.v1.RIR
+	61,   // 582: diode.v1.GenericObject.object_rack:type_name -> diode.v1.Rack
+	62,   // 583: diode.v1.GenericObject.object_rack_reservation:type_name -> diode.v1.RackReservation
+	63,   // 584: diode.v1.GenericObject.object_rack_role:type_name -> diode.v1.RackRole
+	64,   // 585: diode.v1.GenericObject.object_rack_type:type_name -> diode.v1.RackType
+	65,   // 586: diode.v1.GenericObject.object_rear_port:type_name -> diode.v1.RearPort
+	66,   // 587: diode.v1.GenericObject.object_region:type_name -> diode.v1.Region
+	67,   // 588: diode.v1.GenericObject.object_role:type_name -> diode.v1.Role
+	68,   // 589: diode.v1.GenericObject.object_route_target:type_name -> diode.v1.RouteTarget
+	69,   // 590: diode.v1.GenericObject.object_service:type_name -> diode.v1.Service
+	70,   // 591: diode.v1.GenericObject.object_site:type_name -> diode.v1.Site
+	71,   // 592: diode.v1.GenericObject.object_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 593: diode.v1.GenericObject.object_tag:type_name -> diode.v1.Tag
+	73,   // 594: diode.v1.GenericObject.object_tenant:type_name -> diode.v1.Tenant
+	74,   // 595: diode.v1.GenericObject.object_tenant_group:type_name -> diode.v1.TenantGroup
+	75,   // 596: diode.v1.GenericObject.object_tunnel:type_name -> diode.v1.Tunnel
+	76,   // 597: diode.v1.GenericObject.object_tunnel_group:type_name -> diode.v1.TunnelGroup
+	77,   // 598: diode.v1.GenericObject.object_tunnel_termination:type_name -> diode.v1.TunnelTermination
+	78,   // 599: diode.v1.GenericObject.object_vlan:type_name -> diode.v1.VLAN
+	79,   // 600: diode.v1.GenericObject.object_vlan_group:type_name -> diode.v1.VLANGroup
+	80,   // 601: diode.v1.GenericObject.object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	81,   // 602: diode.v1.GenericObject.object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
+	82,   // 603: diode.v1.GenericObject.object_vm_interface:type_name -> diode.v1.VMInterface
+	83,   // 604: diode.v1.GenericObject.object_vrf:type_name -> diode.v1.VRF
+	84,   // 605: diode.v1.GenericObject.object_virtual_chassis:type_name -> diode.v1.VirtualChassis
+	85,   // 606: diode.v1.GenericObject.object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	86,   // 607: diode.v1.GenericObject.object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
+	87,   // 608: diode.v1.GenericObject.object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
+	88,   // 609: diode.v1.GenericObject.object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
+	89,   // 610: diode.v1.GenericObject.object_virtual_disk:type_name -> diode.v1.VirtualDisk
+	90,   // 611: diode.v1.GenericObject.object_virtual_machine:type_name -> diode.v1.VirtualMachine
+	91,   // 612: diode.v1.GenericObject.object_wireless_lan:type_name -> diode.v1.WirelessLAN
+	92,   // 613: diode.v1.GenericObject.object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
+	93,   // 614: diode.v1.GenericObject.object_wireless_link:type_name -> diode.v1.WirelessLink
+	94,   // 615: diode.v1.GenericObject.object_custom_field:type_name -> diode.v1.CustomField
+	95,   // 616: diode.v1.GenericObject.object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	96,   // 617: diode.v1.GenericObject.object_journal_entry:type_name -> diode.v1.JournalEntry
+	97,   // 618: diode.v1.GenericObject.object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
+	98,   // 619: diode.v1.GenericObject.object_custom_link:type_name -> diode.v1.CustomLink
+	72,   // 620: diode.v1.IKEPolicy.tags:type_name -> diode.v1.Tag
+	122,  // 621: diode.v1.IKEPolicy.custom_fields:type_name -> diode.v1.IKEPolicy.CustomFieldsEntry
+	34,   // 622: diode.v1.IKEPolicy.proposals:type_name -> diode.v1.IKEProposal
+	183,  // 623: diode.v1.IKEPolicy.metadata:type_name -> google.protobuf.Struct
+	72,   // 624: diode.v1.IKEProposal.tags:type_name -> diode.v1.Tag
+	123,  // 625: diode.v1.IKEProposal.custom_fields:type_name -> diode.v1.IKEProposal.CustomFieldsEntry
+	183,  // 626: diode.v1.IKEProposal.metadata:type_name -> google.protobuf.Struct
+	83,   // 627: diode.v1.IPAddress.vrf:type_name -> diode.v1.VRF
+	73,   // 628: diode.v1.IPAddress.tenant:type_name -> diode.v1.Tenant
+	29,   // 629: diode.v1.IPAddress.assigned_object_fhrp_group:type_name -> diode.v1.FHRPGroup
+	40,   // 630: diode.v1.IPAddress.assigned_object_interface:type_name -> diode.v1.Interface
+	82,   // 631: diode.v1.IPAddress.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
+	35,   // 632: diode.v1.IPAddress.nat_inside:type_name -> diode.v1.IPAddress
+	72,   // 633: diode.v1.IPAddress.tags:type_name -> diode.v1.Tag
+	124,  // 634: diode.v1.IPAddress.custom_fields:type_name -> diode.v1.IPAddress.CustomFieldsEntry
+	183,  // 635: diode.v1.IPAddress.metadata:type_name -> google.protobuf.Struct
+	83,   // 636: diode.v1.IPRange.vrf:type_name -> diode.v1.VRF
+	73,   // 637: diode.v1.IPRange.tenant:type_name -> diode.v1.Tenant
+	67,   // 638: diode.v1.IPRange.role:type_name -> diode.v1.Role
+	72,   // 639: diode.v1.IPRange.tags:type_name -> diode.v1.Tag
+	125,  // 640: diode.v1.IPRange.custom_fields:type_name -> diode.v1.IPRange.CustomFieldsEntry
+	183,  // 641: diode.v1.IPRange.metadata:type_name -> google.protobuf.Struct
+	72,   // 642: diode.v1.IPSecPolicy.tags:type_name -> diode.v1.Tag
+	126,  // 643: diode.v1.IPSecPolicy.custom_fields:type_name -> diode.v1.IPSecPolicy.CustomFieldsEntry
+	39,   // 644: diode.v1.IPSecPolicy.proposals:type_name -> diode.v1.IPSecProposal
+	183,  // 645: diode.v1.IPSecPolicy.metadata:type_name -> google.protobuf.Struct
+	33,   // 646: diode.v1.IPSecProfile.ike_policy:type_name -> diode.v1.IKEPolicy
+	37,   // 647: diode.v1.IPSecProfile.ipsec_policy:type_name -> diode.v1.IPSecPolicy
+	72,   // 648: diode.v1.IPSecProfile.tags:type_name -> diode.v1.Tag
+	127,  // 649: diode.v1.IPSecProfile.custom_fields:type_name -> diode.v1.IPSecProfile.CustomFieldsEntry
+	183,  // 650: diode.v1.IPSecProfile.metadata:type_name -> google.protobuf.Struct
+	72,   // 651: diode.v1.IPSecProposal.tags:type_name -> diode.v1.Tag
+	128,  // 652: diode.v1.IPSecProposal.custom_fields:type_name -> diode.v1.IPSecProposal.CustomFieldsEntry
+	183,  // 653: diode.v1.IPSecProposal.metadata:type_name -> google.protobuf.Struct
+	25,   // 654: diode.v1.Interface.device:type_name -> diode.v1.Device
+	48,   // 655: diode.v1.Interface.module:type_name -> diode.v1.Module
+	40,   // 656: diode.v1.Interface.parent:type_name -> diode.v1.Interface
+	40,   // 657: diode.v1.Interface.bridge:type_name -> diode.v1.Interface
+	40,   // 658: diode.v1.Interface.lag:type_name -> diode.v1.Interface
+	46,   // 659: diode.v1.Interface.primary_mac_address:type_name -> diode.v1.MACAddress
+	78,   // 660: diode.v1.Interface.untagged_vlan:type_name -> diode.v1.VLAN
+	78,   // 661: diode.v1.Interface.qinq_svlan:type_name -> diode.v1.VLAN
+	80,   // 662: diode.v1.Interface.vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	83,   // 663: diode.v1.Interface.vrf:type_name -> diode.v1.VRF
+	72,   // 664: diode.v1.Interface.tags:type_name -> diode.v1.Tag
+	129,  // 665: diode.v1.Interface.custom_fields:type_name -> diode.v1.Interface.CustomFieldsEntry
+	88,   // 666: diode.v1.Interface.vdcs:type_name -> diode.v1.VirtualDeviceContext
+	78,   // 667: diode.v1.Interface.tagged_vlans:type_name -> diode.v1.VLAN
+	91,   // 668: diode.v1.Interface.wireless_lans:type_name -> diode.v1.WirelessLAN
+	183,  // 669: diode.v1.Interface.metadata:type_name -> google.protobuf.Struct
+	25,   // 670: diode.v1.InventoryItem.device:type_name -> diode.v1.Device
+	41,   // 671: diode.v1.InventoryItem.parent:type_name -> diode.v1.InventoryItem
+	42,   // 672: diode.v1.InventoryItem.role:type_name -> diode.v1.InventoryItemRole
+	47,   // 673: diode.v1.InventoryItem.manufacturer:type_name -> diode.v1.Manufacturer
+	17,   // 674: diode.v1.InventoryItem.component_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 675: diode.v1.InventoryItem.component_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	31,   // 676: diode.v1.InventoryItem.component_front_port:type_name -> diode.v1.FrontPort
+	40,   // 677: diode.v1.InventoryItem.component_interface:type_name -> diode.v1.Interface
+	53,   // 678: diode.v1.InventoryItem.component_power_outlet:type_name -> diode.v1.PowerOutlet
+	55,   // 679: diode.v1.InventoryItem.component_power_port:type_name -> diode.v1.PowerPort
+	65,   // 680: diode.v1.InventoryItem.component_rear_port:type_name -> diode.v1.RearPort
+	72,   // 681: diode.v1.InventoryItem.tags:type_name -> diode.v1.Tag
+	130,  // 682: diode.v1.InventoryItem.custom_fields:type_name -> diode.v1.InventoryItem.CustomFieldsEntry
+	183,  // 683: diode.v1.InventoryItem.metadata:type_name -> google.protobuf.Struct
+	72,   // 684: diode.v1.InventoryItemRole.tags:type_name -> diode.v1.Tag
+	131,  // 685: diode.v1.InventoryItemRole.custom_fields:type_name -> diode.v1.InventoryItemRole.CustomFieldsEntry
+	183,  // 686: diode.v1.InventoryItemRole.metadata:type_name -> google.protobuf.Struct
+	73,   // 687: diode.v1.L2VPN.tenant:type_name -> diode.v1.Tenant
+	72,   // 688: diode.v1.L2VPN.tags:type_name -> diode.v1.Tag
+	132,  // 689: diode.v1.L2VPN.custom_fields:type_name -> diode.v1.L2VPN.CustomFieldsEntry
+	68,   // 690: diode.v1.L2VPN.import_targets:type_name -> diode.v1.RouteTarget
+	68,   // 691: diode.v1.L2VPN.export_targets:type_name -> diode.v1.RouteTarget
+	183,  // 692: diode.v1.L2VPN.metadata:type_name -> google.protobuf.Struct
+	43,   // 693: diode.v1.L2VPNTermination.l2vpn:type_name -> diode.v1.L2VPN
+	40,   // 694: diode.v1.L2VPNTermination.assigned_object_interface:type_name -> diode.v1.Interface
+	78,   // 695: diode.v1.L2VPNTermination.assigned_object_vlan:type_name -> diode.v1.VLAN
+	82,   // 696: diode.v1.L2VPNTermination.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
+	3,    // 697: diode.v1.L2VPNTermination.assigned_object_asn:type_name -> diode.v1.ASN
+	4,    // 698: diode.v1.L2VPNTermination.assigned_object_asn_range:type_name -> diode.v1.ASNRange
+	5,    // 699: diode.v1.L2VPNTermination.assigned_object_aggregate:type_name -> diode.v1.Aggregate
+	6,    // 700: diode.v1.L2VPNTermination.assigned_object_cable:type_name -> diode.v1.Cable
+	7,    // 701: diode.v1.L2VPNTermination.assigned_object_cable_path:type_name -> diode.v1.CablePath
+	8,    // 702: diode.v1.L2VPNTermination.assigned_object_cable_termination:type_name -> diode.v1.CableTermination
+	9,    // 703: diode.v1.L2VPNTermination.assigned_object_circuit:type_name -> diode.v1.Circuit
+	10,   // 704: diode.v1.L2VPNTermination.assigned_object_circuit_group:type_name -> diode.v1.CircuitGroup
+	11,   // 705: diode.v1.L2VPNTermination.assigned_object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
+	12,   // 706: diode.v1.L2VPNTermination.assigned_object_circuit_termination:type_name -> diode.v1.CircuitTermination
+	13,   // 707: diode.v1.L2VPNTermination.assigned_object_circuit_type:type_name -> diode.v1.CircuitType
+	14,   // 708: diode.v1.L2VPNTermination.assigned_object_cluster:type_name -> diode.v1.Cluster
+	15,   // 709: diode.v1.L2VPNTermination.assigned_object_cluster_group:type_name -> diode.v1.ClusterGroup
+	16,   // 710: diode.v1.L2VPNTermination.assigned_object_cluster_type:type_name -> diode.v1.ClusterType
+	17,   // 711: diode.v1.L2VPNTermination.assigned_object_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 712: diode.v1.L2VPNTermination.assigned_object_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	19,   // 713: diode.v1.L2VPNTermination.assigned_object_contact:type_name -> diode.v1.Contact
+	20,   // 714: diode.v1.L2VPNTermination.assigned_object_contact_assignment:type_name -> diode.v1.ContactAssignment
+	21,   // 715: diode.v1.L2VPNTermination.assigned_object_contact_group:type_name -> diode.v1.ContactGroup
+	22,   // 716: diode.v1.L2VPNTermination.assigned_object_contact_role:type_name -> diode.v1.ContactRole
+	94,   // 717: diode.v1.L2VPNTermination.assigned_object_custom_field:type_name -> diode.v1.CustomField
+	95,   // 718: diode.v1.L2VPNTermination.assigned_object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	25,   // 719: diode.v1.L2VPNTermination.assigned_object_device:type_name -> diode.v1.Device
+	26,   // 720: diode.v1.L2VPNTermination.assigned_object_device_bay:type_name -> diode.v1.DeviceBay
+	27,   // 721: diode.v1.L2VPNTermination.assigned_object_device_role:type_name -> diode.v1.DeviceRole
+	28,   // 722: diode.v1.L2VPNTermination.assigned_object_device_type:type_name -> diode.v1.DeviceType
+	29,   // 723: diode.v1.L2VPNTermination.assigned_object_fhrp_group:type_name -> diode.v1.FHRPGroup
+	30,   // 724: diode.v1.L2VPNTermination.assigned_object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
+	31,   // 725: diode.v1.L2VPNTermination.assigned_object_front_port:type_name -> diode.v1.FrontPort
+	33,   // 726: diode.v1.L2VPNTermination.assigned_object_ike_policy:type_name -> diode.v1.IKEPolicy
+	34,   // 727: diode.v1.L2VPNTermination.assigned_object_ike_proposal:type_name -> diode.v1.IKEProposal
+	35,   // 728: diode.v1.L2VPNTermination.assigned_object_ip_address:type_name -> diode.v1.IPAddress
+	36,   // 729: diode.v1.L2VPNTermination.assigned_object_ip_range:type_name -> diode.v1.IPRange
+	37,   // 730: diode.v1.L2VPNTermination.assigned_object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
+	38,   // 731: diode.v1.L2VPNTermination.assigned_object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
+	39,   // 732: diode.v1.L2VPNTermination.assigned_object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
+	41,   // 733: diode.v1.L2VPNTermination.assigned_object_inventory_item:type_name -> diode.v1.InventoryItem
+	42,   // 734: diode.v1.L2VPNTermination.assigned_object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
+	96,   // 735: diode.v1.L2VPNTermination.assigned_object_journal_entry:type_name -> diode.v1.JournalEntry
+	43,   // 736: diode.v1.L2VPNTermination.assigned_object_l2vpn:type_name -> diode.v1.L2VPN
+	44,   // 737: diode.v1.L2VPNTermination.assigned_object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
+	45,   // 738: diode.v1.L2VPNTermination.assigned_object_location:type_name -> diode.v1.Location
+	46,   // 739: diode.v1.L2VPNTermination.assigned_object_mac_address:type_name -> diode.v1.MACAddress
+	47,   // 740: diode.v1.L2VPNTermination.assigned_object_manufacturer:type_name -> diode.v1.Manufacturer
+	48,   // 741: diode.v1.L2VPNTermination.assigned_object_module:type_name -> diode.v1.Module
+	49,   // 742: diode.v1.L2VPNTermination.assigned_object_module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 743: diode.v1.L2VPNTermination.assigned_object_module_type:type_name -> diode.v1.ModuleType
+	97,   // 744: diode.v1.L2VPNTermination.assigned_object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
+	51,   // 745: diode.v1.L2VPNTermination.assigned_object_platform:type_name -> diode.v1.Platform
+	52,   // 746: diode.v1.L2VPNTermination.assigned_object_power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 747: diode.v1.L2VPNTermination.assigned_object_power_outlet:type_name -> diode.v1.PowerOutlet
+	54,   // 748: diode.v1.L2VPNTermination.assigned_object_power_panel:type_name -> diode.v1.PowerPanel
+	55,   // 749: diode.v1.L2VPNTermination.assigned_object_power_port:type_name -> diode.v1.PowerPort
+	56,   // 750: diode.v1.L2VPNTermination.assigned_object_prefix:type_name -> diode.v1.Prefix
+	57,   // 751: diode.v1.L2VPNTermination.assigned_object_provider:type_name -> diode.v1.Provider
+	58,   // 752: diode.v1.L2VPNTermination.assigned_object_provider_account:type_name -> diode.v1.ProviderAccount
+	59,   // 753: diode.v1.L2VPNTermination.assigned_object_provider_network:type_name -> diode.v1.ProviderNetwork
+	60,   // 754: diode.v1.L2VPNTermination.assigned_object_rir:type_name -> diode.v1.RIR
+	61,   // 755: diode.v1.L2VPNTermination.assigned_object_rack:type_name -> diode.v1.Rack
+	62,   // 756: diode.v1.L2VPNTermination.assigned_object_rack_reservation:type_name -> diode.v1.RackReservation
+	63,   // 757: diode.v1.L2VPNTermination.assigned_object_rack_role:type_name -> diode.v1.RackRole
+	64,   // 758: diode.v1.L2VPNTermination.assigned_object_rack_type:type_name -> diode.v1.RackType
+	65,   // 759: diode.v1.L2VPNTermination.assigned_object_rear_port:type_name -> diode.v1.RearPort
+	66,   // 760: diode.v1.L2VPNTermination.assigned_object_region:type_name -> diode.v1.Region
+	67,   // 761: diode.v1.L2VPNTermination.assigned_object_role:type_name -> diode.v1.Role
+	68,   // 762: diode.v1.L2VPNTermination.assigned_object_route_target:type_name -> diode.v1.RouteTarget
+	69,   // 763: diode.v1.L2VPNTermination.assigned_object_service:type_name -> diode.v1.Service
+	70,   // 764: diode.v1.L2VPNTermination.assigned_object_site:type_name -> diode.v1.Site
+	71,   // 765: diode.v1.L2VPNTermination.assigned_object_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 766: diode.v1.L2VPNTermination.assigned_object_tag:type_name -> diode.v1.Tag
+	73,   // 767: diode.v1.L2VPNTermination.assigned_object_tenant:type_name -> diode.v1.Tenant
+	74,   // 768: diode.v1.L2VPNTermination.assigned_object_tenant_group:type_name -> diode.v1.TenantGroup
+	75,   // 769: diode.v1.L2VPNTermination.assigned_object_tunnel:type_name -> diode.v1.Tunnel
+	76,   // 770: diode.v1.L2VPNTermination.assigned_object_tunnel_group:type_name -> diode.v1.TunnelGroup
+	77,   // 771: diode.v1.L2VPNTermination.assigned_object_tunnel_termination:type_name -> diode.v1.TunnelTermination
+	79,   // 772: diode.v1.L2VPNTermination.assigned_object_vlan_group:type_name -> diode.v1.VLANGroup
+	80,   // 773: diode.v1.L2VPNTermination.assigned_object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	81,   // 774: diode.v1.L2VPNTermination.assigned_object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
+	83,   // 775: diode.v1.L2VPNTermination.assigned_object_vrf:type_name -> diode.v1.VRF
+	84,   // 776: diode.v1.L2VPNTermination.assigned_object_virtual_chassis:type_name -> diode.v1.VirtualChassis
+	85,   // 777: diode.v1.L2VPNTermination.assigned_object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	86,   // 778: diode.v1.L2VPNTermination.assigned_object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
+	87,   // 779: diode.v1.L2VPNTermination.assigned_object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
+	88,   // 780: diode.v1.L2VPNTermination.assigned_object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
+	89,   // 781: diode.v1.L2VPNTermination.assigned_object_virtual_disk:type_name -> diode.v1.VirtualDisk
+	90,   // 782: diode.v1.L2VPNTermination.assigned_object_virtual_machine:type_name -> diode.v1.VirtualMachine
+	91,   // 783: diode.v1.L2VPNTermination.assigned_object_wireless_lan:type_name -> diode.v1.WirelessLAN
+	92,   // 784: diode.v1.L2VPNTermination.assigned_object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
+	93,   // 785: diode.v1.L2VPNTermination.assigned_object_wireless_link:type_name -> diode.v1.WirelessLink
+	98,   // 786: diode.v1.L2VPNTermination.assigned_object_custom_link:type_name -> diode.v1.CustomLink
+	72,   // 787: diode.v1.L2VPNTermination.tags:type_name -> diode.v1.Tag
+	133,  // 788: diode.v1.L2VPNTermination.custom_fields:type_name -> diode.v1.L2VPNTermination.CustomFieldsEntry
+	183,  // 789: diode.v1.L2VPNTermination.metadata:type_name -> google.protobuf.Struct
+	70,   // 790: diode.v1.Location.site:type_name -> diode.v1.Site
+	45,   // 791: diode.v1.Location.parent:type_name -> diode.v1.Location
+	73,   // 792: diode.v1.Location.tenant:type_name -> diode.v1.Tenant
+	72,   // 793: diode.v1.Location.tags:type_name -> diode.v1.Tag
+	134,  // 794: diode.v1.Location.custom_fields:type_name -> diode.v1.Location.CustomFieldsEntry
+	183,  // 795: diode.v1.Location.metadata:type_name -> google.protobuf.Struct
+	40,   // 796: diode.v1.MACAddress.assigned_object_interface:type_name -> diode.v1.Interface
+	82,   // 797: diode.v1.MACAddress.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
+	72,   // 798: diode.v1.MACAddress.tags:type_name -> diode.v1.Tag
+	135,  // 799: diode.v1.MACAddress.custom_fields:type_name -> diode.v1.MACAddress.CustomFieldsEntry
+	183,  // 800: diode.v1.MACAddress.metadata:type_name -> google.protobuf.Struct
+	72,   // 801: diode.v1.Manufacturer.tags:type_name -> diode.v1.Tag
+	136,  // 802: diode.v1.Manufacturer.custom_fields:type_name -> diode.v1.Manufacturer.CustomFieldsEntry
+	183,  // 803: diode.v1.Manufacturer.metadata:type_name -> google.protobuf.Struct
+	25,   // 804: diode.v1.Module.device:type_name -> diode.v1.Device
+	49,   // 805: diode.v1.Module.module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 806: diode.v1.Module.module_type:type_name -> diode.v1.ModuleType
+	72,   // 807: diode.v1.Module.tags:type_name -> diode.v1.Tag
+	137,  // 808: diode.v1.Module.custom_fields:type_name -> diode.v1.Module.CustomFieldsEntry
+	183,  // 809: diode.v1.Module.metadata:type_name -> google.protobuf.Struct
+	25,   // 810: diode.v1.ModuleBay.device:type_name -> diode.v1.Device
+	48,   // 811: diode.v1.ModuleBay.module:type_name -> diode.v1.Module
+	48,   // 812: diode.v1.ModuleBay.installed_module:type_name -> diode.v1.Module
+	72,   // 813: diode.v1.ModuleBay.tags:type_name -> diode.v1.Tag
+	138,  // 814: diode.v1.ModuleBay.custom_fields:type_name -> diode.v1.ModuleBay.CustomFieldsEntry
+	183,  // 815: diode.v1.ModuleBay.metadata:type_name -> google.protobuf.Struct
+	47,   // 816: diode.v1.ModuleType.manufacturer:type_name -> diode.v1.Manufacturer
+	72,   // 817: diode.v1.ModuleType.tags:type_name -> diode.v1.Tag
+	139,  // 818: diode.v1.ModuleType.custom_fields:type_name -> diode.v1.ModuleType.CustomFieldsEntry
+	97,   // 819: diode.v1.ModuleType.profile:type_name -> diode.v1.ModuleTypeProfile
+	183,  // 820: diode.v1.ModuleType.metadata:type_name -> google.protobuf.Struct
+	47,   // 821: diode.v1.Platform.manufacturer:type_name -> diode.v1.Manufacturer
+	72,   // 822: diode.v1.Platform.tags:type_name -> diode.v1.Tag
+	140,  // 823: diode.v1.Platform.custom_fields:type_name -> diode.v1.Platform.CustomFieldsEntry
+	51,   // 824: diode.v1.Platform.parent:type_name -> diode.v1.Platform
+	183,  // 825: diode.v1.Platform.metadata:type_name -> google.protobuf.Struct
+	54,   // 826: diode.v1.PowerFeed.power_panel:type_name -> diode.v1.PowerPanel
+	61,   // 827: diode.v1.PowerFeed.rack:type_name -> diode.v1.Rack
+	73,   // 828: diode.v1.PowerFeed.tenant:type_name -> diode.v1.Tenant
+	72,   // 829: diode.v1.PowerFeed.tags:type_name -> diode.v1.Tag
+	141,  // 830: diode.v1.PowerFeed.custom_fields:type_name -> diode.v1.PowerFeed.CustomFieldsEntry
+	183,  // 831: diode.v1.PowerFeed.metadata:type_name -> google.protobuf.Struct
+	25,   // 832: diode.v1.PowerOutlet.device:type_name -> diode.v1.Device
+	48,   // 833: diode.v1.PowerOutlet.module:type_name -> diode.v1.Module
+	55,   // 834: diode.v1.PowerOutlet.power_port:type_name -> diode.v1.PowerPort
+	72,   // 835: diode.v1.PowerOutlet.tags:type_name -> diode.v1.Tag
+	142,  // 836: diode.v1.PowerOutlet.custom_fields:type_name -> diode.v1.PowerOutlet.CustomFieldsEntry
+	183,  // 837: diode.v1.PowerOutlet.metadata:type_name -> google.protobuf.Struct
+	70,   // 838: diode.v1.PowerPanel.site:type_name -> diode.v1.Site
+	45,   // 839: diode.v1.PowerPanel.location:type_name -> diode.v1.Location
+	72,   // 840: diode.v1.PowerPanel.tags:type_name -> diode.v1.Tag
+	143,  // 841: diode.v1.PowerPanel.custom_fields:type_name -> diode.v1.PowerPanel.CustomFieldsEntry
+	183,  // 842: diode.v1.PowerPanel.metadata:type_name -> google.protobuf.Struct
+	25,   // 843: diode.v1.PowerPort.device:type_name -> diode.v1.Device
+	48,   // 844: diode.v1.PowerPort.module:type_name -> diode.v1.Module
+	72,   // 845: diode.v1.PowerPort.tags:type_name -> diode.v1.Tag
+	144,  // 846: diode.v1.PowerPort.custom_fields:type_name -> diode.v1.PowerPort.CustomFieldsEntry
+	183,  // 847: diode.v1.PowerPort.metadata:type_name -> google.protobuf.Struct
+	83,   // 848: diode.v1.Prefix.vrf:type_name -> diode.v1.VRF
+	45,   // 849: diode.v1.Prefix.scope_location:type_name -> diode.v1.Location
+	66,   // 850: diode.v1.Prefix.scope_region:type_name -> diode.v1.Region
+	70,   // 851: diode.v1.Prefix.scope_site:type_name -> diode.v1.Site
+	71,   // 852: diode.v1.Prefix.scope_site_group:type_name -> diode.v1.SiteGroup
+	73,   // 853: diode.v1.Prefix.tenant:type_name -> diode.v1.Tenant
+	78,   // 854: diode.v1.Prefix.vlan:type_name -> diode.v1.VLAN
+	67,   // 855: diode.v1.Prefix.role:type_name -> diode.v1.Role
+	72,   // 856: diode.v1.Prefix.tags:type_name -> diode.v1.Tag
+	145,  // 857: diode.v1.Prefix.custom_fields:type_name -> diode.v1.Prefix.CustomFieldsEntry
+	183,  // 858: diode.v1.Prefix.metadata:type_name -> google.protobuf.Struct
+	72,   // 859: diode.v1.Provider.tags:type_name -> diode.v1.Tag
+	146,  // 860: diode.v1.Provider.custom_fields:type_name -> diode.v1.Provider.CustomFieldsEntry
+	58,   // 861: diode.v1.Provider.accounts:type_name -> diode.v1.ProviderAccount
+	3,    // 862: diode.v1.Provider.asns:type_name -> diode.v1.ASN
+	183,  // 863: diode.v1.Provider.metadata:type_name -> google.protobuf.Struct
+	57,   // 864: diode.v1.ProviderAccount.provider:type_name -> diode.v1.Provider
+	72,   // 865: diode.v1.ProviderAccount.tags:type_name -> diode.v1.Tag
+	147,  // 866: diode.v1.ProviderAccount.custom_fields:type_name -> diode.v1.ProviderAccount.CustomFieldsEntry
+	183,  // 867: diode.v1.ProviderAccount.metadata:type_name -> google.protobuf.Struct
+	57,   // 868: diode.v1.ProviderNetwork.provider:type_name -> diode.v1.Provider
+	72,   // 869: diode.v1.ProviderNetwork.tags:type_name -> diode.v1.Tag
+	148,  // 870: diode.v1.ProviderNetwork.custom_fields:type_name -> diode.v1.ProviderNetwork.CustomFieldsEntry
+	183,  // 871: diode.v1.ProviderNetwork.metadata:type_name -> google.protobuf.Struct
+	72,   // 872: diode.v1.RIR.tags:type_name -> diode.v1.Tag
+	149,  // 873: diode.v1.RIR.custom_fields:type_name -> diode.v1.RIR.CustomFieldsEntry
+	183,  // 874: diode.v1.RIR.metadata:type_name -> google.protobuf.Struct
+	70,   // 875: diode.v1.Rack.site:type_name -> diode.v1.Site
+	45,   // 876: diode.v1.Rack.location:type_name -> diode.v1.Location
+	73,   // 877: diode.v1.Rack.tenant:type_name -> diode.v1.Tenant
+	63,   // 878: diode.v1.Rack.role:type_name -> diode.v1.RackRole
+	64,   // 879: diode.v1.Rack.rack_type:type_name -> diode.v1.RackType
+	72,   // 880: diode.v1.Rack.tags:type_name -> diode.v1.Tag
+	150,  // 881: diode.v1.Rack.custom_fields:type_name -> diode.v1.Rack.CustomFieldsEntry
+	183,  // 882: diode.v1.Rack.metadata:type_name -> google.protobuf.Struct
+	61,   // 883: diode.v1.RackReservation.rack:type_name -> diode.v1.Rack
+	73,   // 884: diode.v1.RackReservation.tenant:type_name -> diode.v1.Tenant
+	72,   // 885: diode.v1.RackReservation.tags:type_name -> diode.v1.Tag
+	151,  // 886: diode.v1.RackReservation.custom_fields:type_name -> diode.v1.RackReservation.CustomFieldsEntry
+	183,  // 887: diode.v1.RackReservation.metadata:type_name -> google.protobuf.Struct
+	72,   // 888: diode.v1.RackRole.tags:type_name -> diode.v1.Tag
+	152,  // 889: diode.v1.RackRole.custom_fields:type_name -> diode.v1.RackRole.CustomFieldsEntry
+	183,  // 890: diode.v1.RackRole.metadata:type_name -> google.protobuf.Struct
+	47,   // 891: diode.v1.RackType.manufacturer:type_name -> diode.v1.Manufacturer
+	72,   // 892: diode.v1.RackType.tags:type_name -> diode.v1.Tag
+	153,  // 893: diode.v1.RackType.custom_fields:type_name -> diode.v1.RackType.CustomFieldsEntry
+	183,  // 894: diode.v1.RackType.metadata:type_name -> google.protobuf.Struct
+	25,   // 895: diode.v1.RearPort.device:type_name -> diode.v1.Device
+	48,   // 896: diode.v1.RearPort.module:type_name -> diode.v1.Module
+	72,   // 897: diode.v1.RearPort.tags:type_name -> diode.v1.Tag
+	154,  // 898: diode.v1.RearPort.custom_fields:type_name -> diode.v1.RearPort.CustomFieldsEntry
+	183,  // 899: diode.v1.RearPort.metadata:type_name -> google.protobuf.Struct
+	66,   // 900: diode.v1.Region.parent:type_name -> diode.v1.Region
+	72,   // 901: diode.v1.Region.tags:type_name -> diode.v1.Tag
+	155,  // 902: diode.v1.Region.custom_fields:type_name -> diode.v1.Region.CustomFieldsEntry
+	183,  // 903: diode.v1.Region.metadata:type_name -> google.protobuf.Struct
+	72,   // 904: diode.v1.Role.tags:type_name -> diode.v1.Tag
+	156,  // 905: diode.v1.Role.custom_fields:type_name -> diode.v1.Role.CustomFieldsEntry
+	183,  // 906: diode.v1.Role.metadata:type_name -> google.protobuf.Struct
+	73,   // 907: diode.v1.RouteTarget.tenant:type_name -> diode.v1.Tenant
+	72,   // 908: diode.v1.RouteTarget.tags:type_name -> diode.v1.Tag
+	157,  // 909: diode.v1.RouteTarget.custom_fields:type_name -> diode.v1.RouteTarget.CustomFieldsEntry
+	183,  // 910: diode.v1.RouteTarget.metadata:type_name -> google.protobuf.Struct
+	25,   // 911: diode.v1.Service.device:type_name -> diode.v1.Device
+	90,   // 912: diode.v1.Service.virtual_machine:type_name -> diode.v1.VirtualMachine
+	72,   // 913: diode.v1.Service.tags:type_name -> diode.v1.Tag
+	158,  // 914: diode.v1.Service.custom_fields:type_name -> diode.v1.Service.CustomFieldsEntry
+	35,   // 915: diode.v1.Service.ipaddresses:type_name -> diode.v1.IPAddress
+	25,   // 916: diode.v1.Service.parent_object_device:type_name -> diode.v1.Device
+	29,   // 917: diode.v1.Service.parent_object_fhrp_group:type_name -> diode.v1.FHRPGroup
+	90,   // 918: diode.v1.Service.parent_object_virtual_machine:type_name -> diode.v1.VirtualMachine
+	183,  // 919: diode.v1.Service.metadata:type_name -> google.protobuf.Struct
+	66,   // 920: diode.v1.Site.region:type_name -> diode.v1.Region
+	71,   // 921: diode.v1.Site.group:type_name -> diode.v1.SiteGroup
+	73,   // 922: diode.v1.Site.tenant:type_name -> diode.v1.Tenant
+	72,   // 923: diode.v1.Site.tags:type_name -> diode.v1.Tag
+	159,  // 924: diode.v1.Site.custom_fields:type_name -> diode.v1.Site.CustomFieldsEntry
+	3,    // 925: diode.v1.Site.asns:type_name -> diode.v1.ASN
+	183,  // 926: diode.v1.Site.metadata:type_name -> google.protobuf.Struct
+	71,   // 927: diode.v1.SiteGroup.parent:type_name -> diode.v1.SiteGroup
+	72,   // 928: diode.v1.SiteGroup.tags:type_name -> diode.v1.Tag
+	160,  // 929: diode.v1.SiteGroup.custom_fields:type_name -> diode.v1.SiteGroup.CustomFieldsEntry
+	183,  // 930: diode.v1.SiteGroup.metadata:type_name -> google.protobuf.Struct
+	183,  // 931: diode.v1.Tag.metadata:type_name -> google.protobuf.Struct
+	74,   // 932: diode.v1.Tenant.group:type_name -> diode.v1.TenantGroup
+	72,   // 933: diode.v1.Tenant.tags:type_name -> diode.v1.Tag
+	161,  // 934: diode.v1.Tenant.custom_fields:type_name -> diode.v1.Tenant.CustomFieldsEntry
+	183,  // 935: diode.v1.Tenant.metadata:type_name -> google.protobuf.Struct
+	74,   // 936: diode.v1.TenantGroup.parent:type_name -> diode.v1.TenantGroup
+	72,   // 937: diode.v1.TenantGroup.tags:type_name -> diode.v1.Tag
+	162,  // 938: diode.v1.TenantGroup.custom_fields:type_name -> diode.v1.TenantGroup.CustomFieldsEntry
+	183,  // 939: diode.v1.TenantGroup.metadata:type_name -> google.protobuf.Struct
+	76,   // 940: diode.v1.Tunnel.group:type_name -> diode.v1.TunnelGroup
+	38,   // 941: diode.v1.Tunnel.ipsec_profile:type_name -> diode.v1.IPSecProfile
+	73,   // 942: diode.v1.Tunnel.tenant:type_name -> diode.v1.Tenant
+	72,   // 943: diode.v1.Tunnel.tags:type_name -> diode.v1.Tag
+	163,  // 944: diode.v1.Tunnel.custom_fields:type_name -> diode.v1.Tunnel.CustomFieldsEntry
+	183,  // 945: diode.v1.Tunnel.metadata:type_name -> google.protobuf.Struct
+	72,   // 946: diode.v1.TunnelGroup.tags:type_name -> diode.v1.Tag
+	164,  // 947: diode.v1.TunnelGroup.custom_fields:type_name -> diode.v1.TunnelGroup.CustomFieldsEntry
+	183,  // 948: diode.v1.TunnelGroup.metadata:type_name -> google.protobuf.Struct
+	75,   // 949: diode.v1.TunnelTermination.tunnel:type_name -> diode.v1.Tunnel
+	3,    // 950: diode.v1.TunnelTermination.termination_asn:type_name -> diode.v1.ASN
+	4,    // 951: diode.v1.TunnelTermination.termination_asn_range:type_name -> diode.v1.ASNRange
+	5,    // 952: diode.v1.TunnelTermination.termination_aggregate:type_name -> diode.v1.Aggregate
+	6,    // 953: diode.v1.TunnelTermination.termination_cable:type_name -> diode.v1.Cable
+	7,    // 954: diode.v1.TunnelTermination.termination_cable_path:type_name -> diode.v1.CablePath
+	8,    // 955: diode.v1.TunnelTermination.termination_cable_termination:type_name -> diode.v1.CableTermination
+	9,    // 956: diode.v1.TunnelTermination.termination_circuit:type_name -> diode.v1.Circuit
+	10,   // 957: diode.v1.TunnelTermination.termination_circuit_group:type_name -> diode.v1.CircuitGroup
+	11,   // 958: diode.v1.TunnelTermination.termination_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
+	12,   // 959: diode.v1.TunnelTermination.termination_circuit_termination:type_name -> diode.v1.CircuitTermination
+	13,   // 960: diode.v1.TunnelTermination.termination_circuit_type:type_name -> diode.v1.CircuitType
+	14,   // 961: diode.v1.TunnelTermination.termination_cluster:type_name -> diode.v1.Cluster
+	15,   // 962: diode.v1.TunnelTermination.termination_cluster_group:type_name -> diode.v1.ClusterGroup
+	16,   // 963: diode.v1.TunnelTermination.termination_cluster_type:type_name -> diode.v1.ClusterType
+	17,   // 964: diode.v1.TunnelTermination.termination_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 965: diode.v1.TunnelTermination.termination_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	19,   // 966: diode.v1.TunnelTermination.termination_contact:type_name -> diode.v1.Contact
+	20,   // 967: diode.v1.TunnelTermination.termination_contact_assignment:type_name -> diode.v1.ContactAssignment
+	21,   // 968: diode.v1.TunnelTermination.termination_contact_group:type_name -> diode.v1.ContactGroup
+	22,   // 969: diode.v1.TunnelTermination.termination_contact_role:type_name -> diode.v1.ContactRole
+	25,   // 970: diode.v1.TunnelTermination.termination_device:type_name -> diode.v1.Device
+	26,   // 971: diode.v1.TunnelTermination.termination_device_bay:type_name -> diode.v1.DeviceBay
+	27,   // 972: diode.v1.TunnelTermination.termination_device_role:type_name -> diode.v1.DeviceRole
+	28,   // 973: diode.v1.TunnelTermination.termination_device_type:type_name -> diode.v1.DeviceType
+	29,   // 974: diode.v1.TunnelTermination.termination_fhrp_group:type_name -> diode.v1.FHRPGroup
+	30,   // 975: diode.v1.TunnelTermination.termination_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
+	31,   // 976: diode.v1.TunnelTermination.termination_front_port:type_name -> diode.v1.FrontPort
+	33,   // 977: diode.v1.TunnelTermination.termination_ike_policy:type_name -> diode.v1.IKEPolicy
+	34,   // 978: diode.v1.TunnelTermination.termination_ike_proposal:type_name -> diode.v1.IKEProposal
+	35,   // 979: diode.v1.TunnelTermination.termination_ip_address:type_name -> diode.v1.IPAddress
+	36,   // 980: diode.v1.TunnelTermination.termination_ip_range:type_name -> diode.v1.IPRange
+	37,   // 981: diode.v1.TunnelTermination.termination_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
+	38,   // 982: diode.v1.TunnelTermination.termination_ip_sec_profile:type_name -> diode.v1.IPSecProfile
+	39,   // 983: diode.v1.TunnelTermination.termination_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
+	40,   // 984: diode.v1.TunnelTermination.termination_interface:type_name -> diode.v1.Interface
+	41,   // 985: diode.v1.TunnelTermination.termination_inventory_item:type_name -> diode.v1.InventoryItem
+	42,   // 986: diode.v1.TunnelTermination.termination_inventory_item_role:type_name -> diode.v1.InventoryItemRole
+	43,   // 987: diode.v1.TunnelTermination.termination_l2vpn:type_name -> diode.v1.L2VPN
+	44,   // 988: diode.v1.TunnelTermination.termination_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
+	45,   // 989: diode.v1.TunnelTermination.termination_location:type_name -> diode.v1.Location
+	46,   // 990: diode.v1.TunnelTermination.termination_mac_address:type_name -> diode.v1.MACAddress
+	47,   // 991: diode.v1.TunnelTermination.termination_manufacturer:type_name -> diode.v1.Manufacturer
+	48,   // 992: diode.v1.TunnelTermination.termination_module:type_name -> diode.v1.Module
+	49,   // 993: diode.v1.TunnelTermination.termination_module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 994: diode.v1.TunnelTermination.termination_module_type:type_name -> diode.v1.ModuleType
+	51,   // 995: diode.v1.TunnelTermination.termination_platform:type_name -> diode.v1.Platform
+	52,   // 996: diode.v1.TunnelTermination.termination_power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 997: diode.v1.TunnelTermination.termination_power_outlet:type_name -> diode.v1.PowerOutlet
+	54,   // 998: diode.v1.TunnelTermination.termination_power_panel:type_name -> diode.v1.PowerPanel
+	55,   // 999: diode.v1.TunnelTermination.termination_power_port:type_name -> diode.v1.PowerPort
+	56,   // 1000: diode.v1.TunnelTermination.termination_prefix:type_name -> diode.v1.Prefix
+	57,   // 1001: diode.v1.TunnelTermination.termination_provider:type_name -> diode.v1.Provider
+	58,   // 1002: diode.v1.TunnelTermination.termination_provider_account:type_name -> diode.v1.ProviderAccount
+	59,   // 1003: diode.v1.TunnelTermination.termination_provider_network:type_name -> diode.v1.ProviderNetwork
+	60,   // 1004: diode.v1.TunnelTermination.termination_rir:type_name -> diode.v1.RIR
+	61,   // 1005: diode.v1.TunnelTermination.termination_rack:type_name -> diode.v1.Rack
+	62,   // 1006: diode.v1.TunnelTermination.termination_rack_reservation:type_name -> diode.v1.RackReservation
+	63,   // 1007: diode.v1.TunnelTermination.termination_rack_role:type_name -> diode.v1.RackRole
+	64,   // 1008: diode.v1.TunnelTermination.termination_rack_type:type_name -> diode.v1.RackType
+	65,   // 1009: diode.v1.TunnelTermination.termination_rear_port:type_name -> diode.v1.RearPort
+	66,   // 1010: diode.v1.TunnelTermination.termination_region:type_name -> diode.v1.Region
+	67,   // 1011: diode.v1.TunnelTermination.termination_role:type_name -> diode.v1.Role
+	68,   // 1012: diode.v1.TunnelTermination.termination_route_target:type_name -> diode.v1.RouteTarget
+	69,   // 1013: diode.v1.TunnelTermination.termination_service:type_name -> diode.v1.Service
+	70,   // 1014: diode.v1.TunnelTermination.termination_site:type_name -> diode.v1.Site
+	71,   // 1015: diode.v1.TunnelTermination.termination_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 1016: diode.v1.TunnelTermination.termination_tag:type_name -> diode.v1.Tag
+	73,   // 1017: diode.v1.TunnelTermination.termination_tenant:type_name -> diode.v1.Tenant
+	74,   // 1018: diode.v1.TunnelTermination.termination_tenant_group:type_name -> diode.v1.TenantGroup
+	75,   // 1019: diode.v1.TunnelTermination.termination_tunnel:type_name -> diode.v1.Tunnel
+	76,   // 1020: diode.v1.TunnelTermination.termination_tunnel_group:type_name -> diode.v1.TunnelGroup
+	77,   // 1021: diode.v1.TunnelTermination.termination_tunnel_termination:type_name -> diode.v1.TunnelTermination
+	78,   // 1022: diode.v1.TunnelTermination.termination_vlan:type_name -> diode.v1.VLAN
+	79,   // 1023: diode.v1.TunnelTermination.termination_vlan_group:type_name -> diode.v1.VLANGroup
+	80,   // 1024: diode.v1.TunnelTermination.termination_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	81,   // 1025: diode.v1.TunnelTermination.termination_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
+	82,   // 1026: diode.v1.TunnelTermination.termination_vm_interface:type_name -> diode.v1.VMInterface
+	83,   // 1027: diode.v1.TunnelTermination.termination_vrf:type_name -> diode.v1.VRF
+	84,   // 1028: diode.v1.TunnelTermination.termination_virtual_chassis:type_name -> diode.v1.VirtualChassis
+	85,   // 1029: diode.v1.TunnelTermination.termination_virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	86,   // 1030: diode.v1.TunnelTermination.termination_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
+	87,   // 1031: diode.v1.TunnelTermination.termination_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
+	88,   // 1032: diode.v1.TunnelTermination.termination_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
+	89,   // 1033: diode.v1.TunnelTermination.termination_virtual_disk:type_name -> diode.v1.VirtualDisk
+	90,   // 1034: diode.v1.TunnelTermination.termination_virtual_machine:type_name -> diode.v1.VirtualMachine
+	91,   // 1035: diode.v1.TunnelTermination.termination_wireless_lan:type_name -> diode.v1.WirelessLAN
+	92,   // 1036: diode.v1.TunnelTermination.termination_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
+	93,   // 1037: diode.v1.TunnelTermination.termination_wireless_link:type_name -> diode.v1.WirelessLink
+	94,   // 1038: diode.v1.TunnelTermination.termination_custom_field:type_name -> diode.v1.CustomField
+	95,   // 1039: diode.v1.TunnelTermination.termination_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	96,   // 1040: diode.v1.TunnelTermination.termination_journal_entry:type_name -> diode.v1.JournalEntry
+	97,   // 1041: diode.v1.TunnelTermination.termination_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
+	98,   // 1042: diode.v1.TunnelTermination.termination_custom_link:type_name -> diode.v1.CustomLink
+	35,   // 1043: diode.v1.TunnelTermination.outside_ip:type_name -> diode.v1.IPAddress
+	72,   // 1044: diode.v1.TunnelTermination.tags:type_name -> diode.v1.Tag
+	165,  // 1045: diode.v1.TunnelTermination.custom_fields:type_name -> diode.v1.TunnelTermination.CustomFieldsEntry
+	183,  // 1046: diode.v1.TunnelTermination.metadata:type_name -> google.protobuf.Struct
+	70,   // 1047: diode.v1.VLAN.site:type_name -> diode.v1.Site
+	79,   // 1048: diode.v1.VLAN.group:type_name -> diode.v1.VLANGroup
+	73,   // 1049: diode.v1.VLAN.tenant:type_name -> diode.v1.Tenant
+	67,   // 1050: diode.v1.VLAN.role:type_name -> diode.v1.Role
+	78,   // 1051: diode.v1.VLAN.qinq_svlan:type_name -> diode.v1.VLAN
+	72,   // 1052: diode.v1.VLAN.tags:type_name -> diode.v1.Tag
+	166,  // 1053: diode.v1.VLAN.custom_fields:type_name -> diode.v1.VLAN.CustomFieldsEntry
+	183,  // 1054: diode.v1.VLAN.metadata:type_name -> google.protobuf.Struct
+	14,   // 1055: diode.v1.VLANGroup.scope_cluster:type_name -> diode.v1.Cluster
+	15,   // 1056: diode.v1.VLANGroup.scope_cluster_group:type_name -> diode.v1.ClusterGroup
+	45,   // 1057: diode.v1.VLANGroup.scope_location:type_name -> diode.v1.Location
+	61,   // 1058: diode.v1.VLANGroup.scope_rack:type_name -> diode.v1.Rack
+	66,   // 1059: diode.v1.VLANGroup.scope_region:type_name -> diode.v1.Region
+	70,   // 1060: diode.v1.VLANGroup.scope_site:type_name -> diode.v1.Site
+	71,   // 1061: diode.v1.VLANGroup.scope_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 1062: diode.v1.VLANGroup.tags:type_name -> diode.v1.Tag
+	167,  // 1063: diode.v1.VLANGroup.custom_fields:type_name -> diode.v1.VLANGroup.CustomFieldsEntry
+	73,   // 1064: diode.v1.VLANGroup.tenant:type_name -> diode.v1.Tenant
+	183,  // 1065: diode.v1.VLANGroup.metadata:type_name -> google.protobuf.Struct
+	183,  // 1066: diode.v1.VLANTranslationPolicy.metadata:type_name -> google.protobuf.Struct
+	80,   // 1067: diode.v1.VLANTranslationRule.policy:type_name -> diode.v1.VLANTranslationPolicy
+	183,  // 1068: diode.v1.VLANTranslationRule.metadata:type_name -> google.protobuf.Struct
+	90,   // 1069: diode.v1.VMInterface.virtual_machine:type_name -> diode.v1.VirtualMachine
+	82,   // 1070: diode.v1.VMInterface.parent:type_name -> diode.v1.VMInterface
+	82,   // 1071: diode.v1.VMInterface.bridge:type_name -> diode.v1.VMInterface
+	46,   // 1072: diode.v1.VMInterface.primary_mac_address:type_name -> diode.v1.MACAddress
+	78,   // 1073: diode.v1.VMInterface.untagged_vlan:type_name -> diode.v1.VLAN
+	78,   // 1074: diode.v1.VMInterface.qinq_svlan:type_name -> diode.v1.VLAN
+	80,   // 1075: diode.v1.VMInterface.vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	83,   // 1076: diode.v1.VMInterface.vrf:type_name -> diode.v1.VRF
+	72,   // 1077: diode.v1.VMInterface.tags:type_name -> diode.v1.Tag
+	168,  // 1078: diode.v1.VMInterface.custom_fields:type_name -> diode.v1.VMInterface.CustomFieldsEntry
+	78,   // 1079: diode.v1.VMInterface.tagged_vlans:type_name -> diode.v1.VLAN
+	183,  // 1080: diode.v1.VMInterface.metadata:type_name -> google.protobuf.Struct
+	73,   // 1081: diode.v1.VRF.tenant:type_name -> diode.v1.Tenant
+	72,   // 1082: diode.v1.VRF.tags:type_name -> diode.v1.Tag
+	169,  // 1083: diode.v1.VRF.custom_fields:type_name -> diode.v1.VRF.CustomFieldsEntry
+	68,   // 1084: diode.v1.VRF.import_targets:type_name -> diode.v1.RouteTarget
+	68,   // 1085: diode.v1.VRF.export_targets:type_name -> diode.v1.RouteTarget
+	183,  // 1086: diode.v1.VRF.metadata:type_name -> google.protobuf.Struct
+	25,   // 1087: diode.v1.VirtualChassis.master:type_name -> diode.v1.Device
+	72,   // 1088: diode.v1.VirtualChassis.tags:type_name -> diode.v1.Tag
+	170,  // 1089: diode.v1.VirtualChassis.custom_fields:type_name -> diode.v1.VirtualChassis.CustomFieldsEntry
+	183,  // 1090: diode.v1.VirtualChassis.metadata:type_name -> google.protobuf.Struct
+	59,   // 1091: diode.v1.VirtualCircuit.provider_network:type_name -> diode.v1.ProviderNetwork
+	58,   // 1092: diode.v1.VirtualCircuit.provider_account:type_name -> diode.v1.ProviderAccount
+	87,   // 1093: diode.v1.VirtualCircuit.type:type_name -> diode.v1.VirtualCircuitType
+	73,   // 1094: diode.v1.VirtualCircuit.tenant:type_name -> diode.v1.Tenant
+	72,   // 1095: diode.v1.VirtualCircuit.tags:type_name -> diode.v1.Tag
+	171,  // 1096: diode.v1.VirtualCircuit.custom_fields:type_name -> diode.v1.VirtualCircuit.CustomFieldsEntry
+	183,  // 1097: diode.v1.VirtualCircuit.metadata:type_name -> google.protobuf.Struct
+	85,   // 1098: diode.v1.VirtualCircuitTermination.virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	40,   // 1099: diode.v1.VirtualCircuitTermination.interface:type_name -> diode.v1.Interface
+	72,   // 1100: diode.v1.VirtualCircuitTermination.tags:type_name -> diode.v1.Tag
+	172,  // 1101: diode.v1.VirtualCircuitTermination.custom_fields:type_name -> diode.v1.VirtualCircuitTermination.CustomFieldsEntry
+	183,  // 1102: diode.v1.VirtualCircuitTermination.metadata:type_name -> google.protobuf.Struct
+	72,   // 1103: diode.v1.VirtualCircuitType.tags:type_name -> diode.v1.Tag
+	173,  // 1104: diode.v1.VirtualCircuitType.custom_fields:type_name -> diode.v1.VirtualCircuitType.CustomFieldsEntry
+	183,  // 1105: diode.v1.VirtualCircuitType.metadata:type_name -> google.protobuf.Struct
+	25,   // 1106: diode.v1.VirtualDeviceContext.device:type_name -> diode.v1.Device
+	73,   // 1107: diode.v1.VirtualDeviceContext.tenant:type_name -> diode.v1.Tenant
+	35,   // 1108: diode.v1.VirtualDeviceContext.primary_ip4:type_name -> diode.v1.IPAddress
+	35,   // 1109: diode.v1.VirtualDeviceContext.primary_ip6:type_name -> diode.v1.IPAddress
+	72,   // 1110: diode.v1.VirtualDeviceContext.tags:type_name -> diode.v1.Tag
+	174,  // 1111: diode.v1.VirtualDeviceContext.custom_fields:type_name -> diode.v1.VirtualDeviceContext.CustomFieldsEntry
+	183,  // 1112: diode.v1.VirtualDeviceContext.metadata:type_name -> google.protobuf.Struct
+	90,   // 1113: diode.v1.VirtualDisk.virtual_machine:type_name -> diode.v1.VirtualMachine
+	72,   // 1114: diode.v1.VirtualDisk.tags:type_name -> diode.v1.Tag
+	175,  // 1115: diode.v1.VirtualDisk.custom_fields:type_name -> diode.v1.VirtualDisk.CustomFieldsEntry
+	183,  // 1116: diode.v1.VirtualDisk.metadata:type_name -> google.protobuf.Struct
+	70,   // 1117: diode.v1.VirtualMachine.site:type_name -> diode.v1.Site
+	14,   // 1118: diode.v1.VirtualMachine.cluster:type_name -> diode.v1.Cluster
+	25,   // 1119: diode.v1.VirtualMachine.device:type_name -> diode.v1.Device
+	27,   // 1120: diode.v1.VirtualMachine.role:type_name -> diode.v1.DeviceRole
+	73,   // 1121: diode.v1.VirtualMachine.tenant:type_name -> diode.v1.Tenant
+	51,   // 1122: diode.v1.VirtualMachine.platform:type_name -> diode.v1.Platform
+	35,   // 1123: diode.v1.VirtualMachine.primary_ip4:type_name -> diode.v1.IPAddress
+	35,   // 1124: diode.v1.VirtualMachine.primary_ip6:type_name -> diode.v1.IPAddress
+	72,   // 1125: diode.v1.VirtualMachine.tags:type_name -> diode.v1.Tag
+	176,  // 1126: diode.v1.VirtualMachine.custom_fields:type_name -> diode.v1.VirtualMachine.CustomFieldsEntry
+	183,  // 1127: diode.v1.VirtualMachine.metadata:type_name -> google.protobuf.Struct
+	92,   // 1128: diode.v1.WirelessLAN.group:type_name -> diode.v1.WirelessLANGroup
+	78,   // 1129: diode.v1.WirelessLAN.vlan:type_name -> diode.v1.VLAN
+	45,   // 1130: diode.v1.WirelessLAN.scope_location:type_name -> diode.v1.Location
+	66,   // 1131: diode.v1.WirelessLAN.scope_region:type_name -> diode.v1.Region
+	70,   // 1132: diode.v1.WirelessLAN.scope_site:type_name -> diode.v1.Site
+	71,   // 1133: diode.v1.WirelessLAN.scope_site_group:type_name -> diode.v1.SiteGroup
+	73,   // 1134: diode.v1.WirelessLAN.tenant:type_name -> diode.v1.Tenant
+	72,   // 1135: diode.v1.WirelessLAN.tags:type_name -> diode.v1.Tag
+	177,  // 1136: diode.v1.WirelessLAN.custom_fields:type_name -> diode.v1.WirelessLAN.CustomFieldsEntry
+	183,  // 1137: diode.v1.WirelessLAN.metadata:type_name -> google.protobuf.Struct
+	92,   // 1138: diode.v1.WirelessLANGroup.parent:type_name -> diode.v1.WirelessLANGroup
+	72,   // 1139: diode.v1.WirelessLANGroup.tags:type_name -> diode.v1.Tag
+	178,  // 1140: diode.v1.WirelessLANGroup.custom_fields:type_name -> diode.v1.WirelessLANGroup.CustomFieldsEntry
+	183,  // 1141: diode.v1.WirelessLANGroup.metadata:type_name -> google.protobuf.Struct
+	40,   // 1142: diode.v1.WirelessLink.interface_a:type_name -> diode.v1.Interface
+	40,   // 1143: diode.v1.WirelessLink.interface_b:type_name -> diode.v1.Interface
+	73,   // 1144: diode.v1.WirelessLink.tenant:type_name -> diode.v1.Tenant
+	72,   // 1145: diode.v1.WirelessLink.tags:type_name -> diode.v1.Tag
+	179,  // 1146: diode.v1.WirelessLink.custom_fields:type_name -> diode.v1.WirelessLink.CustomFieldsEntry
+	183,  // 1147: diode.v1.WirelessLink.metadata:type_name -> google.protobuf.Struct
+	95,   // 1148: diode.v1.CustomField.choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	183,  // 1149: diode.v1.CustomField.metadata:type_name -> google.protobuf.Struct
+	183,  // 1150: diode.v1.CustomFieldChoiceSet.metadata:type_name -> google.protobuf.Struct
+	3,    // 1151: diode.v1.JournalEntry.assigned_object_asn:type_name -> diode.v1.ASN
+	4,    // 1152: diode.v1.JournalEntry.assigned_object_asn_range:type_name -> diode.v1.ASNRange
+	5,    // 1153: diode.v1.JournalEntry.assigned_object_aggregate:type_name -> diode.v1.Aggregate
+	6,    // 1154: diode.v1.JournalEntry.assigned_object_cable:type_name -> diode.v1.Cable
+	7,    // 1155: diode.v1.JournalEntry.assigned_object_cable_path:type_name -> diode.v1.CablePath
+	8,    // 1156: diode.v1.JournalEntry.assigned_object_cable_termination:type_name -> diode.v1.CableTermination
+	9,    // 1157: diode.v1.JournalEntry.assigned_object_circuit:type_name -> diode.v1.Circuit
+	10,   // 1158: diode.v1.JournalEntry.assigned_object_circuit_group:type_name -> diode.v1.CircuitGroup
+	11,   // 1159: diode.v1.JournalEntry.assigned_object_circuit_group_assignment:type_name -> diode.v1.CircuitGroupAssignment
+	12,   // 1160: diode.v1.JournalEntry.assigned_object_circuit_termination:type_name -> diode.v1.CircuitTermination
+	13,   // 1161: diode.v1.JournalEntry.assigned_object_circuit_type:type_name -> diode.v1.CircuitType
+	14,   // 1162: diode.v1.JournalEntry.assigned_object_cluster:type_name -> diode.v1.Cluster
+	15,   // 1163: diode.v1.JournalEntry.assigned_object_cluster_group:type_name -> diode.v1.ClusterGroup
+	16,   // 1164: diode.v1.JournalEntry.assigned_object_cluster_type:type_name -> diode.v1.ClusterType
+	17,   // 1165: diode.v1.JournalEntry.assigned_object_console_port:type_name -> diode.v1.ConsolePort
+	18,   // 1166: diode.v1.JournalEntry.assigned_object_console_server_port:type_name -> diode.v1.ConsoleServerPort
+	19,   // 1167: diode.v1.JournalEntry.assigned_object_contact:type_name -> diode.v1.Contact
+	20,   // 1168: diode.v1.JournalEntry.assigned_object_contact_assignment:type_name -> diode.v1.ContactAssignment
+	21,   // 1169: diode.v1.JournalEntry.assigned_object_contact_group:type_name -> diode.v1.ContactGroup
+	22,   // 1170: diode.v1.JournalEntry.assigned_object_contact_role:type_name -> diode.v1.ContactRole
+	94,   // 1171: diode.v1.JournalEntry.assigned_object_custom_field:type_name -> diode.v1.CustomField
+	95,   // 1172: diode.v1.JournalEntry.assigned_object_custom_field_choice_set:type_name -> diode.v1.CustomFieldChoiceSet
+	25,   // 1173: diode.v1.JournalEntry.assigned_object_device:type_name -> diode.v1.Device
+	26,   // 1174: diode.v1.JournalEntry.assigned_object_device_bay:type_name -> diode.v1.DeviceBay
+	27,   // 1175: diode.v1.JournalEntry.assigned_object_device_role:type_name -> diode.v1.DeviceRole
+	28,   // 1176: diode.v1.JournalEntry.assigned_object_device_type:type_name -> diode.v1.DeviceType
+	29,   // 1177: diode.v1.JournalEntry.assigned_object_fhrp_group:type_name -> diode.v1.FHRPGroup
+	30,   // 1178: diode.v1.JournalEntry.assigned_object_fhrp_group_assignment:type_name -> diode.v1.FHRPGroupAssignment
+	31,   // 1179: diode.v1.JournalEntry.assigned_object_front_port:type_name -> diode.v1.FrontPort
+	33,   // 1180: diode.v1.JournalEntry.assigned_object_ike_policy:type_name -> diode.v1.IKEPolicy
+	34,   // 1181: diode.v1.JournalEntry.assigned_object_ike_proposal:type_name -> diode.v1.IKEProposal
+	35,   // 1182: diode.v1.JournalEntry.assigned_object_ip_address:type_name -> diode.v1.IPAddress
+	36,   // 1183: diode.v1.JournalEntry.assigned_object_ip_range:type_name -> diode.v1.IPRange
+	37,   // 1184: diode.v1.JournalEntry.assigned_object_ip_sec_policy:type_name -> diode.v1.IPSecPolicy
+	38,   // 1185: diode.v1.JournalEntry.assigned_object_ip_sec_profile:type_name -> diode.v1.IPSecProfile
+	39,   // 1186: diode.v1.JournalEntry.assigned_object_ip_sec_proposal:type_name -> diode.v1.IPSecProposal
+	40,   // 1187: diode.v1.JournalEntry.assigned_object_interface:type_name -> diode.v1.Interface
+	41,   // 1188: diode.v1.JournalEntry.assigned_object_inventory_item:type_name -> diode.v1.InventoryItem
+	42,   // 1189: diode.v1.JournalEntry.assigned_object_inventory_item_role:type_name -> diode.v1.InventoryItemRole
+	96,   // 1190: diode.v1.JournalEntry.assigned_object_journal_entry:type_name -> diode.v1.JournalEntry
+	43,   // 1191: diode.v1.JournalEntry.assigned_object_l2vpn:type_name -> diode.v1.L2VPN
+	44,   // 1192: diode.v1.JournalEntry.assigned_object_l2vpn_termination:type_name -> diode.v1.L2VPNTermination
+	45,   // 1193: diode.v1.JournalEntry.assigned_object_location:type_name -> diode.v1.Location
+	46,   // 1194: diode.v1.JournalEntry.assigned_object_mac_address:type_name -> diode.v1.MACAddress
+	47,   // 1195: diode.v1.JournalEntry.assigned_object_manufacturer:type_name -> diode.v1.Manufacturer
+	48,   // 1196: diode.v1.JournalEntry.assigned_object_module:type_name -> diode.v1.Module
+	49,   // 1197: diode.v1.JournalEntry.assigned_object_module_bay:type_name -> diode.v1.ModuleBay
+	50,   // 1198: diode.v1.JournalEntry.assigned_object_module_type:type_name -> diode.v1.ModuleType
+	97,   // 1199: diode.v1.JournalEntry.assigned_object_module_type_profile:type_name -> diode.v1.ModuleTypeProfile
+	51,   // 1200: diode.v1.JournalEntry.assigned_object_platform:type_name -> diode.v1.Platform
+	52,   // 1201: diode.v1.JournalEntry.assigned_object_power_feed:type_name -> diode.v1.PowerFeed
+	53,   // 1202: diode.v1.JournalEntry.assigned_object_power_outlet:type_name -> diode.v1.PowerOutlet
+	54,   // 1203: diode.v1.JournalEntry.assigned_object_power_panel:type_name -> diode.v1.PowerPanel
+	55,   // 1204: diode.v1.JournalEntry.assigned_object_power_port:type_name -> diode.v1.PowerPort
+	56,   // 1205: diode.v1.JournalEntry.assigned_object_prefix:type_name -> diode.v1.Prefix
+	57,   // 1206: diode.v1.JournalEntry.assigned_object_provider:type_name -> diode.v1.Provider
+	58,   // 1207: diode.v1.JournalEntry.assigned_object_provider_account:type_name -> diode.v1.ProviderAccount
+	59,   // 1208: diode.v1.JournalEntry.assigned_object_provider_network:type_name -> diode.v1.ProviderNetwork
+	60,   // 1209: diode.v1.JournalEntry.assigned_object_rir:type_name -> diode.v1.RIR
+	61,   // 1210: diode.v1.JournalEntry.assigned_object_rack:type_name -> diode.v1.Rack
+	62,   // 1211: diode.v1.JournalEntry.assigned_object_rack_reservation:type_name -> diode.v1.RackReservation
+	63,   // 1212: diode.v1.JournalEntry.assigned_object_rack_role:type_name -> diode.v1.RackRole
+	64,   // 1213: diode.v1.JournalEntry.assigned_object_rack_type:type_name -> diode.v1.RackType
+	65,   // 1214: diode.v1.JournalEntry.assigned_object_rear_port:type_name -> diode.v1.RearPort
+	66,   // 1215: diode.v1.JournalEntry.assigned_object_region:type_name -> diode.v1.Region
+	67,   // 1216: diode.v1.JournalEntry.assigned_object_role:type_name -> diode.v1.Role
+	68,   // 1217: diode.v1.JournalEntry.assigned_object_route_target:type_name -> diode.v1.RouteTarget
+	69,   // 1218: diode.v1.JournalEntry.assigned_object_service:type_name -> diode.v1.Service
+	70,   // 1219: diode.v1.JournalEntry.assigned_object_site:type_name -> diode.v1.Site
+	71,   // 1220: diode.v1.JournalEntry.assigned_object_site_group:type_name -> diode.v1.SiteGroup
+	72,   // 1221: diode.v1.JournalEntry.assigned_object_tag:type_name -> diode.v1.Tag
+	73,   // 1222: diode.v1.JournalEntry.assigned_object_tenant:type_name -> diode.v1.Tenant
+	74,   // 1223: diode.v1.JournalEntry.assigned_object_tenant_group:type_name -> diode.v1.TenantGroup
+	75,   // 1224: diode.v1.JournalEntry.assigned_object_tunnel:type_name -> diode.v1.Tunnel
+	76,   // 1225: diode.v1.JournalEntry.assigned_object_tunnel_group:type_name -> diode.v1.TunnelGroup
+	77,   // 1226: diode.v1.JournalEntry.assigned_object_tunnel_termination:type_name -> diode.v1.TunnelTermination
+	78,   // 1227: diode.v1.JournalEntry.assigned_object_vlan:type_name -> diode.v1.VLAN
+	79,   // 1228: diode.v1.JournalEntry.assigned_object_vlan_group:type_name -> diode.v1.VLANGroup
+	80,   // 1229: diode.v1.JournalEntry.assigned_object_vlan_translation_policy:type_name -> diode.v1.VLANTranslationPolicy
+	81,   // 1230: diode.v1.JournalEntry.assigned_object_vlan_translation_rule:type_name -> diode.v1.VLANTranslationRule
+	82,   // 1231: diode.v1.JournalEntry.assigned_object_vm_interface:type_name -> diode.v1.VMInterface
+	83,   // 1232: diode.v1.JournalEntry.assigned_object_vrf:type_name -> diode.v1.VRF
+	84,   // 1233: diode.v1.JournalEntry.assigned_object_virtual_chassis:type_name -> diode.v1.VirtualChassis
+	85,   // 1234: diode.v1.JournalEntry.assigned_object_virtual_circuit:type_name -> diode.v1.VirtualCircuit
+	86,   // 1235: diode.v1.JournalEntry.assigned_object_virtual_circuit_termination:type_name -> diode.v1.VirtualCircuitTermination
+	87,   // 1236: diode.v1.JournalEntry.assigned_object_virtual_circuit_type:type_name -> diode.v1.VirtualCircuitType
+	88,   // 1237: diode.v1.JournalEntry.assigned_object_virtual_device_context:type_name -> diode.v1.VirtualDeviceContext
+	89,   // 1238: diode.v1.JournalEntry.assigned_object_virtual_disk:type_name -> diode.v1.VirtualDisk
+	90,   // 1239: diode.v1.JournalEntry.assigned_object_virtual_machine:type_name -> diode.v1.VirtualMachine
+	91,   // 1240: diode.v1.JournalEntry.assigned_object_wireless_lan:type_name -> diode.v1.WirelessLAN
+	92,   // 1241: diode.v1.JournalEntry.assigned_object_wireless_lan_group:type_name -> diode.v1.WirelessLANGroup
+	93,   // 1242: diode.v1.JournalEntry.assigned_object_wireless_link:type_name -> diode.v1.WirelessLink
+	98,   // 1243: diode.v1.JournalEntry.assigned_object_custom_link:type_name -> diode.v1.CustomLink
+	72,   // 1244: diode.v1.JournalEntry.tags:type_name -> diode.v1.Tag
+	180,  // 1245: diode.v1.JournalEntry.custom_fields:type_name -> diode.v1.JournalEntry.CustomFieldsEntry
+	183,  // 1246: diode.v1.JournalEntry.metadata:type_name -> google.protobuf.Struct
+	72,   // 1247: diode.v1.ModuleTypeProfile.tags:type_name -> diode.v1.Tag
+	181,  // 1248: diode.v1.ModuleTypeProfile.custom_fields:type_name -> diode.v1.ModuleTypeProfile.CustomFieldsEntry
+	183,  // 1249: diode.v1.ModuleTypeProfile.metadata:type_name -> google.protobuf.Struct
+	183,  // 1250: diode.v1.CustomLink.metadata:type_name -> google.protobuf.Struct
+	24,   // 1251: diode.v1.ASN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1252: diode.v1.ASNRange.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1253: diode.v1.Aggregate.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1254: diode.v1.Cable.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1255: diode.v1.Circuit.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1256: diode.v1.CircuitGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1257: diode.v1.CircuitTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1258: diode.v1.CircuitType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1259: diode.v1.Cluster.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1260: diode.v1.ClusterGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1261: diode.v1.ClusterType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1262: diode.v1.ConsolePort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1263: diode.v1.ConsoleServerPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1264: diode.v1.Contact.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1265: diode.v1.ContactAssignment.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1266: diode.v1.ContactGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1267: diode.v1.ContactRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1268: diode.v1.Device.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1269: diode.v1.DeviceBay.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1270: diode.v1.DeviceRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1271: diode.v1.DeviceType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1272: diode.v1.FHRPGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1273: diode.v1.FrontPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1274: diode.v1.IKEPolicy.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1275: diode.v1.IKEProposal.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1276: diode.v1.IPAddress.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1277: diode.v1.IPRange.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1278: diode.v1.IPSecPolicy.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1279: diode.v1.IPSecProfile.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1280: diode.v1.IPSecProposal.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1281: diode.v1.Interface.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1282: diode.v1.InventoryItem.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1283: diode.v1.InventoryItemRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1284: diode.v1.L2VPN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1285: diode.v1.L2VPNTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1286: diode.v1.Location.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1287: diode.v1.MACAddress.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1288: diode.v1.Manufacturer.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1289: diode.v1.Module.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1290: diode.v1.ModuleBay.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1291: diode.v1.ModuleType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1292: diode.v1.Platform.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1293: diode.v1.PowerFeed.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1294: diode.v1.PowerOutlet.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1295: diode.v1.PowerPanel.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1296: diode.v1.PowerPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1297: diode.v1.Prefix.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1298: diode.v1.Provider.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1299: diode.v1.ProviderAccount.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1300: diode.v1.ProviderNetwork.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1301: diode.v1.RIR.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1302: diode.v1.Rack.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1303: diode.v1.RackReservation.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1304: diode.v1.RackRole.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1305: diode.v1.RackType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1306: diode.v1.RearPort.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1307: diode.v1.Region.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1308: diode.v1.Role.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1309: diode.v1.RouteTarget.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1310: diode.v1.Service.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1311: diode.v1.Site.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1312: diode.v1.SiteGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1313: diode.v1.Tenant.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1314: diode.v1.TenantGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1315: diode.v1.Tunnel.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1316: diode.v1.TunnelGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1317: diode.v1.TunnelTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1318: diode.v1.VLAN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1319: diode.v1.VLANGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1320: diode.v1.VMInterface.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1321: diode.v1.VRF.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1322: diode.v1.VirtualChassis.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1323: diode.v1.VirtualCircuit.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1324: diode.v1.VirtualCircuitTermination.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1325: diode.v1.VirtualCircuitType.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1326: diode.v1.VirtualDeviceContext.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1327: diode.v1.VirtualDisk.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1328: diode.v1.VirtualMachine.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1329: diode.v1.WirelessLAN.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1330: diode.v1.WirelessLANGroup.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1331: diode.v1.WirelessLink.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1332: diode.v1.JournalEntry.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	24,   // 1333: diode.v1.ModuleTypeProfile.CustomFieldsEntry.value:type_name -> diode.v1.CustomFieldValue
+	184,  // 1334: diode.v1.netbox_supported:extendee -> google.protobuf.FieldOptions
+	1,    // 1335: diode.v1.IngesterService.Ingest:input_type -> diode.v1.IngestRequest
+	2,    // 1336: diode.v1.IngesterService.Ingest:output_type -> diode.v1.IngestResponse
+	1336, // [1336:1337] is the sub-list for method output_type
+	1335, // [1335:1336] is the sub-list for method input_type
+	1335, // [1335:1335] is the sub-list for extension type_name
+	1334, // [1334:1335] is the sub-list for extension extendee
+	0,    // [0:1334] is the sub-list for field type_name
 }
 
 func init() { file_diode_v1_ingester_proto_init() }
@@ -29137,12 +30108,13 @@ func file_diode_v1_ingester_proto_init() {
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_diode_v1_ingester_proto_rawDesc), len(file_diode_v1_ingester_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   182,
-			NumExtensions: 0,
+			NumExtensions: 1,
 			NumServices:   1,
 		},
 		GoTypes:           file_diode_v1_ingester_proto_goTypes,
 		DependencyIndexes: file_diode_v1_ingester_proto_depIdxs,
 		MessageInfos:      file_diode_v1_ingester_proto_msgTypes,
+		ExtensionInfos:    file_diode_v1_ingester_proto_extTypes,
 	}.Build()
 	File_diode_v1_ingester_proto = out.File
 	file_diode_v1_ingester_proto_goTypes = nil

--- a/diode/v1/diodepb/ingester.pb.validate.go
+++ b/diode/v1/diodepb/ingester.pb.validate.go
@@ -4129,6 +4129,35 @@ func (m *IngestRequest) validate(all bool) error {
 		errors = append(errors, err)
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IngestRequestValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IngestRequestValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IngestRequestValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if len(errors) > 0 {
 		return IngestRequestMultiError(errors)
 	}
@@ -4417,6 +4446,35 @@ func (m *ASN) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ASNValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ASNValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ASNValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -4710,6 +4768,35 @@ func (m *ASNRange) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ASNRangeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ASNRangeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ASNRangeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Tenant != nil {
 
 		if all {
@@ -4954,6 +5041,35 @@ func (m *Aggregate) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, AggregateValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, AggregateValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return AggregateValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -5277,6 +5393,35 @@ func (m *Cable) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CableValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CableValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CableValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Type != nil {
 
 		if _, ok := _Cable_Type_InLookup[m.GetType()]; !ok {
@@ -5516,6 +5661,35 @@ func (m *CablePath) validate(all bool) error {
 
 	var errors []error
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CablePathValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CablePathValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CablePathValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.IsActive != nil {
 		// no validation rules for IsActive
 	}
@@ -5665,6 +5839,35 @@ func (m *CableTermination) validate(all bool) error {
 			return err
 		}
 		errors = append(errors, err)
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CableTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CableTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CableTerminationValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	switch v := m.Termination.(type) {
@@ -6319,6 +6522,35 @@ func (m *Circuit) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CircuitValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CircuitValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CircuitValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.ProviderAccount != nil {
 
 		if all {
@@ -6696,6 +6928,35 @@ func (m *CircuitGroup) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CircuitGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CircuitGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CircuitGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -6893,6 +7154,35 @@ func (m *CircuitGroupAssignment) validate(all bool) error {
 			}
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CircuitGroupAssignmentValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CircuitGroupAssignmentValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CircuitGroupAssignmentValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	switch v := m.Member.(type) {
@@ -7223,6 +7513,35 @@ func (m *CircuitTermination) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CircuitTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CircuitTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CircuitTerminationValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -7651,6 +7970,35 @@ func (m *CircuitType) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CircuitTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CircuitTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CircuitTypeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Color != nil {
 		// no validation rules for Color
 	}
@@ -7865,6 +8213,35 @@ func (m *Cluster) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ClusterValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ClusterValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ClusterValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -8317,6 +8694,35 @@ func (m *ClusterGroup) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ClusterGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ClusterGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ClusterGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -8501,6 +8907,35 @@ func (m *ClusterType) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ClusterTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ClusterTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ClusterTypeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -8715,6 +9150,35 @@ func (m *ConsolePort) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ConsolePortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ConsolePortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ConsolePortValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -9029,6 +9493,35 @@ func (m *ConsoleServerPort) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ConsoleServerPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ConsoleServerPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ConsoleServerPortValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -9353,6 +9846,35 @@ func (m *Contact) validate(all bool) error {
 
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ContactValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ContactValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ContactValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Group != nil {
 
 		if all {
@@ -9619,6 +10141,35 @@ func (m *ContactAssignment) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ContactAssignmentValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ContactAssignmentValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ContactAssignmentValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -13681,6 +14232,35 @@ func (m *ContactGroup) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ContactGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ContactGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ContactGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Parent != nil {
 
 		if all {
@@ -13902,6 +14482,35 @@ func (m *ContactRole) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ContactRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ContactRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ContactRoleValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -18452,6 +19061,35 @@ func (m *Device) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DeviceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DeviceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DeviceValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Name != nil {
 		// no validation rules for Name
 	}
@@ -19072,6 +19710,35 @@ func (m *DeviceBay) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DeviceBayValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DeviceBayValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DeviceBayValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Label != nil {
 		// no validation rules for Label
 	}
@@ -19293,6 +19960,35 @@ func (m *DeviceRole) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DeviceRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DeviceRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DeviceRoleValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -19554,6 +20250,35 @@ func (m *DeviceType) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, DeviceTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, DeviceTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return DeviceTypeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -19880,6 +20605,35 @@ func (m *FHRPGroup) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, FHRPGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, FHRPGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return FHRPGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Name != nil {
 		// no validation rules for Name
 	}
@@ -20055,6 +20809,35 @@ func (m *FHRPGroupAssignment) validate(all bool) error {
 	}
 
 	// no validation rules for Priority
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, FHRPGroupAssignmentValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, FHRPGroupAssignmentValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return FHRPGroupAssignmentValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
 
 	switch v := m.Interface.(type) {
 	case *FHRPGroupAssignment_InterfaceAsn:
@@ -24124,6 +24907,35 @@ func (m *FrontPort) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, FrontPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, FrontPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return FrontPortValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -28385,6 +29197,35 @@ func (m *IKEPolicy) validate(all bool) error {
 
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IKEPolicyValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IKEPolicyValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IKEPolicyValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -28633,6 +29474,35 @@ func (m *IKEProposal) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IKEProposalValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IKEProposalValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IKEProposalValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -28894,6 +29764,35 @@ func (m *IPAddress) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IPAddressValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IPAddressValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IPAddressValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -29367,6 +30266,35 @@ func (m *IPRange) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IPRangeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IPRangeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IPRangeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Vrf != nil {
 
 		if all {
@@ -29718,6 +30646,35 @@ func (m *IPSecPolicy) validate(all bool) error {
 
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IPSecPolicyValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IPSecPolicyValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IPSecPolicyValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -30018,6 +30975,35 @@ func (m *IPSecProfile) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IPSecProfileValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IPSecProfileValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IPSecProfileValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -30209,6 +31195,35 @@ func (m *IPSecProposal) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, IPSecProposalValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, IPSecProposalValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return IPSecProposalValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -30599,6 +31614,35 @@ func (m *Interface) validate(all bool) error {
 			}
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, InterfaceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, InterfaceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return InterfaceValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	if m.Module != nil {
@@ -31685,6 +32729,35 @@ func (m *InventoryItem) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, InventoryItemValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, InventoryItemValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return InventoryItemValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	switch v := m.Component.(type) {
 	case *InventoryItem_ComponentConsolePort:
 		if v == nil {
@@ -32308,6 +33381,35 @@ func (m *InventoryItemRole) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, InventoryItemRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, InventoryItemRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return InventoryItemRoleValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Color != nil {
 		// no validation rules for Color
 	}
@@ -32567,6 +33669,35 @@ func (m *L2VPN) validate(all bool) error {
 			}
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, L2VPNValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, L2VPNValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return L2VPNValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	if m.Identifier != nil {
@@ -32872,6 +34003,35 @@ func (m *L2VPNTermination) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, L2VPNTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, L2VPNTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return L2VPNTerminationValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -36906,6 +38066,35 @@ func (m *Location) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, LocationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, LocationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return LocationValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Parent != nil {
 
 		if all {
@@ -37188,6 +38377,35 @@ func (m *MACAddress) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, MACAddressValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, MACAddressValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return MACAddressValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	switch v := m.AssignedObject.(type) {
 	case *MACAddress_AssignedObjectInterface:
 		if v == nil {
@@ -37466,6 +38684,35 @@ func (m *Manufacturer) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ManufacturerValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ManufacturerValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ManufacturerValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -37735,6 +38982,35 @@ func (m *Module) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ModuleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ModuleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ModuleValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Status != nil {
 
 		if _, ok := _Module_Status_InLookup[m.GetStatus()]; !ok {
@@ -37982,6 +39258,35 @@ func (m *ModuleBay) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ModuleBayValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ModuleBayValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ModuleBayValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -38273,6 +39578,35 @@ func (m *ModuleType) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ModuleTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ModuleTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ModuleTypeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.PartNumber != nil {
 		// no validation rules for PartNumber
 	}
@@ -38552,6 +39886,35 @@ func (m *Platform) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PlatformValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PlatformValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PlatformValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -38836,6 +40199,35 @@ func (m *PowerFeed) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PowerFeedValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PowerFeedValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PowerFeedValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -39218,6 +40610,35 @@ func (m *PowerOutlet) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PowerOutletValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PowerOutletValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PowerOutletValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -39672,6 +41093,35 @@ func (m *PowerPanel) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PowerPanelValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PowerPanelValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PowerPanelValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Location != nil {
 
 		if all {
@@ -39920,6 +41370,35 @@ func (m *PowerPort) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PowerPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PowerPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PowerPortValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -40276,6 +41755,35 @@ func (m *Prefix) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PrefixValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PrefixValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PrefixValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -40869,6 +42377,35 @@ func (m *Provider) validate(all bool) error {
 
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ProviderValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ProviderValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ProviderValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -41084,6 +42621,35 @@ func (m *ProviderAccount) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ProviderAccountValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ProviderAccountValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ProviderAccountValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -41310,6 +42876,35 @@ func (m *ProviderNetwork) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ProviderNetworkValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ProviderNetworkValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ProviderNetworkValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.ServiceId != nil {
 		// no validation rules for ServiceId
 	}
@@ -41502,6 +43097,35 @@ func (m *RIR) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RIRValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RIRValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RIRValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -41719,6 +43343,35 @@ func (m *Rack) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RackValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RackValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RackValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -42252,6 +43905,35 @@ func (m *RackReservation) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RackReservationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RackReservationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RackReservationValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Tenant != nil {
 
 		if all {
@@ -42494,6 +44176,35 @@ func (m *RackRole) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RackRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RackRoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RackRoleValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Color != nil {
 		// no validation rules for Color
 	}
@@ -42711,6 +44422,35 @@ func (m *RackType) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RackTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RackTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RackTypeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -43068,6 +44808,35 @@ func (m *RearPort) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RearPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RearPortValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RearPortValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Module != nil {
 
 		if all {
@@ -43364,6 +45133,35 @@ func (m *Region) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RegionValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RegionValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RegionValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Parent != nil {
 
 		if all {
@@ -43587,6 +45385,35 @@ func (m *Role) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RoleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RoleValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Weight != nil {
 		// no validation rules for Weight
 	}
@@ -43773,6 +45600,35 @@ func (m *RouteTarget) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RouteTargetValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RouteTargetValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RouteTargetValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -44029,6 +45885,35 @@ func (m *Service) validate(all bool) error {
 			}
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ServiceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ServiceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ServiceValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	switch v := m.ParentObject.(type) {
@@ -44470,6 +46355,35 @@ func (m *Site) validate(all bool) error {
 
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, SiteValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, SiteValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return SiteValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Status != nil {
 
 		if _, ok := _Site_Status_InLookup[m.GetStatus()]; !ok {
@@ -44807,6 +46721,35 @@ func (m *SiteGroup) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, SiteGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, SiteGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return SiteGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Parent != nil {
 
 		if all {
@@ -44964,6 +46907,35 @@ func (m *Tag) validate(all bool) error {
 			errors = append(errors, err)
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, TagValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, TagValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return TagValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	if m.Color != nil {
@@ -45249,6 +47221,35 @@ func (m *Tenant) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, TenantValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, TenantValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return TenantValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Group != nil {
 
 		if all {
@@ -45470,6 +47471,35 @@ func (m *TenantGroup) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, TenantGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, TenantGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return TenantGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -45713,6 +47743,35 @@ func (m *Tunnel) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, TunnelValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, TunnelValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return TunnelValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -46027,6 +48086,35 @@ func (m *TunnelGroup) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, TunnelGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, TunnelGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return TunnelGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -46247,6 +48335,35 @@ func (m *TunnelTermination) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, TunnelTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, TunnelTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return TunnelTerminationValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -50292,6 +52409,35 @@ func (m *VLAN) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VLANValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VLANValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VLANValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Site != nil {
 
 		if all {
@@ -50686,6 +52832,35 @@ func (m *VLANGroup) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VLANGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VLANGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VLANGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -51119,6 +53294,35 @@ func (m *VLANTranslationPolicy) validate(all bool) error {
 
 	// no validation rules for Name
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VLANTranslationPolicyValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VLANTranslationPolicyValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VLANTranslationPolicyValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -51257,6 +53461,35 @@ func (m *VLANTranslationRule) validate(all bool) error {
 	// no validation rules for LocalVid
 
 	// no validation rules for RemoteVid
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VLANTranslationRuleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VLANTranslationRuleValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VLANTranslationRuleValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
 
 	if m.Description != nil {
 		// no validation rules for Description
@@ -51507,6 +53740,35 @@ func (m *VMInterface) validate(all bool) error {
 			}
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VMInterfaceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VMInterfaceValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VMInterfaceValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	if m.Enabled != nil {
@@ -52022,6 +54284,35 @@ func (m *VRF) validate(all bool) error {
 
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VRFValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VRFValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VRFValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Rd != nil {
 		// no validation rules for Rd
 	}
@@ -52249,6 +54540,35 @@ func (m *VirtualChassis) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VirtualChassisValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VirtualChassisValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VirtualChassisValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -52534,6 +54854,35 @@ func (m *VirtualCircuit) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VirtualCircuitValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VirtualCircuitValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VirtualCircuitValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -52873,6 +55222,35 @@ func (m *VirtualCircuitTermination) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VirtualCircuitTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VirtualCircuitTerminationValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VirtualCircuitTerminationValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Role != nil {
 
 		if _, ok := _VirtualCircuitTermination_Role_InLookup[m.GetRole()]; !ok {
@@ -53081,6 +55459,35 @@ func (m *VirtualCircuitType) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VirtualCircuitTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VirtualCircuitTypeValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VirtualCircuitTypeValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -53313,6 +55720,35 @@ func (m *VirtualDeviceContext) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VirtualDeviceContextValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VirtualDeviceContextValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VirtualDeviceContextValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -53648,6 +56084,35 @@ func (m *VirtualDisk) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VirtualDiskValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VirtualDiskValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VirtualDiskValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -53830,6 +56295,35 @@ func (m *VirtualMachine) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, VirtualMachineValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, VirtualMachineValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return VirtualMachineValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -54325,6 +56819,35 @@ func (m *WirelessLAN) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, WirelessLANValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, WirelessLANValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return WirelessLANValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -54856,6 +57379,35 @@ func (m *WirelessLANGroup) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, WirelessLANGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, WirelessLANGroupValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return WirelessLANGroupValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Parent != nil {
 
 		if all {
@@ -55135,6 +57687,35 @@ func (m *WirelessLink) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, WirelessLinkValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, WirelessLinkValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return WirelessLinkValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Ssid != nil {
 		// no validation rules for Ssid
 	}
@@ -55400,6 +57981,35 @@ func (m *CustomField) validate(all bool) error {
 			errors = append(errors, err)
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CustomFieldValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CustomFieldValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CustomFieldValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	if m.RelatedObjectType != nil {
@@ -55871,6 +58481,35 @@ func (m *CustomFieldChoiceSet) validate(all bool) error {
 
 	// no validation rules for Name
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CustomFieldChoiceSetValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CustomFieldChoiceSetValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CustomFieldChoiceSetValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -56081,6 +58720,35 @@ func (m *JournalEntry) validate(all bool) error {
 				}
 			}
 
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, JournalEntryValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, JournalEntryValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return JournalEntryValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
 		}
 	}
 
@@ -60105,6 +62773,35 @@ func (m *ModuleTypeProfile) validate(all bool) error {
 		}
 	}
 
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ModuleTypeProfileValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ModuleTypeProfileValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ModuleTypeProfileValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.Description != nil {
 		// no validation rules for Description
 	}
@@ -60239,6 +62936,35 @@ func (m *CustomLink) validate(all bool) error {
 			errors = append(errors, err)
 		}
 
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CustomLinkValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CustomLinkValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CustomLinkValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
 	}
 
 	if m.Enabled != nil {

--- a/diode/v1/diodepb/ingester_grpc.pb.go
+++ b/diode/v1/diodepb/ingester_grpc.pb.go
@@ -6,7 +6,7 @@
 
 // Generated Code. DO NOT EDIT.
 // Source: NetBox v4.4.2
-// Timestamp: 2025-10-02 12:39:08Z
+// Timestamp: 2025-11-14 18:10:21Z
 
 package diodepb
 


### PR DESCRIPTION
This pull request adds support for attaching custom metadata to ingestion requests and entities in the Diode Go SDK. Users can now provide additional context or tracking information at both the entity and request level, and this metadata is preserved across gRPC, dry run, and OTLP export flows. The documentation and test suite have been updated to demonstrate and verify these new capabilities.

**Metadata support and API changes:**

* Added a new `WithIngestMetadata` option and supporting types to allow passing metadata (as key-value pairs) with `Ingest` and `IngestProto` calls in both `GRPCClient` and `DryRunClient`. This metadata is attached to the `IngestRequest` and serialized as a protobuf struct. [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L205-R225) [[2]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L520-R548) [[3]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R561-R569) [[4]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aL59-R85)
* Updated the client interfaces and implementations to accept variadic options for ingest operations, ensuring backward compatibility. [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L205-R225) [[2]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aL59-R85)

**Documentation improvements:**

* Expanded the `README.md` with detailed usage examples for entity-level and request-level metadata, including how metadata is handled in dry run and OTLP export scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R122-R288) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R350-R379) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R430-R470)

**Testing enhancements:**

* Added comprehensive tests to verify metadata handling in `Ingest`, `IngestProto`, and dry run flows, including tests for various metadata types (primitives, arrays, nested objects, and edge cases). Ensured that metadata is correctly serialized and included in requests. [[1]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bR1206-R1502) [[2]](diffhunk://#diff-955649906a2a759d331a53dba7f1c3f15eeee11ee6b25ba639e2ccf512d29f23R165-R209)

**Internal codebase updates:**

* Imported necessary protobuf packages for struct and JSON serialization to support the new metadata functionality. [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287R28-R29) [[2]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aR14) [[3]](diffhunk://#diff-5b0704091b945f4382d427b699d48076b98041a69fb48bb5e1563756bcdc3d3bR24)

These changes make the SDK more flexible and extensible for tracking, auditing, and enriching ingested data with custom attributes.