### PR TITLE
feat: add backoff on auth for 429/5xx responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ go get github.com/netboxlabs/diode-sdk-go
 * `DIODE_SDK_LOG_LEVEL` - Log level for the SDK (default: `INFO`)
 * `DIODE_CLIENT_ID` - Client ID for OAuth2 authentication
 * `DIODE_CLIENT_SECRET` - Client Secret for OAuth2 authentication
+* `DIODE_MAX_AUTH_RETRIES` - Maximum attempts for OAuth2 token fetch and gRPC re-authentication on `Unauthenticated` (default: `3`). Token fetch retries with exponential backoff on `429`, `500`, `502`, and `503`, honouring `Retry-After` when present on `429`/`503`.
 * `DIODE_CERT_FILE` - Path to custom certificate file for TLS connections
 * `DIODE_SKIP_TLS_VERIFY` - Skip TLS verification (default: `false`)
 * `DIODE_DRY_RUN_OUTPUT_DIR` - Directory to write dry run output files when using `DryRunClient`

--- a/diode/client.go
+++ b/diode/client.go
@@ -387,7 +387,6 @@ type diodeAuthentication struct {
 	// Test hooks; zero values use production defaults in authenticate().
 	initialRetryDelay time.Duration
 	maxRetryDelay     time.Duration
-	sleep             func(time.Duration)
 }
 
 // NewDiodeAuthentication creates a new instance of DiodeAuthentication.
@@ -469,22 +468,22 @@ func authRetryDelay(attempt int, statusCode int, retryAfter string, initialDelay
 	return total
 }
 
-func waitForAuthRetry(ctx context.Context, delay time.Duration, sleep func(time.Duration)) error {
+func waitForAuthRetry(ctx context.Context, delay time.Duration) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if delay <= 0 {
 		return nil
 	}
-	done := make(chan struct{})
-	go func() {
-		sleep(delay)
-		close(done)
-	}()
+
+	timer := time.NewTimer(delay)
 	select {
 	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
 		return ctx.Err()
-	case <-done:
+	case <-timer.C:
 		return nil
 	}
 }
@@ -513,11 +512,6 @@ func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Log
 	if maxDelay == 0 {
 		maxDelay = authMaxRetryDelay
 	}
-	sleep := d.sleep
-	if sleep == nil {
-		sleep = time.Sleep
-	}
-
 	client := &http.Client{}
 	if d.isPlaintext {
 		client.Transport = &http.Transport{
@@ -586,7 +580,7 @@ func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Log
 			"attempt", attempt,
 			"retry_in", delay,
 		)
-		if err := waitForAuthRetry(ctx, delay, sleep); err != nil {
+		if err := waitForAuthRetry(ctx, delay); err != nil {
 			return "", fmt.Errorf("authentication canceled: %w", err)
 		}
 	}

--- a/diode/client.go
+++ b/diode/client.go
@@ -415,6 +415,8 @@ func isRetriableAuthHTTPStatus(statusCode int) bool {
 	}
 }
 
+const maxRetryAfterSeconds = int64((1<<63 - 1) / int64(time.Second))
+
 func parseRetryAfterHeader(value string) (time.Duration, bool) {
 	if value == "" {
 		return 0, false
@@ -423,7 +425,11 @@ func parseRetryAfterHeader(value string) (time.Duration, bool) {
 		if seconds < 0 {
 			return 0, false
 		}
-		return time.Duration(seconds) * time.Second, true
+		sec := int64(seconds)
+		if sec > maxRetryAfterSeconds {
+			sec = maxRetryAfterSeconds
+		}
+		return time.Duration(sec) * time.Second, true
 	}
 	if t, err := http.ParseTime(value); err == nil {
 		delay := time.Until(t)
@@ -456,7 +462,11 @@ func authRetryDelay(attempt int, statusCode int, retryAfter string, initialDelay
 		delay = maxDelay
 	}
 	jitter := time.Duration(rand.Int63n(int64(delay)/4 + 1))
-	return delay + jitter
+	total := delay + jitter
+	if total > maxDelay {
+		total = maxDelay
+	}
+	return total
 }
 
 // Authenticate requests an OAuth2 token using client credentials and returns it.

--- a/diode/client.go
+++ b/diode/client.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -57,6 +59,9 @@ const (
 	DiodeSkipTLSVerifyEnvVarName = "DIODE_SKIP_TLS_VERIFY"
 
 	defaultStreamName = "latest"
+
+	authInitialRetryDelay = 1 * time.Second
+	authMaxRetryDelay     = 30 * time.Second
 )
 
 var (
@@ -359,7 +364,7 @@ func WithSkipTLSVerify() ClientOption {
 // authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
 func (g *GRPCClient) authenticate() error {
 	authClient := newDiodeAuthentication(g.target, g.path, g.isPlaintext, g.tlsVerify, g.rootCAs, g.clientID, g.clientSecret)
-	accessToken, err := authClient.authenticate(g.logger, []string{DiodeOAuth2IngestScope})
+	accessToken, err := authClient.authenticate(g.logger, []string{DiodeOAuth2IngestScope}, g.maxAuthRetries)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
@@ -378,6 +383,11 @@ type diodeAuthentication struct {
 	tlsVerify    bool
 	clientID     string
 	clientSecret string
+
+	// Test hooks; zero values use production defaults in authenticate().
+	initialRetryDelay time.Duration
+	maxRetryDelay     time.Duration
+	sleep             func(time.Duration)
 }
 
 // NewDiodeAuthentication creates a new instance of DiodeAuthentication.
@@ -393,8 +403,64 @@ func newDiodeAuthentication(target string, path string, isPlaintext bool, tlsVer
 	}
 }
 
+func isRetriableAuthHTTPStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseRetryAfterHeader(value string) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		delay := time.Until(t)
+		if delay < 0 {
+			delay = 0
+		}
+		return delay, true
+	}
+	return 0, false
+}
+
+func authRetryDelay(attempt int, statusCode int, retryAfter string, initialDelay, maxDelay time.Duration) time.Duration {
+	var delay time.Duration
+	if statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable {
+		if parsed, ok := parseRetryAfterHeader(retryAfter); ok {
+			delay = parsed
+		}
+	}
+	if delay == 0 {
+		delay = initialDelay
+		for i := 1; i < attempt; i++ {
+			delay *= 2
+			if delay >= maxDelay {
+				delay = maxDelay
+				break
+			}
+		}
+	}
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	jitter := time.Duration(rand.Int63n(int64(delay)/4 + 1))
+	return delay + jitter
+}
+
 // Authenticate requests an OAuth2 token using client credentials and returns it.
-func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string) (string, error) {
+func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string, maxRetries int) (string, error) {
 	scheme := "https"
 	if d.isPlaintext {
 		scheme = "http"
@@ -403,59 +469,93 @@ func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string)
 	if d.path != "" {
 		authURL = fmt.Sprintf("%s://%s%s/auth/token", scheme, d.target, d.path)
 	}
-	data := url.Values{}
-	data.Set("grant_type", "client_credentials")
-	data.Set("client_id", d.clientID)
-	data.Set("client_secret", d.clientSecret)
-	data.Set("scope", strings.Join(scopes, " "))
-	req, err := http.NewRequest(http.MethodPost, authURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+	formData := url.Values{}
+	formData.Set("grant_type", "client_credentials")
+	formData.Set("client_id", d.clientID)
+	formData.Set("client_secret", d.clientSecret)
+	formData.Set("scope", strings.Join(scopes, " "))
+
+	initialDelay := d.initialRetryDelay
+	if initialDelay == 0 {
+		initialDelay = authInitialRetryDelay
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	maxDelay := d.maxRetryDelay
+	if maxDelay == 0 {
+		maxDelay = authMaxRetryDelay
+	}
+	sleep := d.sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
 
 	client := &http.Client{}
 	if d.isPlaintext {
-		// HTTP plaintext - no TLS
 		client.Transport = &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 		}
 	} else {
-		// HTTPS - always use TLS for secure schemes
 		client.Transport = &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs:            d.rootCAs,
-				InsecureSkipVerify: !d.tlsVerify, // Skip verification if tlsVerify is false
+				InsecureSkipVerify: !d.tlsVerify,
 			},
 		}
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to send request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Error("failed to close response body", "error", err)
+	var lastStatus string
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		req, err := http.NewRequest(http.MethodPost, authURL, strings.NewReader(formData.Encode()))
+		if err != nil {
+			return "", fmt.Errorf("failed to create request: %w", err)
 		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("authentication failed: %s", resp.Status)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("failed to send request: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			var result struct {
+				AccessToken string `json:"access_token"`
+			}
+			decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+			closeErr := resp.Body.Close()
+			if decodeErr != nil {
+				return "", fmt.Errorf("failed to parse response: %w", decodeErr)
+			}
+			if closeErr != nil {
+				logger.Error("failed to close response body", "error", closeErr)
+			}
+			if result.AccessToken == "" {
+				return "", errors.New("access token not found in response")
+			}
+			return result.AccessToken, nil
+		}
+
+		lastStatus = resp.Status
+		retryAfter := resp.Header.Get("Retry-After")
+		_, _ = io.Copy(io.Discard, resp.Body)
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.Error("failed to close response body", "error", closeErr)
+		}
+
+		if !isRetriableAuthHTTPStatus(resp.StatusCode) || attempt >= maxRetries {
+			return "", fmt.Errorf("authentication failed: %s", lastStatus)
+		}
+
+		delay := authRetryDelay(attempt, resp.StatusCode, retryAfter, initialDelay, maxDelay)
+		logger.Debug(
+			"Auth token request failed, retrying",
+			"status", resp.StatusCode,
+			"attempt", attempt,
+			"retry_in", delay,
+		)
+		sleep(delay)
 	}
 
-	var result struct {
-		AccessToken string `json:"access_token"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	if result.AccessToken == "" {
-		return "", errors.New("access token not found in response")
-	}
-
-	return result.AccessToken, nil
+	return "", fmt.Errorf("authentication failed: %s", lastStatus)
 }
 
 // NewClient creates a new diode client based on gRPC

--- a/diode/client.go
+++ b/diode/client.go
@@ -362,9 +362,9 @@ func WithSkipTLSVerify() ClientOption {
 }
 
 // authenticate fetches an OAuth2 token using client credentials and updates the metadata with the token.
-func (g *GRPCClient) authenticate() error {
+func (g *GRPCClient) authenticate(ctx context.Context) error {
 	authClient := newDiodeAuthentication(g.target, g.path, g.isPlaintext, g.tlsVerify, g.rootCAs, g.clientID, g.clientSecret)
-	accessToken, err := authClient.authenticate(g.logger, []string{DiodeOAuth2IngestScope}, g.maxAuthRetries)
+	accessToken, err := authClient.authenticate(ctx, g.logger, []string{DiodeOAuth2IngestScope}, g.maxAuthRetries)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
@@ -469,8 +469,28 @@ func authRetryDelay(attempt int, statusCode int, retryAfter string, initialDelay
 	return total
 }
 
+func waitForAuthRetry(ctx context.Context, delay time.Duration, sleep func(time.Duration)) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if delay <= 0 {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		sleep(delay)
+		close(done)
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
 // Authenticate requests an OAuth2 token using client credentials and returns it.
-func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string, maxRetries int) (string, error) {
+func (d *diodeAuthentication) authenticate(ctx context.Context, logger *slog.Logger, scopes []string, maxRetries int) (string, error) {
 	scheme := "https"
 	if d.isPlaintext {
 		scheme = "http"
@@ -515,7 +535,11 @@ func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string,
 
 	var lastStatus string
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		req, err := http.NewRequest(http.MethodPost, authURL, strings.NewReader(formData.Encode()))
+		if err := ctx.Err(); err != nil {
+			return "", fmt.Errorf("authentication canceled: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, strings.NewReader(formData.Encode()))
 		if err != nil {
 			return "", fmt.Errorf("failed to create request: %w", err)
 		}
@@ -562,7 +586,9 @@ func (d *diodeAuthentication) authenticate(logger *slog.Logger, scopes []string,
 			"attempt", attempt,
 			"retry_in", delay,
 		)
-		sleep(delay)
+		if err := waitForAuthRetry(ctx, delay, sleep); err != nil {
+			return "", fmt.Errorf("authentication canceled: %w", err)
+		}
 	}
 
 	return "", fmt.Errorf("authentication failed: %s", lastStatus)
@@ -672,7 +698,7 @@ func NewClient(target string, appName string, appVersion string, opts ...ClientO
 	c.clientID = clientID
 	c.clientSecret = clientSecret
 
-	if err = c.authenticate(); err != nil {
+	if err = c.authenticate(context.Background()); err != nil {
 		return nil, err
 	}
 
@@ -743,7 +769,10 @@ func (g *GRPCClient) ingestSingleRequest(ctx context.Context, entities []*diodep
 					return nil, fmt.Errorf("authentication failed after %d attempts: %w", attempt, err)
 				}
 				g.logger.Debug("Authentication failed, retrying...", "attempt", attempt)
-				if err := g.authenticate(); err != nil {
+				if err := g.authenticate(ctx); err != nil {
+					if ctx.Err() != nil {
+						return nil, fmt.Errorf("re-authentication canceled: %w", ctx.Err())
+					}
 					g.logger.Error("Failed to re-authenticate", "error", err)
 				}
 				continue

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -1648,7 +1648,7 @@ func TestAuthenticateRetriesRetriableHTTPStatuses(t *testing.T) {
 			authClient.maxRetryDelay = 0
 			authClient.sleep = func(time.Duration) {}
 
-			token, err := authClient.authenticate(slog.Default(), []string{DiodeOAuth2IngestScope}, tt.maxRetries)
+			token, err := authClient.authenticate(context.Background(), slog.Default(), []string{DiodeOAuth2IngestScope}, tt.maxRetries)
 			assert.Equal(t, tt.wantCalls, calls)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1659,4 +1659,28 @@ func TestAuthenticateRetriesRetriableHTTPStatuses(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthenticateRespectsContextDuringBackoff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	authClient := newDiodeAuthentication(host, "", true, false, nil, "client-id", "client-secret")
+	authClient.initialRetryDelay = time.Second
+	authClient.maxRetryDelay = 30 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := authClient.authenticate(ctx, slog.Default(), []string{DiodeOAuth2IngestScope}, 3)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 2*time.Second, "backoff should abort when context expires")
 }

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -1540,6 +1540,15 @@ func TestParseRetryAfterHeader(t *testing.T) {
 		_, ok := parseRetryAfterHeader("not-a-date")
 		assert.False(t, ok)
 	})
+
+	t.Run("large seconds does not overflow", func(t *testing.T) {
+		delay, ok := parseRetryAfterHeader("9223372037")
+		assert.True(t, ok)
+		assert.Positive(t, delay)
+
+		got := authRetryDelay(1, http.StatusTooManyRequests, "9223372037", time.Second, 30*time.Second)
+		assert.LessOrEqual(t, got, 30*time.Second)
+	})
 }
 
 func TestAuthRetryDelay(t *testing.T) {
@@ -1572,6 +1581,13 @@ func TestAuthRetryDelay(t *testing.T) {
 
 	t.Run("caps retry-after at max delay", func(t *testing.T) {
 		assertDelayInRange(t, authRetryDelay(1, http.StatusTooManyRequests, "120", initial, maxDelay), maxDelay)
+	})
+
+	t.Run("final delay never exceeds max delay after jitter", func(t *testing.T) {
+		for range 100 {
+			got := authRetryDelay(10, http.StatusInternalServerError, "", initial, maxDelay)
+			assert.LessOrEqual(t, got, maxDelay)
+		}
 	})
 }
 

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -1646,7 +1646,6 @@ func TestAuthenticateRetriesRetriableHTTPStatuses(t *testing.T) {
 			authClient := newDiodeAuthentication(host, "", true, false, nil, "client-id", "client-secret")
 			authClient.initialRetryDelay = 0
 			authClient.maxRetryDelay = 0
-			authClient.sleep = func(time.Duration) {}
 
 			token, err := authClient.authenticate(context.Background(), slog.Default(), []string{DiodeOAuth2IngestScope}, tt.maxRetries)
 			assert.Equal(t, tt.wantCalls, calls)
@@ -1659,6 +1658,18 @@ func TestAuthenticateRetriesRetriableHTTPStatuses(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWaitForAuthRetryCancelsOnContextDone(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := waitForAuthRetry(ctx, 30*time.Second)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 2*time.Second, "timer wait should abort when context expires")
 }
 
 func TestAuthenticateRespectsContextDuringBackoff(t *testing.T) {

--- a/diode/client_test.go
+++ b/diode/client_test.go
@@ -8,11 +8,13 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1499,4 +1501,146 @@ func (m *MockIngesterWithCapture) Ingest(_ context.Context, req *diodepb.IngestR
 		m.captureFunc(req)
 	}
 	return &diodepb.IngestResponse{Errors: nil}, nil
+}
+
+func TestIsRetriableAuthHTTPStatus(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		want       bool
+	}{
+		{statusCode: http.StatusTooManyRequests, want: true},
+		{statusCode: http.StatusInternalServerError, want: true},
+		{statusCode: http.StatusBadGateway, want: true},
+		{statusCode: http.StatusServiceUnavailable, want: true},
+		{statusCode: http.StatusUnauthorized, want: false},
+		{statusCode: http.StatusForbidden, want: false},
+		{statusCode: http.StatusBadRequest, want: false},
+		{statusCode: http.StatusOK, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.statusCode), func(t *testing.T) {
+			assert.Equal(t, tt.want, isRetriableAuthHTTPStatus(tt.statusCode))
+		})
+	}
+}
+
+func TestParseRetryAfterHeader(t *testing.T) {
+	t.Run("seconds", func(t *testing.T) {
+		delay, ok := parseRetryAfterHeader("5")
+		assert.True(t, ok)
+		assert.Equal(t, 5*time.Second, delay)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		_, ok := parseRetryAfterHeader("")
+		assert.False(t, ok)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, ok := parseRetryAfterHeader("not-a-date")
+		assert.False(t, ok)
+	})
+}
+
+func TestAuthRetryDelay(t *testing.T) {
+	initial := time.Second
+	maxDelay := 30 * time.Second
+
+	assertDelayInRange := func(t *testing.T, got, want time.Duration) {
+		t.Helper()
+		maxJitter := want / 4
+		if maxJitter == 0 {
+			maxJitter = time.Nanosecond
+		}
+		assert.GreaterOrEqual(t, got, want)
+		assert.LessOrEqual(t, got, want+maxJitter)
+	}
+
+	t.Run("exponential backoff without retry-after", func(t *testing.T) {
+		assertDelayInRange(t, authRetryDelay(1, http.StatusInternalServerError, "", initial, maxDelay), time.Second)
+		assertDelayInRange(t, authRetryDelay(2, http.StatusInternalServerError, "", initial, maxDelay), 2*time.Second)
+		assertDelayInRange(t, authRetryDelay(3, http.StatusBadGateway, "", initial, maxDelay), 4*time.Second)
+	})
+
+	t.Run("honours retry-after on 429", func(t *testing.T) {
+		assertDelayInRange(t, authRetryDelay(1, http.StatusTooManyRequests, "7", initial, maxDelay), 7*time.Second)
+	})
+
+	t.Run("honours retry-after on 503", func(t *testing.T) {
+		assertDelayInRange(t, authRetryDelay(1, http.StatusServiceUnavailable, "12", initial, maxDelay), 12*time.Second)
+	})
+
+	t.Run("caps retry-after at max delay", func(t *testing.T) {
+		assertDelayInRange(t, authRetryDelay(1, http.StatusTooManyRequests, "120", initial, maxDelay), maxDelay)
+	})
+}
+
+func TestAuthenticateRetriesRetriableHTTPStatuses(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		maxRetries int
+		wantCalls  int
+		wantErr    bool
+	}{
+		{
+			name:       "503 then success",
+			statusCode: http.StatusServiceUnavailable,
+			maxRetries: 3,
+			wantCalls:  2,
+			wantErr:    false,
+		},
+		{
+			name:       "429 exhausts retries",
+			statusCode: http.StatusTooManyRequests,
+			maxRetries: 2,
+			wantCalls:  2,
+			wantErr:    true,
+		},
+		{
+			name:       "401 fails fast",
+			statusCode: http.StatusUnauthorized,
+			maxRetries: 3,
+			wantCalls:  1,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				if !tt.wantErr && calls == 1 {
+					w.Header().Set("Retry-After", "0")
+					w.WriteHeader(tt.statusCode)
+					return
+				}
+				if tt.wantErr {
+					w.Header().Set("Retry-After", "0")
+					w.WriteHeader(tt.statusCode)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"access_token":"token"}`))
+			}))
+			t.Cleanup(server.Close)
+
+			host := strings.TrimPrefix(server.URL, "http://")
+			authClient := newDiodeAuthentication(host, "", true, false, nil, "client-id", "client-secret")
+			authClient.initialRetryDelay = 0
+			authClient.maxRetryDelay = 0
+			authClient.sleep = func(time.Duration) {}
+
+			token, err := authClient.authenticate(slog.Default(), []string{DiodeOAuth2IngestScope}, tt.maxRetries)
+			assert.Equal(t, tt.wantCalls, calls)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, token)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, "token", token)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
Add retry/backoff on the OAuth2 token HTTP call when the auth endpoint returns transient failures.

## What changed
- Retry `/auth/token` on `429`, `500`, `502`, and `503` only; other 4xx fail immediately
- Exponential backoff (1s initial, 30s cap) with random jitter (0–25% of delay)
- Honour `Retry-After` on `429` and `503` when present (seconds or HTTP-date), capped at 30s
- Respect existing `DIODE_MAX_AUTH_RETRIES` for total auth HTTP attempts (default `3`)
- Document `DIODE_MAX_AUTH_RETRIES` in README
- Unit tests for retriable status codes, delay calculation, and httptest retry behaviour

## How tested
- `go test ./...`
- `make fix-lint`

Made with [Cursor](https://cursor.com)