### PR TITLE
chore: detect circular dependency to avoid stack overflow

### DIFF
--- a/diode/client.go
+++ b/diode/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"regexp"
 	"runtime"
 	"runtime/debug"
@@ -537,7 +538,11 @@ func (g *GRPCClient) Close() error {
 
 // Ingest sends an ingest request to the ingester service
 func (g *GRPCClient) Ingest(ctx context.Context, entities []Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
-	return g.IngestProto(ctx, convertEntitiesToProto(entities), opts...)
+	protoEntities, err := convertEntitiesToProto(entities)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert entities: %w", err)
+	}
+	return g.IngestProto(ctx, protoEntities, opts...)
 }
 
 // IngestProto sends an ingest request to the ingester service with proto entities
@@ -593,14 +598,110 @@ func (g *GRPCClient) IngestProto(ctx context.Context, entities []*diodepb.Entity
 }
 
 // convertEntitiesToProto converts entities to proto entities
-func convertEntitiesToProto(entities []Entity) []*diodepb.Entity {
+func convertEntitiesToProto(entities []Entity) ([]*diodepb.Entity, error) {
+	// Detect cycles before conversion
+	if err := detectCycles(entities); err != nil {
+		return nil, fmt.Errorf("circular reference detected in entity graph: %w", err)
+	}
+
 	protoEntities := make([]*diodepb.Entity, 0)
 	for _, entity := range entities {
 		entityPb := entity.ConvertToProtoEntity()
 		entityPb.Timestamp = timestamppb.New(time.Now().UTC())
 		protoEntities = append(protoEntities, entityPb)
 	}
-	return protoEntities
+	return protoEntities, nil
+}
+
+// detectCycles checks if there are any circular references in the entity graph
+func detectCycles(entities []Entity) error {
+	visited := make(map[uintptr]bool)
+
+	for _, entity := range entities {
+		if err := detectCyclesInEntity(entity, visited, []string{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// detectCyclesInEntity recursively walks an entity graph to detect cycles
+func detectCyclesInEntity(entity any, visited map[uintptr]bool, path []string) error {
+	if entity == nil {
+		return nil
+	}
+
+	// Get the pointer value of the entity using reflection
+	v := reflect.ValueOf(entity)
+	if v.Kind() != reflect.Ptr {
+		return nil
+	}
+	if v.IsNil() {
+		return nil
+	}
+
+	ptr := v.Pointer()
+
+	// Check if we've seen this entity in the current path (cycle detected)
+	if visited[ptr] {
+		return fmt.Errorf("circular reference detected: %s", strings.Join(path, " -> "))
+	}
+
+	// Mark as visited
+	visited[ptr] = true
+
+	// Get the entity type name for error messages
+	elem := v.Elem()
+
+	// Only walk through struct fields
+	if elem.Kind() != reflect.Struct {
+		// Still need to unmark before returning
+		delete(visited, ptr)
+		return nil
+	}
+
+	typeName := elem.Type().Name()
+	newPath := append(path, typeName)
+
+	// Walk through all fields of the entity struct
+	for i := 0; i < elem.NumField(); i++ {
+		field := elem.Field(i)
+
+		// Handle pointer fields
+		if field.Kind() == reflect.Ptr && !field.IsNil() {
+			// Check if this field implements Entity interface
+			if field.CanInterface() {
+				fieldValue := field.Interface()
+				if _, ok := fieldValue.(Entity); ok {
+					if err := detectCyclesInEntity(fieldValue, visited, newPath); err != nil {
+						return err
+					}
+				} else {
+					// For non-Entity types, still recurse to check nested entities
+					if err := detectCyclesInEntity(fieldValue, visited, newPath); err != nil {
+						return err
+					}
+				}
+			}
+		}
+
+		// Handle slice fields (e.g., []*Tag, []*VLAN)
+		if field.Kind() == reflect.Slice {
+			for j := 0; j < field.Len(); j++ {
+				item := field.Index(j)
+				if item.Kind() == reflect.Ptr && !item.IsNil() && item.CanInterface() {
+					if err := detectCyclesInEntity(item.Interface(), visited, newPath); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	// Unmark after visiting all children (allow same entity in different branches)
+	delete(visited, ptr)
+
+	return nil
 }
 
 // methodUnaryInterceptor returns a gRPC dial option with a unary interceptor

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -788,13 +788,96 @@ func TestConvertEntitiesToProto(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			protoEntities := convertEntitiesToProto(tt.entities)
+			protoEntities, err := convertEntitiesToProto(tt.entities)
+			require.NoError(t, err)
 			require.NotNil(t, protoEntities)
 			assert.Equal(t, len(tt.entities), len(protoEntities))
 			for _, entityPb := range protoEntities {
 				assert.NotNil(t, entityPb.Timestamp)
 				assert.NotZero(t, entityPb.Timestamp.Seconds)
 				assert.NotZero(t, entityPb.Timestamp.Nanos)
+			}
+		})
+	}
+}
+
+func TestCircularReferenceDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		entities []Entity
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "Module and ModuleBay cycle",
+			entities: func() []Entity {
+				d := &Device{
+					Name: String("test-device"),
+					Site: &Site{Name: String("test-site")},
+				}
+				m := &Module{Device: d}
+				b := &ModuleBay{Device: d, Name: String("bay")}
+				m.ModuleBay = b
+				b.Module = m // creates a cycle
+				return []Entity{m}
+			}(),
+			wantErr: true,
+			errMsg:  "circular reference detected",
+		},
+		{
+			name: "Device and VirtualChassis cycle",
+			entities: func() []Entity {
+				d := &Device{
+					Name: String("test-device"),
+					Site: &Site{Name: String("test-site")},
+				}
+				vc := &VirtualChassis{Name: String("vc-1")}
+				d.VirtualChassis = vc
+				vc.Master = d // creates a cycle
+				return []Entity{d}
+			}(),
+			wantErr: true,
+			errMsg:  "circular reference detected",
+		},
+		{
+			name: "Valid entity without cycle",
+			entities: []Entity{
+				&Device{
+					Name: String("test-device"),
+					Site: &Site{Name: String("test-site")},
+					DeviceType: &DeviceType{
+						Model: String("model-1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple entities with shared references (no cycle)",
+			entities: func() []Entity {
+				site := &Site{Name: String("shared-site")}
+				d1 := &Device{
+					Name: String("device-1"),
+					Site: site,
+				}
+				d2 := &Device{
+					Name: String("device-2"),
+					Site: site, // shared reference is OK
+				}
+				return []Entity{d1, d2}
+			}(),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := convertEntitiesToProto(tt.entities)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/diode/dryrun.go
+++ b/diode/dryrun.go
@@ -58,7 +58,11 @@ func (d *DryRunClient) Close() error {
 // Ingest writes the given entities to stdout or a file depending on the configuration.
 // This is a wrapper around IngestProto that converts the entities to protobuf first.
 func (d *DryRunClient) Ingest(ctx context.Context, entities []Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
-	return d.IngestProto(ctx, convertEntitiesToProto(entities), opts...)
+	protoEntities, err := convertEntitiesToProto(entities)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert entities: %w", err)
+	}
+	return d.IngestProto(ctx, protoEntities, opts...)
 }
 
 // IngestProto serializes entities as JSON and writes them to stdout or a file.

--- a/diode/otlp_client.go
+++ b/diode/otlp_client.go
@@ -172,7 +172,11 @@ func (c *OTLPClient) Close() error {
 
 // Ingest converts the provided entities to proto messages before exporting them.
 func (c *OTLPClient) Ingest(ctx context.Context, entities []Entity, opts ...IngestOption) (*diodepb.IngestResponse, error) {
-	return c.IngestProto(ctx, convertEntitiesToProto(entities), opts...)
+	protoEntities, err := convertEntitiesToProto(entities)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert entities: %w", err)
+	}
+	return c.IngestProto(ctx, protoEntities, opts...)
 }
 
 // IngestProto exports proto entities as OTLP log records.


### PR DESCRIPTION
This pull request introduces robust cycle detection for entity graphs during proto conversion, preventing issues from circular references when ingesting entities. The main changes include updating the `convertEntitiesToProto` function to return errors on cycles, adding recursive cycle detection logic, updating client code to handle errors, and adding comprehensive tests for circular reference scenarios.

### Performance Cons
* `O(N)` overhead on every Ingest call - The cycle detection traverses the entire entity graph using reflection before every ingestion, even for simple cases with no cycles
* Reflection performance cost - Using `reflect` package is slower than direct field access, adding latency to every ingest operation
* No caching - The same entity structures are re-validated on every call, even if they haven't changed

### Entity conversion and cycle detection

* Updated `convertEntitiesToProto` to return an error if a circular reference is detected in the entity graph, using a new recursive `detectCycles` helper. This improves reliability by preventing infinite loops and stack overflows during proto conversion.
* Added `reflect` import to support runtime introspection for cycle detection logic.

### Client error handling

* Modified `Ingest` methods in `GRPCClient`, `DryRunClient`, and `OTLPClient` to handle conversion errors, returning a descriptive error if cycle detection fails. [[1]](diffhunk://#diff-754428b2d0c15530c0f78da3f3d46a161120fd38968a8ed8ae9c153a005e9287L540-R545) [[2]](diffhunk://#diff-e9a55596ddc9960faef1a74c0a5ca4afd26485ada827b62ca68196a60b71721aL61-R65) [[3]](diffhunk://#diff-a5ac5176694d259ac1858b11aa6dcc7144dcfcd891426fd1615949bdda9443d8L175-R179)

### Testing improvements

* Enhanced `TestConvertEntitiesToProto` to check for errors returned by the new conversion logic.
* Added `TestCircularReferenceDetection` to verify cycle detection works for various scenarios, including cycles and shared references.