### PR TITLE
chore(codeowners): add three owners and remove two

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jajeffries @leoparente @ltucker @mfiedorowicz @MicahParks @davidlanouette
+* @jajeffries @leoparente @mfiedorowicz @davidlanouette @paulstuart @samiura @manrodrigues


### PR DESCRIPTION
Refreshes the code owner list for this SDK.

```diff
-* @jajeffries @leoparente @ltucker @mfiedorowicz @MicahParks @davidlanouette
+* @jajeffries @leoparente @mfiedorowicz @davidlanouette @paulstuart @samiura @manrodrigues
```

**Added** — all three already own code in `orb-agent`, which consumes this SDK, so reviews here reach them too:

| Handle | Name |
|---|---|
| `@paulstuart` | Paul Stuart |
| `@samiura` | Samiur Arif |
| `@manrodrigues` | Amanda Rodrigues |

**Removed:**

| Handle | Name |
|---|---|
| `@MicahParks` | Micah Parks |
| `@ltucker` | Luke Tucker |

Every handle was resolved against the GitHub user API rather than inferred, because a wrong handle in CODEOWNERS fails silently: an added one is never assigned, and a removed one strips review coverage from the wrong person. Two cases where that mattered here:

- `@mfiedorowicz` is **Michal** Fiedorowicz, not Micah, so it stays. Both begin "Mic" and only one was meant to go.
- Amanda Rodrigues is `@manrodrigues`; there is no `amanda*` account in the org, so a guessed handle would have been silently ignored. Confirmed by mapping her commits (`arodrigues@netboxlabs.com`) to that login.

Same change as netboxlabs/diode-sdk-python#108, so the two SDKs stay aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)