### PR TITLE
feat(OBS-2873): add gRPC client keepalive configuration

### DIFF
--- a/diode/client.go
+++ b/diode/client.go
@@ -513,6 +513,7 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithUserAgent(fmt.Sprintf("%s/%s", c.sdkName, c.sdkVersion)),
+		defaultClientKeepaliveDialOption(),
 	}
 
 	if path != "" {

--- a/diode/grpc_keepalive.go
+++ b/diode/grpc_keepalive.go
@@ -7,10 +7,11 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-// defaultClientKeepaliveDialOption configures HTTP/2 pings so idle client connections
-// are less likely to be torn down by middleboxes (L4/L7 proxies, NAT). Intervals match
-// netbox-assurance-plugin reconciler gRPC client and are compatible with diode-pro
-// reconciler-pro server keepalive enforcement (MinTime 10s; client Time 30s).
+// defaultClientKeepaliveDialOption configures HTTP/2 pings for the Diode **ingester**
+// client (`NewClient`). Do not attach this to OTLP exporter dials—generic OTLP collectors
+// often reject idle pings (`GOAWAY` / too_many_pings). Intervals match the assurance
+// reconciler gRPC client and are compatible with diode-pro reconciler-pro server policy
+// (MinTime 10s; client Time 30s).
 func defaultClientKeepaliveDialOption() grpc.DialOption {
 	return grpc.WithKeepaliveParams(keepalive.ClientParameters{
 		Time:                30 * time.Second,

--- a/diode/grpc_keepalive.go
+++ b/diode/grpc_keepalive.go
@@ -1,0 +1,20 @@
+package diode
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+// defaultClientKeepaliveDialOption configures HTTP/2 pings so idle client connections
+// are less likely to be torn down by middleboxes (L4/L7 proxies, NAT). Intervals match
+// netbox-assurance-plugin reconciler gRPC client and are compatible with diode-pro
+// reconciler-pro server keepalive enforcement (MinTime 10s; client Time 30s).
+func defaultClientKeepaliveDialOption() grpc.DialOption {
+	return grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                30 * time.Second,
+		Timeout:             10 * time.Second,
+		PermitWithoutStream: true,
+	})
+}

--- a/diode/otlp_client.go
+++ b/diode/otlp_client.go
@@ -131,6 +131,7 @@ func (c *OTLPClient) dial(authority, path string, isPlaintext bool, tlsVerify bo
 
 	userAgent := fmt.Sprintf("%s/%s %s/%s", c.sdkName, c.sdkVersion, c.appName, c.appVersion)
 	dialOpts = append(dialOpts, grpc.WithUserAgent(userAgent))
+	dialOpts = append(dialOpts, defaultClientKeepaliveDialOption())
 
 	if path != "" {
 		dialOpts = append(dialOpts, methodUnaryInterceptor(path))

--- a/diode/otlp_client.go
+++ b/diode/otlp_client.go
@@ -131,7 +131,8 @@ func (c *OTLPClient) dial(authority, path string, isPlaintext bool, tlsVerify bo
 
 	userAgent := fmt.Sprintf("%s/%s %s/%s", c.sdkName, c.sdkVersion, c.appName, c.appVersion)
 	dialOpts = append(dialOpts, grpc.WithUserAgent(userAgent))
-	dialOpts = append(dialOpts, defaultClientKeepaliveDialOption())
+	// Intentionally no grpc keepalive dial option: OTLP collectors vary widely and many
+	// disallow pings without active streams / enforce long min intervals (Codex/OBS-2873).
 
 	if path != "" {
 		dialOpts = append(dialOpts, methodUnaryInterceptor(path))


### PR DESCRIPTION
## Summary
This change adds default gRPC HTTP/2 keepalive on the **Diode ingester** client (`NewClient`) so long-lived or idle connections to the Diode API are less likely to be closed by load balancers, NAT, or similar middleboxes.

**OTLP export** (`NewOTLPClient` / `OTLPClient.dial`) does **not** use this keepalive policy: generic OTLP collectors often reject idle pings (`GOAWAY` / `too_many_pings`), so only user agent, interceptor, and transport credentials apply there.

## What changed
- Added `diode/grpc_keepalive.go` with `defaultClientKeepaliveDialOption()` using `grpc.WithKeepaliveParams` (30s ping interval, 10s timeout, `PermitWithoutStream: true`).
- Wired that option into **`NewClient` (ingester)** only, alongside existing user agent, path interceptor, and transport credentials.
- **`OTLPClient.dial`** omits keepalive intentionally (Codex / OBS-2873 follow-up).

Ingester keepalive aligns with diode-pro reconciler-pro server policy and the assurance reconciler gRPC client where that environment expects Diode-tolerant ping behavior.

## How tested
- `go test ./...`

## Linear
OBS-2873 — https://linear.app/netboxlabs/issue/OBS-2873/add-grpc-keepalive-configuration-where-necessary

Made with [Cursor](https://cursor.com)