### PR TITLE
ci: track go.mod toolchain and update golangci-lint for Go 1.25

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,10 +21,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version-file: go.mod
           check-latest: true
       - name: Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
+        uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 #v9.1.0
         with:
-          version: v2.1
+          version: v2.12
           args: --config ./.github/golangci.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version-file: go.mod
           check-latest: true
       - name: Run go build
         run: go build ./...


### PR DESCRIPTION
Unblocks #77, where lint fails with:

```
can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
```

The x/net bump raises the `go` directive to 1.25.0, but the workflows pinned Go 1.24.x and golangci-lint v2.1 (built with Go 1.24).

- lint/test workflows: `go-version: '1.24.x'` → `go-version-file: go.mod`, so the toolchain tracks go.mod and can't drift again
- golangci-lint-action pinned to v9.1.0 (also resolves the Node 20 deprecation warning), linter v2.1 → v2.12

Verified golangci-lint v2.10+ reports 0 issues on the current codebase with the existing config.

Note: #77 raises the consumer minimum Go version to 1.25 — worth a release-notes mention.