### PR TITLE
feat(OBS-3342): align user agent with Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ go get github.com/netboxlabs/diode-sdk-go
 * `DIODE_SKIP_TLS_VERIFY` - Skip TLS verification (default: `false`)
 * `DIODE_DRY_RUN_OUTPUT_DIR` - Directory to write dry run output files when using `DryRunClient`
 
+OAuth `NewClient` sets the gRPC User-Agent and the `/auth/token` HTTP `User-Agent` header to `{sdkName}/{sdkVersion} {appName}/{appVersion}` (for example `diode-sdk-go/1.9.0 snmp-discovery/0.42.0`).
+
 ### Example
 
 * `target` should be the address of the Diode service.

--- a/diode/client.go
+++ b/diode/client.go
@@ -361,9 +361,17 @@ func WithSkipTLSVerify() ClientOption {
 	}
 }
 
+func formatClientUserAgent(sdkName, sdkVersion, appName, appVersion string) string {
+	return fmt.Sprintf("%s/%s %s/%s", sdkName, sdkVersion, appName, appVersion)
+}
+
 // authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
 func (g *GRPCClient) authenticate(ctx context.Context) error {
-	authClient := newDiodeAuthentication(g.target, g.path, g.isPlaintext, g.tlsVerify, g.rootCAs, g.clientID, g.clientSecret)
+	authClient := newDiodeAuthentication(
+		g.target, g.path, g.isPlaintext, g.tlsVerify, g.rootCAs,
+		g.clientID, g.clientSecret,
+		g.sdkName, g.sdkVersion, g.appName, g.appVersion,
+	)
 	accessToken, err := authClient.authenticate(ctx, g.logger, []string{DiodeOAuth2IngestScope}, g.maxAuthRetries)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
@@ -383,6 +391,10 @@ type diodeAuthentication struct {
 	tlsVerify    bool
 	clientID     string
 	clientSecret string
+	sdkName      string
+	sdkVersion   string
+	appName      string
+	appVersion   string
 
 	// Test hooks; zero values use production defaults in authenticate().
 	initialRetryDelay time.Duration
@@ -390,7 +402,15 @@ type diodeAuthentication struct {
 }
 
 // NewDiodeAuthentication creates a new instance of DiodeAuthentication.
-func newDiodeAuthentication(target string, path string, isPlaintext bool, tlsVerify bool, rootCAs *x509.CertPool, clientID, clientSecret string) *diodeAuthentication {
+func newDiodeAuthentication(
+	target string,
+	path string,
+	isPlaintext bool,
+	tlsVerify bool,
+	rootCAs *x509.CertPool,
+	clientID, clientSecret string,
+	sdkName, sdkVersion, appName, appVersion string,
+) *diodeAuthentication {
 	return &diodeAuthentication{
 		target:       target,
 		path:         path,
@@ -399,6 +419,10 @@ func newDiodeAuthentication(target string, path string, isPlaintext bool, tlsVer
 		rootCAs:      rootCAs,
 		clientID:     clientID,
 		clientSecret: clientSecret,
+		sdkName:      sdkName,
+		sdkVersion:   sdkVersion,
+		appName:      appName,
+		appVersion:   appVersion,
 	}
 }
 
@@ -538,6 +562,7 @@ func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Log
 			return "", fmt.Errorf("failed to create request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("User-Agent", formatClientUserAgent(d.sdkName, d.sdkVersion, d.appName, d.appVersion))
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -641,8 +666,9 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 	}
 	c.rootCAs = rootCAs
 
+	userAgent := formatClientUserAgent(c.sdkName, c.sdkVersion, c.appName, c.appVersion)
 	dialOpts := []grpc.DialOption{
-		grpc.WithUserAgent(fmt.Sprintf("%s/%s", c.sdkName, c.sdkVersion)),
+		grpc.WithUserAgent(userAgent),
 		defaultClientKeepaliveDialOption(),
 	}
 

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -70,6 +70,66 @@ func TestLoadCerts(t *testing.T) {
 	}
 }
 
+func TestFormatClientUserAgent(t *testing.T) {
+	tests := []struct {
+		name       string
+		sdkName    string
+		sdkVersion string
+		appName    string
+		appVersion string
+		want       string
+	}{
+		{
+			name:       "simple app name",
+			sdkName:    "diode-sdk-go",
+			sdkVersion: "1.9.0",
+			appName:    "snmp-discovery",
+			appVersion: "0.42.0",
+			want:       "diode-sdk-go/1.9.0 snmp-discovery/0.42.0",
+		},
+		{
+			name:       "prefixed app name",
+			sdkName:    "diode-sdk-go",
+			sdkVersion: "1.9.0",
+			appName:    "my-agent/network-discovery",
+			appVersion: "0.1.0",
+			want:       "diode-sdk-go/1.9.0 my-agent/network-discovery/0.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatClientUserAgent(tt.sdkName, tt.sdkVersion, tt.appName, tt.appVersion))
+		})
+	}
+}
+
+func TestAuthenticateSetsUserAgent(t *testing.T) {
+	var capturedUserAgent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		capturedUserAgent = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token": "mock-token"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	authClient := newDiodeAuthentication(
+		host, "", true, false, nil,
+		"client-id", "client-secret",
+		"diode-sdk-go", "1.0.0", "my-producer", "0.1.0",
+	)
+
+	token, err := authClient.authenticate(context.Background(), slog.Default(), []string{DiodeOAuth2IngestScope}, 3)
+	require.NoError(t, err)
+	require.Equal(t, "mock-token", token)
+	assert.Equal(t, "diode-sdk-go/1.0.0 my-producer/0.1.0", capturedUserAgent)
+}
+
 func TestParseTarget(t *testing.T) {
 	tests := []struct {
 		desc      string
@@ -1643,7 +1703,7 @@ func TestAuthenticateRetriesRetriableHTTPStatuses(t *testing.T) {
 			t.Cleanup(server.Close)
 
 			host := strings.TrimPrefix(server.URL, "http://")
-			authClient := newDiodeAuthentication(host, "", true, false, nil, "client-id", "client-secret")
+			authClient := newDiodeAuthentication(host, "", true, false, nil, "client-id", "client-secret", "", "", "", "")
 			authClient.initialRetryDelay = 0
 			authClient.maxRetryDelay = 0
 
@@ -1680,7 +1740,7 @@ func TestAuthenticateRespectsContextDuringBackoff(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	host := strings.TrimPrefix(server.URL, "http://")
-	authClient := newDiodeAuthentication(host, "", true, false, nil, "client-id", "client-secret")
+	authClient := newDiodeAuthentication(host, "", true, false, nil, "client-id", "client-secret", "", "", "", "")
 	authClient.initialRetryDelay = time.Second
 	authClient.maxRetryDelay = 30 * time.Second
 


### PR DESCRIPTION
## Summary

Align `diode-sdk-go` gRPC and OAuth HTTP User-Agent headers with `diode-sdk-python` by including producer app name and version alongside the SDK identity.

## What changed

- Added `formatClientUserAgent()` helper producing `{sdkName}/{sdkVersion} {appName}/{appVersion}`
- OAuth `/auth/token` requests now set the `User-Agent` header (previously unset)
- gRPC `NewClient` dial option now includes app name/version (previously SDK name/version only)
- Unit tests for formatter and auth request header; README documents the format

Example: `diode-sdk-go/1.9.0 snmp-discovery/0.42.0`

## How tested

- `go test ./diode/... -run 'TestFormatClientUserAgent|TestAuthenticateSetsUserAgent' -count=1`

## Linear

OBS-3342 — https://linear.app/netboxlabs/issue/OBS-3342/diode-sdk-go-align-user-agent-with-python-sdk

Made with [Cursor](https://cursor.com)