### PR TITLE
fix: remove debug log

### DIFF
--- a/diode/client.go
+++ b/diode/client.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -562,10 +561,6 @@ func (g *GRPCClient) IngestProto(ctx context.Context, entities []*diodepb.Entity
 	if len(cfg.metadata) > 0 {
 		req.Metadata, _ = structpb.NewStruct(cfg.metadata)
 	}
-
-	data, _ := protojson.MarshalOptions{UseProtoNames: true, Indent: "  "}.Marshal(req)
-
-	fmt.Printf("entities: %s\n", data)
 
 	ctx = metadata.NewOutgoingContext(ctx, g.metadata)
 


### PR DESCRIPTION
This pull request makes a minor cleanup to the `diode/client.go` file by removing unused imports and debug print statements related to proto message marshalling. These changes help keep the codebase cleaner and remove unnecessary output.

- **Code cleanup:**
  * Removed the unused `protojson` import from the import block.
  * Removed the debug code that marshalled and printed the `IngestEntitiesRequest` proto message in the `IngestProto` method.