### PR TITLE
fix: proxy support from environment for HTTP client

### DIFF
--- a/diode/client.go
+++ b/diode/client.go
@@ -376,10 +376,13 @@ func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string)
 	client := &http.Client{}
 	if d.isPlaintext {
 		// HTTP plaintext - no TLS
-		client.Transport = &http.Transport{}
+		client.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
 	} else {
 		// HTTPS - always use TLS for secure schemes
 		client.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs:            d.rootCAs,
 				InsecureSkipVerify: !d.tlsVerify, // Skip verification if tlsVerify is false


### PR DESCRIPTION
This pull request makes a minor update to the HTTP client transport configuration in `diode/client.go`. The change ensures that the HTTP client honors proxy settings from the environment for both plaintext and TLS connections.

* Updated the `http.Transport` initialization in the `authenticate` method to set the `Proxy` field to `http.ProxyFromEnvironment`, allowing the client to use environment proxy settings for both HTTP and HTTPS connections.