### PR TITLE
ci: add Trivy filesystem vulnerability and secret scan

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,95 @@
+name: Security scan
+
+on:
+  push:
+    branches:
+      - "!release"
+  pull_request:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC, to catch newly published advisories
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Filesystem scan reads go.mod / go.sum (and any secrets in the tree).
+      # This is the library equivalent of the container scan orb-agent runs;
+      # it surfaces known-vulnerable dependencies before they ship to
+      # consumers. exit-code 0 keeps it non-blocking: findings are reported
+      # as GitHub code-scanning alerts rather than failing the build.
+      - name: Scan filesystem for vulnerabilities and secrets
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: json
+          output: trivy-output.json
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          ignore-unfixed: true
+          exit-code: "0"
+
+      - name: Build scan summary
+        if: "!cancelled()"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('trivy-output.json', 'utf8'));
+            const vulns = (data.Results || []).flatMap(r =>
+              (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
+            );
+            const secrets = (data.Results || []).flatMap(r =>
+              (r.Secrets || []).map(s => ({ ...s, target: r.Target }))
+            );
+
+            const SEVERITY_LABEL = {
+              CRITICAL: '🔴 **CRITICAL**',
+              HIGH: '🟠 **HIGH**',
+              MEDIUM: '🟡 MEDIUM',
+              LOW: '⚪ LOW'
+            };
+
+            let summary = `### Trivy filesystem scan\n\n`;
+            if (vulns.length === 0) {
+              summary += '_No known-vulnerable dependencies found._\n';
+            } else {
+              summary += `| Library | Vulnerability | Severity | Installed | Fixed | Title |\n`;
+              summary += `|---|---|---|---|---|---|\n`;
+              for (const v of vulns) {
+                const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
+                const id = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
+                summary += `| ${v.PkgName} | ${id} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+              }
+            }
+            if (secrets.length > 0) {
+              summary += `\n**Potential secrets:** ${secrets.length} (see the Security tab for details).\n`;
+            }
+
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+      - name: Convert scan results to SARIF
+        if: "!cancelled()"
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-output.json
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: "!cancelled()"
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary

Adds a **Trivy filesystem scan** to the SDK's CI, closing the gap that let a vulnerable `google.golang.org/grpc` (1.79.3) sit in `go.mod` unnoticed until it surfaced downstream in orb-agent.

CodeQL is already running here (the `Analyze (go/actions)` checks via GitHub default setup), and orb-agent additionally runs Trivy against its container image. The SDK is a library with no image, so this mirrors that Trivy coverage in **filesystem mode**: it reads `go.mod` / `go.sum` for known-vulnerable dependencies and scans the tree for secrets, then uploads results to GitHub code-scanning as SARIF (same pinned action versions orb-agent uses).

## Behavior

- Runs on push (non-`release`), pull requests, a **daily schedule** (so newly published advisories against already-pinned deps get caught without a code change), and manual dispatch.
- `scanners: vuln,secret`, all severities, `ignore-unfixed: true` — matching orb-agent.
- **Non-blocking** (`exit-code: 0`): findings appear as code-scanning alerts in the Security tab and a job-summary table, rather than failing the build. A blocking gate on HIGH/CRITICAL can be added later if desired.

## Verification

Ran the same scan locally against the current `develop` tree and it correctly flags the one outstanding advisory:

```
google.golang.org/grpc  GHSA-hrxh-6v49-42gf  HIGH  v1.79.3  ->  1.82.1
```

That's the exact advisory that reached orb-agent through this SDK, so once #80 (the dependency bump) merges this scan should come back clean. `actionlint` passes on the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
